### PR TITLE
whole numbers on leaderboards

### DIFF
--- a/src/components/Donator/Estimates.tsx
+++ b/src/components/Donator/Estimates.tsx
@@ -13,9 +13,9 @@ export default function Estimates() {
   //Estimates is inside Formik
   const { submitForm, resetForm } = useFormikContext();
 
-  const amount = toCurrency(estimates?.amount);
-  const fee = toCurrency(estimates?.txFee);
-  const total = toCurrency(estimates!.amount + estimates!.txFee);
+  const amount = toCurrency(estimates?.amount, 3);
+  const fee = toCurrency(estimates?.txFee, 3);
+  const total = toCurrency(estimates!.amount + estimates!.txFee, 3);
 
   function handleProceed() {
     setStatus({ step: Steps.ready });

--- a/src/components/Donator/Results.tsx
+++ b/src/components/Donator/Results.tsx
@@ -13,8 +13,8 @@ export default function Results() {
   //Estimates is inside Formik
   const { resetForm } = useFormikContext();
 
-  const received = toCurrency(result?.received);
-  const deposited = toCurrency(result?.deposited);
+  const received = toCurrency(result?.received, 3);
+  const deposited = toCurrency(result?.deposited, 3);
 
   function handleShare() {
     setStatus({ step: Steps.initial });

--- a/src/helpers/toCurrency.ts
+++ b/src/helpers/toCurrency.ts
@@ -2,7 +2,7 @@ export default function toCurrency(num = 0, precision = 2) {
   //set local to undefined to use user's default format
 
   return num.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
+    minimumFractionDigits: precision,
     maximumFractionDigits: precision,
   });
 }

--- a/src/pages/Leaderboard/Charity/Amount.tsx
+++ b/src/pages/Leaderboard/Charity/Amount.tsx
@@ -11,7 +11,7 @@ export default function Amount(props: Props) {
       <span className="font-body uppercase text-sm text-angel-grey w-24 inline-block">
         {props.type}:
       </span>{" "}
-      $ {toCurrency(props.amount)}
+      $ {toCurrency(props.amount, 0)}
     </p>
   );
 }

--- a/src/pages/Leaderboard/TCA/Entry.tsx
+++ b/src/pages/Leaderboard/TCA/Entry.tsx
@@ -20,7 +20,7 @@ export default function TCAMember(props: Props) {
           </a>
         </div>
       </td>
-      <td className="font-heading">$ {toCurrency(props.amount)}</td>
+      <td className="font-heading">$ {toCurrency(props.amount, 0)}</td>
     </tr>
   );
 }


### PR DESCRIPTION
## Description of the Problem / Feature
Leaderboards should be rounded to the nearest whole number.

## Explanation of the solution
- Round both leaderboards values to the nearest whole number
- Fixed precision of crypto TX numbers to 3 decimals

## Instructions on making this work
Nope

## UI changes for review
Both leaderboards amount values should be rounded to the nearest whole number. 