### PR TITLE
modified section container to match header

### DIFF
--- a/src/layout/Header/Header.tsx
+++ b/src/layout/Header/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
       ref={shadowRef}
       className={`grid fixed w-full bg-${bgColor} h-24 z-10 transition-shadow `}
     >
-      <nav className="lg:container lg:mx-auto w-full grid grid-cols-a1a items-center justify-items-end md:justify-items-center px-5">
+      <nav className="xl:container xl:mx-auto w-full grid grid-cols-a1a items-center justify-items-end md:justify-items-center px-5">
         <LeftBox />
         <MiddleBox />
         <RightBox />

--- a/src/pages/Charities/Specs.tsx
+++ b/src/pages/Charities/Specs.tsx
@@ -13,7 +13,7 @@ export default function Specs() {
   return (
     <section
       ref={ref}
-      className="h-auto grid grid-rows-a1 justify-items-center text-blue-accent py-16 px-10"
+      className="xl:container xl:mx-auto h-auto grid grid-rows-a1 justify-items-center text-blue-accent py-16 px-10"
     >
       <h3
         className={`${transitionIn(


### PR DESCRIPTION
Closes #<issue_number>

## Description of the Problem / Feature
cards section wider than nav

## Explanation of the solution
applied the same `container` class to the section with `xl:` breakpoint on both to only apply 
limits on +1200px screens 

## Instructions on making this work
N.A

## UI changes for review
![uifix](https://user-images.githubusercontent.com/89639563/134470041-c964f2a5-886c-4b3d-a1dc-5cb959467520.png)



When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design
