### PR TITLE
Move HaloSwap title out of the graph card

### DIFF
--- a/src/pages/LBP/Auction.tsx
+++ b/src/pages/LBP/Auction.tsx
@@ -64,9 +64,9 @@ export default function Auction() {
     <div className="grid grid-rows-a1 place-items-start pt-2">
       <DappHead />
       <div className="content-section">
+        <h1 className="text-4xl font-bold font-heading pl-10 mb-5">HaloSwap</h1>
         <div className="auction-section">
           <div className="auction-data-section">
-            <h1 className="text-4xl font-bold font-heading">HaloSwap</h1>
             <div className="flex items-center justify-center xl:hidden w-115 my-3">
               <button
                 onClick={() => showModal(SwapModal, {})}


### PR DESCRIPTION
Closes #361

## Description of the Problem / Feature
Move HaloSwap title out of the graph card

## Explanation of the solution
Moved HaloSwap title out of the graph card

## Instructions on making this work
- run app
- go to _/app/auctions_

## UI changes for review
Before:
![Screenshot from 2021-12-16 10-12-47](https://user-images.githubusercontent.com/19427053/146342411-0adc1efc-a74f-415e-95f7-305233027ca9.png)


After:
![angel-protocol-auctions-v4](https://user-images.githubusercontent.com/19427053/146342262-5613075e-e38d-4394-af78-e784a62b4e8a.png)

