### PR TITLE
LBP countdown timer fixes

### DIFF
--- a/src/components/CountDownTimer/CountDownTimer.tsx
+++ b/src/components/CountDownTimer/CountDownTimer.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import formatTimer from "./formatTimer";
 
 type Props = {
-  deadline: number;
+  deadline: string | number;
+  start: number | any;
 };
 
 type FormattedProps = {
@@ -12,7 +13,7 @@ type FormattedProps = {
   seconds: string | number;
 };
 
-export default function CountdownTimer({ deadline }: Props) {
+export default function CountdownTimer({ deadline, start }: Props) {
   const [{ days, hours, minutes, seconds }, setFormattedDeadline] =
     useState<FormattedProps>({
       days: 0,
@@ -23,7 +24,7 @@ export default function CountdownTimer({ deadline }: Props) {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      const formatted = formatTimer(deadline);
+      const formatted = formatTimer(deadline, start);
       setFormattedDeadline(formatted);
     }, 1000);
     return () => {

--- a/src/components/CountDownTimer/formatTimer.ts
+++ b/src/components/CountDownTimer/formatTimer.ts
@@ -1,7 +1,33 @@
-export default function formatTimer(deadline: number) {
-  //deadline epoch_num
-  const dueTime = new Date(deadline).getTime();
+export default function formatTimer(
+  deadline: string | number,
+  start: number | any
+) {
+  const startTime = start ? start : new Date().getTime();
+  const dueTime =
+    typeof deadline === "string"
+      ? new Date(deadline.replace(/-/g, "/")).getTime()
+      : new Date(deadline).getTime();
   const now = new Date().getTime();
+
+  // event has already ended
+  if (deadline < now) {
+    return {
+      days: "00",
+      hours: "00",
+      minutes: "00",
+      seconds: "00",
+    };
+  }
+
+  // event hasn't started yet
+  if (startTime > now) {
+    return {
+      days: "-",
+      hours: "-",
+      minutes: "-",
+      seconds: "-",
+    };
+  }
 
   var seconds = Math.floor((dueTime - now) / 1000);
   var minutes = Math.floor(seconds / 60);

--- a/src/pages/LBP/Auction.tsx
+++ b/src/pages/LBP/Auction.tsx
@@ -40,7 +40,12 @@ function AuctionStats() {
       />
       <StatsDetails
         title="Ends in"
-        value={<CountdownTimer deadline={pairInfo.end_time * 1000} />}
+        value={
+          <CountdownTimer
+            deadline={pairInfo.end_time * 1000}
+            start={pairInfo.start_time * 1000}
+          />
+        }
         Icon={FaStopwatch}
       />
       <StatsDetails title="Price" value={`UST ${toCurrency(ust_price, 6)}`} />


### PR DESCRIPTION
## Description of the Problem / Feature
LBP Countdown timer showed negative numbers when event ended. Also shows larger countdown before event starts. Neither should be the case. 

## Explanation of the solution
- adds event start date to inputs to take that into account (show all "--")
- adds logic to check if the event has ended, now > end time (show all "00")

## Instructions on making this work
Nada