### PR TITLE
HOT_FIX: terraAddr not in tca_list on db

### DIFF
--- a/src/pages/Leaderboard/TCA/Entry.tsx
+++ b/src/pages/Leaderboard/TCA/Entry.tsx
@@ -4,7 +4,6 @@ import { Details } from "./types";
 type Props = { name: string; details: Details };
 export default function TCAMember(props: Props) {
   const isLight = props.details.iconLight;
-  console.log(isLight, props.name);
 
   return (
     <tr className="border-b">

--- a/src/pages/Leaderboard/TCA/useBoard.ts
+++ b/src/pages/Leaderboard/TCA/useBoard.ts
@@ -41,7 +41,8 @@ export default function useBoard() {
             name = defaultName,
             icon = defaultIcon,
             iconLight,
-          } = tcaDonors[donor.address];
+          } = tcaDonors[donor.address] || {};
+
           //init details
           _sums[name] ||= { icon, iconLight, amount: Number.MIN_VALUE };
           //increment if existing

--- a/src/pages/Leaderboard/Updator.tsx
+++ b/src/pages/Leaderboard/Updator.tsx
@@ -6,7 +6,6 @@ type Props = {
 };
 
 export default function Updator({ lastUpdate, isLoading, refresh }: Props) {
-  console.log(lastUpdate);
   return (
     <div className="flex absolute top-3 right-6 gap-2 text-sm font-body">
       <p className="text-angel-grey italic">

--- a/src/services/aws/alliance/alliance.ts
+++ b/src/services/aws/alliance/alliance.ts
@@ -8,7 +8,6 @@ const alliance_api = aws.injectEndpoints({
       transformResponse: (res: Result) => {
         const _donors: Donors = {};
         res.Items.forEach((donor) => {
-          console.log(donor);
           _donors[donor.address] = {
             name: donor.name,
             icon: donor.icon,


### PR DESCRIPTION
## Description of the Problem / Feature
at line 41. at `pages/Leaderboard/TCA/useBoard.ts`
getting donor info from `donor_list` --> `donor_list[uknown_donor_addr]` --> undefined
and when tried to destructure `const {name, .. } = undefined` throws error

## Explanation of the solution
put empty `{}` as fallback 
```
const {
    name = defaultName,
    icon = defaultIcon,
    iconLight,
  } = tcaDonors[donor.address] || {};
```


## Instructions on making this work
pull latest from this branch

## UI changes for review
TCA board shows 
