### PR TITLE
bring in testnet profiles #459

### DIFF
--- a/src/pages/Market/Market.tsx
+++ b/src/pages/Market/Market.tsx
@@ -2,9 +2,14 @@ import { useMemo } from "react";
 import DappHead from "components/Headers/DappHead";
 import Index from "./Index";
 import { useProfilesQuery } from "services/aws/endowments/endowments";
+import { useConnectedWallet } from "@terra-money/wallet-provider";
+import { chainIDs } from "contracts/types";
 
 export default function Market() {
-  const { data: profiles = [] } = useProfilesQuery(undefined);
+  const wallet = useConnectedWallet();
+  const isTest = wallet?.network.chainID === chainIDs.testnet;
+
+  const { data: profiles = [] } = useProfilesQuery(isTest);
   const sdg_ids = useMemo(
     () =>
       Array.from(

--- a/src/pages/Market/useProfile.ts
+++ b/src/pages/Market/useProfile.ts
@@ -1,8 +1,13 @@
+import { useConnectedWallet } from "@terra-money/wallet-provider";
+import { chainIDs } from "contracts/types";
 import { useProfilesQuery } from "services/aws/endowments/endowments";
 import { profile as profile_placeholder } from "services/aws/endowments/placeholders";
 
 export default function useProfile(address: string) {
-  const { profile = profile_placeholder } = useProfilesQuery(undefined, {
+  const wallet = useConnectedWallet();
+  const isTest = wallet?.network.chainID === chainIDs.testnet;
+
+  const { profile = profile_placeholder } = useProfilesQuery(isTest, {
     selectFromResult: ({ data }) => ({
       profile: data?.find((profile) => profile.endowment_address === address),
     }),

--- a/src/pages/Market/useProfiles.ts
+++ b/src/pages/Market/useProfiles.ts
@@ -1,7 +1,12 @@
+import { useConnectedWallet } from "@terra-money/wallet-provider";
+import { chainIDs } from "contracts/types";
 import { useProfilesQuery } from "services/aws/endowments/endowments";
 
 export default function useProfiles(fund_id: number) {
-  const { profiles = [] } = useProfilesQuery(undefined, {
+  const wallet = useConnectedWallet();
+  const isTest = wallet?.network.chainID === chainIDs.testnet;
+
+  const { profiles = [] } = useProfilesQuery(isTest, {
     selectFromResult: ({ data }) => ({
       profiles: data?.filter((profile) => profile.un_sdg === `${fund_id}`),
     }),

--- a/src/services/aws/endowments/endowments.ts
+++ b/src/services/aws/endowments/endowments.ts
@@ -49,9 +49,9 @@ const endowments_api = aws.injectEndpoints({
         return res.Items;
       },
     }),
-    profiles: builder.query<Profile[], undefined>({
+    profiles: builder.query<Profile[], boolean>({
       //TODO:refactor this query pattern - how?
-      query: () => `endowments/profiles`,
+      query: (isTest) => `endowments/profiles${isTest ? "/testnet" : ""}`,
       //transform response before saving to cache for easy lookup by component
       transformResponse: (res: QueryRes<Profile[]>) => {
         return res.Items;


### PR DESCRIPTION
Closes #459

## Description of the Problem / Feature
Testnet loads mainnet charity profiles

## Explanation of the solution
Use the connected wallet to detect network and modify url to pull testnet data from ```endowments/profiles/testent```

## Instructions on making this work
connect wallet on testnet

## UI changes for review
<img width="1242" alt="Screenshot 2022-01-11 at 13 45 13" src="https://user-images.githubusercontent.com/31709531/148944957-8db0533e-8200-4afa-b319-3941fe3f39a6.png">
