### PR TITLE
Auction page review

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+


### PR DESCRIPTION
## Description of the Problem / Feature
- Balance should be shown on both HALO and UST, I think.
![Screenshot from 2021-12-21 10-32-06](https://user-images.githubusercontent.com/43941751/146857838-0750db29-213c-4e33-8bdd-a51767a3bbc3.png)
![unknown](https://user-images.githubusercontent.com/43941751/146857848-8d3d872d-22f8-4be1-84c5-c81cd5547c62.png)

- When I click Balance in Buy HALO, the max value should be set in the UST/HALO field.
- Halo<>UST price isn't changed whenever the token price is changed in the HALO Swap chart
- After swap tokens I got the transaction error even though swap transaction was succeeded.
- Token price is different as 0.02 between the auction page and coin hall.
- Replace `Balance` to the same line with `From`
- When click `Balance` in the `From:` section, fills the full balance as the input amount