### PR TITLE
WIP: Charity Leaderboard Redesign

### DIFF
--- a/src/pages/Leaderboard/Charity/Amount.tsx
+++ b/src/pages/Leaderboard/Charity/Amount.tsx
@@ -2,16 +2,10 @@ import toCurrency from "helpers/toCurrency";
 
 type Props = {
   type: string;
-  amount: number;
+  locked: number;
+  liquid: number;
 };
 
 export default function Amount(props: Props) {
-  return (
-    <p>
-      <span className="font-body uppercase text-sm text-angel-grey w-24 inline-block">
-        {props.type}:
-      </span>{" "}
-      ${toCurrency(props.amount, 0)}
-    </p>
-  );
+  return <p>${toCurrency(props.locked + props.liquid, 0)}</p>;
 }

--- a/src/pages/Leaderboard/Charity/Board.tsx
+++ b/src/pages/Leaderboard/Charity/Board.tsx
@@ -32,10 +32,9 @@ export default function BoardCharity() {
           <table className="border-collapse table-auto w-full">
             <thead className="">
               <tr>
-                <Heading text="Charity" />
-                {/*<Heading text="Endowment Address" />*/}
-                <Heading text="Donations Received" />
-                <Heading text="10YR Projection" withTooltip />
+                <Heading text="" />
+                <Heading text="Total" />
+                <Heading text="10YR Projection" />
               </tr>
             </thead>
             <tbody>

--- a/src/pages/Leaderboard/Charity/Entry.tsx
+++ b/src/pages/Leaderboard/Charity/Entry.tsx
@@ -9,6 +9,10 @@ type Props = {
   chainID: string;
 };
 
+function show10yrModal() {
+  console.log("Clicked me!! hahaha!");
+}
+
 export default function Entry({ address, balance, chainID }: Props) {
   const { locked, liquid } = projectFunds(
     10,
@@ -23,15 +27,17 @@ export default function Entry({ address, balance, chainID }: Props) {
         <Description address={address} chainID={chainID} />
       </td>
       <td>
-        <div className="flex flex-col">
-          <Amount type="principal" amount={balance.total_locked} />
-          <Amount type="donations" amount={balance.total_liq} />
+        <div className="flex flex-col w-40">
+          <Amount
+            type="total"
+            locked={balance.total_locked}
+            liquid={balance.total_liq}
+          />
         </div>
       </td>
       <td>
-        <div className="flex flex-col">
-          <Amount type="principal" amount={locked} />
-          <Amount type="donations" amount={liquid} />
+        <div className="flex flex-col w-40">
+          <Amount type="10years" locked={locked} liquid={liquid} />
         </div>
       </td>
     </tr>

--- a/src/pages/Leaderboard/Heading.tsx
+++ b/src/pages/Leaderboard/Heading.tsx
@@ -2,7 +2,8 @@ import useTooltip from "hooks/useTooltip";
 import { AiOutlineQuestionCircle } from "react-icons/ai";
 import _Tooltip from "./Charity/Tooltip";
 
-type Props = { text: string; withTooltip?: true };
+type Props = { text: string };
+
 export default function Heading(props: Props) {
   const { enter, exit, handleClick, Tooltip } = useTooltip(_Tooltip);
   return (
@@ -10,15 +11,9 @@ export default function Heading(props: Props) {
       onClick={handleClick}
       onMouseEnter={enter}
       onMouseLeave={exit}
-      className={`${
-        props.withTooltip ? "cursor-help relative" : "cursor-text"
-      } text-left uppercase font-heading text-md p-2 pl-0 text-angel-grey`}
+      className={`text-left uppercase font-heading text-md p-2 pl-0 text-angel-grey`}
     >
-      {props.text}{" "}
-      {props.withTooltip && (
-        <AiOutlineQuestionCircle className="inline text-lg mb-1" />
-      )}
-      {props.withTooltip && <Tooltip />}
+      {props.text}
     </th>
   );
 }

--- a/src/pages/Leaderboard/Leaderboard.tsx
+++ b/src/pages/Leaderboard/Leaderboard.tsx
@@ -1,4 +1,4 @@
-import BoardCharity from "./Charity/Board";
+import CharityLeaderboard from "./Charity/Board";
 import DappHead from "components/Headers/DappHead";
 
 export default function Leaderboard() {
@@ -9,7 +9,7 @@ export default function Leaderboard() {
       <h3 className="mt-6 padded-container uppercase text-white-grey text-3xl font-bold">
         Leaderboard
       </h3>
-      <BoardCharity />
+      <CharityLeaderboard />
     </section>
   );
 }


### PR DESCRIPTION
Contributes to #304

## Description of the Problem / Feature
Redesign of charity leaderboard to hide number breakdowns in a toggle-able modal for both "Total" and "10 YR Projections" columns. 

## Explanation of the solution thus far
- `Amount` takes locked and liquid as separate props (so that they can be later passed to a modal for display of breakdowns)
- Table column titles changed 
- removes tool tip from <th>

## WIP / Next steps needed
- Need to add info icons to trigger modals with details
![image](https://user-images.githubusercontent.com/85138450/145666975-257db2e0-5b29-4749-87b8-7ee0da1c4dcf.png)
- Total Modal component created
![image](https://user-images.githubusercontent.com/85138450/145667223-444e8500-1cbc-4c52-9ed6-adc445bce76d.png)
- 10 Year Projection Modal component created
![image](https://user-images.githubusercontent.com/85138450/145667230-b16f66b7-b631-4692-bbce-8cc7f9820456.png)

## Instructions on making this work
None

## UI changes for review
