### PR TITLE
datetime stamp formatting

### DIFF
--- a/src/pages/Leaderboard/Updator.tsx
+++ b/src/pages/Leaderboard/Updator.tsx
@@ -11,8 +11,9 @@ export default function Updator({ lastUpdate, isLoading, refresh }: Props) {
       <p className="text-angel-grey italic">
         last update:{" "}
         {new Date(lastUpdate).toLocaleTimeString([], {
-          hour: "2-digit",
-          minute: "2-digit",
+          dateStyle: "short",
+          timeStyle: "short",
+          hour12: false,
         })}
       </p>
       <button


### PR DESCRIPTION
## Description of the Problem / Feature
Fix datetime stamp on leaderboards to show date & time.

## Explanation of the solution
Changes Date object locale formatting options. 

## Instructions on making this work
Nada