### PR TITLE
Wiring Endowment Balances to Charity Profile page

### DIFF
--- a/src/App/Views.tsx
+++ b/src/App/Views.tsx
@@ -9,7 +9,7 @@ import Login from "pages/Login/Login";
 // import Register from "pages/registration/index";
 import TCA from "pages/TCA/TCA";
 import { app, site } from "../types/routes";
-// import Charity from "pages/Charity/Charity";
+import Charity from "pages/Charity/Charity";
 import Leaderboard from "pages/Leaderboard/Leaderboard";
 import Withdraw from "pages/Withdraw/Withdraw";
 // import Market from "pages/Market/Market";
@@ -25,7 +25,7 @@ export default function Views() {
     <Switch>
       <Redirect from="/:url*(/+)" to={location.pathname.slice(0, -1)} />
       <Route path={`${path}/${app.leaderboard}`} component={Leaderboard} />
-      {/*<Route path={`${path}/${app.charity}/:address`} component={Charity} />*/}
+      <Route path={`${path}/${app.charity}/:address`} component={Charity} />
       <Route path={`${path}/${app.login}`} component={Login} />
       {/*<Route path={`${path}/${app.register}`} component={Register} />*/}
       <Route path={`${path}/${app.tca}`} component={TCA} />

--- a/src/pages/Charity/CharityInfoTab.tsx
+++ b/src/pages/Charity/CharityInfoTab.tsx
@@ -1,6 +1,8 @@
 import useProfile from "pages/Market/useProfile";
 import { useRouteMatch } from "react-router-dom";
 import { CharityParam } from "./Charity";
+import useQueryEndowmentBal from "./useQueryEndowmentBal";
+import toCurrency from "helpers/toCurrency";
 
 function OverviewTab() {
   const match = useRouteMatch<CharityParam>();
@@ -71,6 +73,31 @@ function AccountAction() {
 }
 
 function CharityEndowmentInfo() {
+  const match = useRouteMatch<CharityParam>();
+  const charity_addr = match.params.address;
+  const profile = useProfile(charity_addr);
+  const { locked, liquid, overall } = useQueryEndowmentBal(
+    charity_addr,
+    profile.is_placeholder
+  );
+
+  const accountDetails = [
+    {
+      type: "Current Account",
+      balance: `$${toCurrency(liquid)}`,
+      strategy: "Anchor Protocol",
+      allocation: "100%",
+      color: "bg-green-400",
+    },
+    {
+      type: "Principal Account",
+      balance: `$${toCurrency(locked)}`,
+      strategy: "Anchor Protocol",
+      allocation: "100%",
+      color: "bg-orange",
+    },
+  ];
+
   return (
     <div className="w-full lg:min-h-1/2 lg:mt-5 text-left mt-10">
       <div className="flex flex-wrap gap-5 justify-between items-center min-h-r15 w-full bg-transparent shadow-none border-0 rounded-2xl mb-5">
@@ -79,7 +106,7 @@ function CharityEndowmentInfo() {
             Endowment Balance
           </p>
           <p className="uppercase font-bold text-thin-blue text-7xl my-5">
-            $5,023
+            ${toCurrency(overall)}
           </p>
           <p className="uppercase font-medium text-thin-blue text-sm">
             Total donations
@@ -89,7 +116,7 @@ function CharityEndowmentInfo() {
         {/* <div className="endowment_graph flex-grow bg-blue-100 hidden lg:block">
           <p className="text-center">Charts</p>
         </div> */}
-        {mockAccountDetails.map((account) => (
+        {accountDetails.map((account) => (
           <AccountInfo
             account={account}
             className={`${account.color}`}
@@ -161,19 +188,3 @@ export default function CharityInfoTab({
     </>
   );
 }
-const mockAccountDetails = [
-  {
-    type: "current account",
-    balance: "$1,023",
-    strategy: "anchor protocol",
-    allocation: "60%",
-    color: "bg-green-400",
-  },
-  {
-    type: "principal account",
-    balance: "$4,023",
-    strategy: "anchor protocol",
-    allocation: "60%",
-    color: "bg-orange",
-  },
-];

--- a/src/pages/Charity/useQueryEndowmentBal.ts
+++ b/src/pages/Charity/useQueryEndowmentBal.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { LCDClient } from "@terra-money/terra.js";
+import { Holdings, Swap } from "contracts/types";
+
+function useQueryEndowmentBal(
+  address: string,
+  placeholder: boolean | undefined
+) {
+  const [locked, setLocked] = useState<number>();
+  const [liquid, setLiquid] = useState<number>();
+  const [overall, setOverall] = useState<number>();
+
+  // Allows fetching of endowment balance even if wallet is not connected
+  const getOnChainData = async () => {
+    const terra = new LCDClient({
+      URL: "https://lcd.terra.dev",
+      chainID: "columbus-5",
+    });
+
+    const endowmentBal: Holdings = await terra.wasm.contractQuery(address, {
+      balance: {},
+    });
+
+    const rateQuery: Swap = await terra.wasm.contractQuery(
+      "terra172ue5d0zm7jlsj2d9af4vdff6wua7mnv6dq5vp",
+      { exchange_rate: { input_denom: "uust" } }
+    );
+
+    const exchangeRate = Number(rateQuery.exchange_rate);
+    const microLocked =
+      (Number(endowmentBal.locked_cw20[0].amount!) * exchangeRate) / 1e6;
+    const microLiquid =
+      (Number(endowmentBal.liquid_cw20[0].amount!) * exchangeRate) / 1e6;
+
+    setLocked(microLocked);
+    setLiquid(microLiquid);
+    setOverall(microLocked + microLiquid);
+  };
+
+  useEffect(() => {
+    try {
+      // If invalid endowment addr is entered in the url, return 0 values
+      if (placeholder) {
+        setLocked(0);
+        setLiquid(0);
+        setOverall(0);
+      } else {
+        getOnChainData();
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }, [address, placeholder]);
+
+  return {
+    locked,
+    liquid,
+    overall,
+  };
+}
+
+export default useQueryEndowmentBal;


### PR DESCRIPTION
## Description of the Problem / Feature
1. To use the live on-chain data in displaying the balances available for a given charity even if user's wallet is not connected.
2. To check if the endowment address entered in the url is invalid.

## Explanation of the solution
1. Created new file called `useQueryEndowmentBal` inside `src/pages/Charity/`.
2. Used the hook `useProfile` to check for invalid endowment addresses.

## Instructions on making this work
`checkout` this branch and install all dependencies using `./bin/setup`. Then go to path, `/app/charity/terra1k6v33x6sc9chztxgyh859npz740gmn9d4rnfkz`.

## UI changes for review
No major UI changes.

### Uses on-chain data:
![Screenshot from 2021-12-20 19-38-19](https://user-images.githubusercontent.com/65009749/146763308-fba4f132-a429-4cef-9b98-84af6c2d181c.png)