### PR TITLE
Hide all routes/pages not related to MVP

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,14 +11,14 @@ import TerraConnector from "components/TerraConnector/TerraConnector";
 import Header from "components/Layout/Header";
 import Footer from "components/Layout/Footer";
 import Donate from "pages/Donate";
-import Dashboard from "pages/Dashboard";
-import Home from "pages/Home";
-import About from "pages/About";
-import Goals from "pages/Goals";
 import Login from "pages/Login";
-import Register from "pages/registration/index";
 import { useEffect } from "react";
 import jwt_decode from "jwt-decode";
+// import Dashboard from "pages/Dashboard";
+// import Home from "pages/Home";
+// import About from "pages/About";
+// import Goals from "pages/Goals";
+// import Register from "pages/registration/index";
 
 const App = () => {
   const location = useLocation();
@@ -49,14 +49,14 @@ const App = () => {
       <Switch>
         <Redirect from="/:url*(/+)" to={location.pathname.slice(0, -1)} />
         <Route exact path="/test" component={TerraConnector} />
-        <Route exact path="/about" component={About} />
-        <Route exact path="/about-unsdgs" component={Goals} />
-        <Route exact path="/dashboard" component={Dashboard} />
         <Route exact path="/donate" component={Donate} />
         <Route exact path="/login" component={Login} />
-        <Route exact path="/register" component={Register} />
-        <Route exact path="/" component={Home} />
         <Redirect from="*" to="/donate" />
+        {/* <Route exact path="/about" component={About} /> */}
+        {/* <Route exact path="/about-unsdgs" component={Goals} /> */}
+        {/* <Route exact path="/dashboard" component={Dashboard} /> */}
+        {/* <Route exact path="/register" component={Register} /> */}
+        {/* <Route exact path="/" component={Home} /> */}
       </Switch>
       <Footer hasMenu={!inLogin} />
     </div>

--- a/src/components/Layout/NavMenu/index.tsx
+++ b/src/components/Layout/NavMenu/index.tsx
@@ -18,7 +18,7 @@ const NavMenu = () => {
           Donate Now
         </NavLink>
       </li>
-      <li className="mr-4">
+      {/* <li className="mr-4">
         <NavLink to="/dashboard" {...linkStyles}>
           For Charities
         </NavLink>
@@ -27,7 +27,7 @@ const NavMenu = () => {
         <NavLink to="/about-unsdgs" {...linkStyles}>
           About UNSDGs
         </NavLink>
-      </li>
+      </li> */}
     </ul>
   );
 };


### PR DESCRIPTION
Closes #60 

## Description of the Problem / Feature
Our MVP only needs the Login and Donate pages. As well as the functionality for the TerraConnector component.

## Explanation of the solution
Commented out all routes/pages not related to MVP. All undefined routes will redirect back to the Donate page if they're logged in. If they're not, they will be redirected to the Login page.

## Instructions on making this work
Install your dependencies using `./bin/setup` and you can run it locally using `yarn start`.

## UI changes for review

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design

Header:
![image](https://user-images.githubusercontent.com/65009749/132631966-acbc7583-bfac-4a8b-9c24-bd333ca98533.png)

Footer:
![image](https://user-images.githubusercontent.com/65009749/132632069-a421e390-701a-47b6-a5cf-91e433a08bda.png)


