### PR TITLE
Added an icon for Discord

### DIFF
--- a/src/components/Footers/WebFoot.tsx
+++ b/src/components/Footers/WebFoot.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-icons/ai";
 import { Link } from "react-router-dom";
 import { FaTelegramPlane } from "react-icons/fa";
+import { RiDiscordFill } from "react-icons/ri";
 
 export default function WebFoot() {
   return (
@@ -81,5 +82,12 @@ const links = [
     link: "https://angelprotocol.medium.com/",
     textColor: "text-gray-800",
     title: "Medium",
+  },
+  {
+    id: 5,
+    Icon: RiDiscordFill,
+    link: "https://discord.gg/RhqA652ySA",
+    textColor: "text-gray-800",
+    title: "Discord",
   },
 ];


### PR DESCRIPTION
Closes #169 

## Description of the Problem / Feature
On our marketing website, there is no icon for our Discord group.

## Explanation of the solution
Add an icon that points to our Discord group in the footer of our marketing website.

## Instructions on making this work
Install dependencies using `./bin/setup` and run your local server using `yarn start`.
You can see on the footer of our marketing website is the icon for Discord.

## UI changes for review

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design

![Screenshot from 2021-10-13 11-14-08](https://user-images.githubusercontent.com/65009749/137062562-80bb41e4-5469-464f-b38a-22308e733e1c.png)
