### PR TITLE
update money-market addr

### DIFF
--- a/src/components/Donator/getDepositAmount.ts
+++ b/src/components/Donator/getDepositAmount.ts
@@ -1,8 +1,11 @@
 import { TxLog, Coin, Denom } from "@terra-money/terra.js";
+import Account from "contracts/Account";
 
-const anchorContractAddr = "terra15dwd5mj8v59wpj0wvt233mf5efdff808c5tkal";
-
-export default function getDepositAmount(logs: TxLog[]): number {
+export default function getDepositAmount(
+  logs: TxLog[],
+  chainID: string
+): number {
+  const anchorAddr = Account.anchorAddrs[chainID];
   const eventLog = logs.find((log) => "events" in log);
   const receiveEvent = eventLog!.events.find(
     (event) => event.type === "coin_received"
@@ -14,7 +17,7 @@ export default function getDepositAmount(logs: TxLog[]): number {
 
   for (let i = 0; i < attributes.length; i++) {
     const currentAttr = attributes[i];
-    if (currentAttr.value === anchorContractAddr) {
+    if (currentAttr.value === anchorAddr) {
       //get next attribute
       const nextAttr = attributes[i + 1];
       totalCoinDeposit = totalCoinDeposit.add(Coin.fromString(nextAttr.value));

--- a/src/components/Donator/useDonate.ts
+++ b/src/components/Donator/useDonate.ts
@@ -113,7 +113,7 @@ function useDonate(status: Status, setStatus: SetStatus, receiver?: AccAddress |
         } else {
           //code property is present on failed transaction info
           if (!txInfo.code) {
-            const depositAmount = getDepositAmount(txInfo.logs!);
+            const depositAmount = getDepositAmount(txInfo.logs!, wallet.network.chainID);
             setStatus({
               step: Steps.success,
               message: `Thank you for your donation!`,

--- a/src/contracts/Account.ts
+++ b/src/contracts/Account.ts
@@ -9,9 +9,16 @@ import {
 } from "@terra-money/terra.js";
 import { ConnectedWallet } from "@terra-money/wallet-provider";
 import Contract from "./Contract";
+import { chains, ContractAddrs } from "./types";
 
 export default class Account extends Contract {
   accountAddr: AccAddress;
+
+  static anchorAddrs: ContractAddrs = {
+    [chains.mainnet]: "terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s",
+    [chains.testnet]: "terra15dwd5mj8v59wpj0wvt233mf5efdff808c5tkal",
+    [chains.localterra]: "terra15dwd5mj8v59wpj0wvt233mf5efdff808c5tkal",
+  };
 
   constructor(wallet: ConnectedWallet, accountAddr: AccAddress) {
     super(wallet);


### PR DESCRIPTION
## Description of the Problem / Feature
update `anchorContractAddr` to be used by `getDepositAmount`

## Explanation of the solution
`getDepositAmount` consolidates donations made to a particular money-market contract
updated address for both `main` and `testnet` donations

## Instructions on making this work
pull latest from `main`
