### PR TITLE
add new tier property & quick filter to remove 2 tier 1 charities

### DIFF
--- a/src/pages/Leaderboard/Board.tsx
+++ b/src/pages/Leaderboard/Board.tsx
@@ -7,6 +7,12 @@ export default function Board() {
   const { isReady, isLoading, error, charities, refresh, lastUpdate } =
     useBoard();
 
+  // temp tier 1 restricted chairites list
+  const tier1Charities = [
+    "terra1mcf9lhce23znkpmvg6c5pxx0a36s03yamsklad",
+    "terra1d5phnyr7e7l44yaathtwrh4f4mv5agajcy508f",
+  ];
+
   return (
     <div className="relative min-h-leader-table p-6 pt-10 my-5 mt-2 grid place-items-center overflow-hidden bg-white rounded-xl shadow-lg">
       <Updator
@@ -24,7 +30,11 @@ export default function Board() {
           bgColorClass="bg-angel-grey"
         />
       )}
-      {isReady && <TableView charities={charities} />}
+      {isReady && (
+        <TableView
+          charities={charities.filter((c) => !tier1Charities.includes(c[0]))}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/Leaderboard/Charity/useDescription.ts
+++ b/src/pages/Leaderboard/Charity/useDescription.ts
@@ -14,5 +14,7 @@ export default function useDescription(address: string, chainID: string) {
   const icon = details?.icon || defaultIcon;
   const iconLight = details?.iconLight;
 
-  return { name, description, url, icon, iconLight };
+  const tier = details?.tier || 3;
+
+  return { name, description, url, icon, iconLight, tier };
 }

--- a/src/pages/Leaderboard/types.ts
+++ b/src/pages/Leaderboard/types.ts
@@ -4,6 +4,7 @@ export interface Details {
   url: string;
   name: string;
   description: string;
+  tier: number;
 }
 
 export type Charities = {

--- a/src/services/aws/endowments/endowments.ts
+++ b/src/services/aws/endowments/endowments.ts
@@ -19,13 +19,22 @@ const endowments_api = aws.injectEndpoints({
       transformResponse: (res: QueryRes<Endowment[]>) => {
         const _accounts: Accounts = {};
         res.Items.forEach(
-          ({ address, name, description, url, icon, iconLight = false }) => {
+          ({
+            address,
+            name,
+            description,
+            url,
+            icon,
+            iconLight = false,
+            tier,
+          }) => {
             _accounts[address] = {
               name,
               description,
               url,
               icon,
               iconLight,
+              tier,
             };
           }
         );

--- a/src/services/aws/endowments/types.ts
+++ b/src/services/aws/endowments/types.ts
@@ -6,6 +6,7 @@ export interface Endowment {
   url: string;
   name: string;
   iconLight?: boolean;
+  tier: number;
 }
 export interface Details {
   description: string;
@@ -13,6 +14,7 @@ export interface Details {
   name: string;
   icon: string;
   iconLight?: boolean;
+  tier: number;
 }
 export interface Profile {
   charity_image: string; //url of image


### PR DESCRIPTION
Closes #392

## Description of the Problem / Feature
New concept of Tiered Endowments needs to be pushed to filter two Tier 1 endowments from the Leaderboard. 

## Explanation of the solution
- Adds new `tier` column to types in web app
- Adds a quick array of Tier 1 charities addresses on Board to filter them off the leaderboard (NOTE: will need to refactor to a more dynamic solution after holiday break. See issue #397)

## Instructions on making this work
Leaderboard should no longer show two tier 1 endowments