### PR TITLE
priority change: public terra lcd to figment via aws proxy

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -7,8 +7,10 @@ export const apes_endpoint =
 
 //terra urls
 export const terra_lcds: URL_GROUP = {
-  [chainIDs.testnet]: "https://bombay-lcd.terra.dev",
-  [chainIDs.mainnet]: "https://lcd.terra.dev",
+  [chainIDs.testnet]:
+    "https://59vigz9r91.execute-api.us-east-1.amazonaws.com/terra/lcd/test",
+  [chainIDs.mainnet]:
+    "https://59vigz9r91.execute-api.us-east-1.amazonaws.com/terra/lcd/main",
   [chainIDs.localterra]: "http://localhost:3060",
 };
 

--- a/src/contracts/Contract.ts
+++ b/src/contracts/Contract.ts
@@ -22,7 +22,7 @@ export default class Contract {
   constructor(wallet?: ConnectedWallet) {
     this.wallet = wallet;
     this.chainID = this.wallet?.network.chainID || chainIDs.mainnet;
-    this.url = this.wallet?.network.lcd || terra_lcds[chainIDs.mainnet];
+    this.url = terra_lcds[this.chainID];
     this.walletAddr = this.wallet?.walletAddress;
     this.client = new LCDClient({
       chainID: this.chainID,


### PR DESCRIPTION
Closes #381

## Description of the Problem / Feature
migrate from public lcd to figment via aws
can't use figment directly due to CORS issues

## Explanation of the solution
1. create aws proxy `FIGMENT PROXY` and lambda `figment`
2. change url in `constants/urls`
3. test some tesnet tca donation and mainnet swap (bought a dollar of HALO baby xD) - all is well!

## Instructions on making this work
pull latest from this branch

## UI changes for review
N.A

