### PR TITLE
Refactor transactionDate attribute to return UTC timezone stamp

### DIFF
--- a/src/components/Donator/useDonate.ts
+++ b/src/components/Donator/useDonate.ts
@@ -114,11 +114,7 @@ function useDonate(status: Status, setStatus: SetStatus, receiver?: AccAddress |
           valuesToBeSubmitted["denomination"] = "UST";
           valuesToBeSubmitted["fundId"] = fundId;
           valuesToBeSubmitted["transactionId"] = txInfo.txhash;
-          valuesToBeSubmitted["transactionDate"] = new Date().toLocaleString([], {
-            dateStyle: "long",
-            timeStyle: "short",
-            hour12: false,
-          });
+          valuesToBeSubmitted["transactionDate"] = new Date().toISOString();
           Object.keys(valuesToBeSubmitted).forEach(key => valuesToBeSubmitted[key] === "" && delete valuesToBeSubmitted[key]); // Removes blank strings ("")
 
           // Auth token to be passed as part of the header of the request

--- a/yarn.lock
+++ b/yarn.lock
@@ -4676,7 +4676,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.0":
+"@types/react@*":
   version "17.0.31"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.31.tgz#fe05ebf91ff3ae35bb6b13f6c1b461db8089dff8"
   integrity sha512-MQSR5EL4JZtdWRvqDgz9kXhSDDoy2zMTYyg7UhP+FZ5ttUOocWyxiqFJiI57sUG0BtaEX7WDXYQlkCYkb3X9vQ==
@@ -8706,14 +8706,15 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
   integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
 
-curve25519-js@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/curve25519-js/-/curve25519-js-0.0.4.tgz#e6ad967e8cd284590d657bbfc90d8b50e49ba060"
-  integrity sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==
 currency-list@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/currency-list/-/currency-list-1.0.6.tgz#c0f929d0efa2b3a394fc30876290e01f60113999"
   integrity sha512-aYf2iqX8DdEvUfvK/h8uCXq+LYshwZ65jhPTgTBS+DZjCygyPj53vvL78FUePDA6vS1e+F4tAOnVGOuhPxpRFw==
+
+curve25519-js@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/curve25519-js/-/curve25519-js-0.0.4.tgz#e6ad967e8cd284590d657bbfc90d8b50e49ba060"
+  integrity sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==
 
 cyclist@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description of the Problem / Feature
Transaction timestamps are not of standard format.

## Explanation of the solution
We will use the `.toISOString()` method to produce a standard format for our transaction dates. As well as for our future partner dapps.

## Instructions on making this work
Install all dependencies using `./bin/setup`. And run on your local server using `yarn start`.

## UI changes for review
No major UI changes.