### PR TITLE
Added Link component to Charity Card and a new page, Charity.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import "./App.css";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 
 import Dashboard from "pages/Dashboard";
+import Charity from "pages/Charity";
 import { ConnectTerraButton } from "./components/ConnectTerraButton";
 import { DonationForm } from "./components/DonationForm";
 import { CurrentBalance } from "./components/CurrentBalance";
@@ -40,6 +41,7 @@ const App = () => {
       <Switch>
         <Route exact path="/" component={ExampleApp} />
         <Route path="/dashboard" component={Dashboard} />
+        <Route path="/charity/:title" component={Charity} />
       </Switch>
     </Router>
   );

--- a/src/components/CharityCard/index.tsx
+++ b/src/components/CharityCard/index.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 interface CharityCardProps {
   title: string;
   description: string;
@@ -11,9 +13,11 @@ const CharityCard = ({
 }: CharityCardProps) => {
   return (
     <article className="w-64 h-48 ml-4 flex-none">
-      <img className="rounded-lg" src={backgroundImageUrl} />
-      <h1 className="font-bold text-lg">{title}</h1>
-      <p className="text-sm">{description}</p>
+      <Link to={`/charity/${title}`}>
+        <img className="rounded-lg" src={backgroundImageUrl} />
+        <h1 className="font-bold text-lg">{title}</h1>
+        <p className="text-sm">{description}</p>
+      </Link>
     </article>
   );
 };

--- a/src/pages/Charity.tsx
+++ b/src/pages/Charity.tsx
@@ -1,0 +1,16 @@
+import { useParams } from "react-router-dom";
+import Header from "components/Layout/Header";
+import Footer from "components/Layout/Footer";
+
+const Charity = () => {
+  let { title }: { title: string } = useParams();
+  return (
+    <div className="bg-blue-400">
+      <Header hasMenu={true} onConnect={() => {}} onDisconnect={() => {}} />
+      <h2>Hello from {title}'s Charity Page!</h2>
+      <Footer hasMenu={true} />
+    </div>
+  );
+};
+
+export default Charity;


### PR DESCRIPTION
Part of issue #21 

## Description of the Problem / Feature
When the Charity Card component is clicked, they should be redirected to the specific Charity's page.

## Explanation of the solution
Added a Link component in the Charity Card that points to `Charity.tsx` via URL params. Also added routing for the charity page to show up. 

## Instructions on making this work
Update dependencies and run locally via `yarn start`. Visit the dashboard page and click on a Charity Card.

## UI changes for review
The newly created Charity page looks like this for now:
![image](https://user-images.githubusercontent.com/65009749/130179170-d92a4eb7-b02d-4cbd-8aae-d05dca5530d1.png)

