### PR TITLE
image overflow bug in ap,io

### DIFF
--- a/src/pages/Donors/Alignment.tsx
+++ b/src/pages/Donors/Alignment.tsx
@@ -16,7 +16,7 @@ export default function Alignment() {
           className={`${transitionIn(
             isVisible,
             Direction.fromLeft
-          )} w-video:sm rounded-sm shadow-lg mb-4 lg:mb-0`}
+          )} w-135 rounded-sm shadow-lg mb-4 lg:mb-0`}
         />
       </div>
       <article


### PR DESCRIPTION
# Description of the Problem / Feature
was browsing the site and saw this 
![image](https://user-images.githubusercontent.com/89639563/137431160-339d7a6f-2ec3-41c3-8100-358fcdc13e0e.png)
turned out that when I'm styling this, I used a class `w-video:sm` intended for youtube-embeds
I had the `youtube classes` removed since I changed the way youtube embed UI and this results to this x_x

## Explanation of the solution
update depracated class

## Instructions on making this work
pull latest from `RC-MVP`

## UI changes for review
![image](https://user-images.githubusercontent.com/89639563/137431361-399477f1-82e6-4eeb-8874-76cc9edb466b.png)

