### PR TITLE
fix on execessive rerender

### DIFF
--- a/src/App/Views.tsx
+++ b/src/App/Views.tsx
@@ -16,8 +16,10 @@ import Withdraw from "pages/Withdraw/Withdraw";
 import Governance from "pages/Governance/Governance";
 import Auction from "pages/LBP/Auction";
 import Fund from "pages/Fund/Fund";
+import useWalletSuite from "components/WalletSuite/useWalletSuite";
 
 export default function Views() {
+  useWalletSuite();
   const { path } = useRouteMatch();
   const location = useLocation();
 

--- a/src/components/Headers/DappHead.tsx
+++ b/src/components/Headers/DappHead.tsx
@@ -1,14 +1,12 @@
 import Logo from "components/Logo/Logo";
 import MobileDappNav from "components/MobileNav/MobileDappNav";
 import DappMenu from "components/NavMenus/DappMenu";
-import useWalletSuite from "components/WalletSuite/useWalletSuite";
 import WalletSuite from "components/WalletSuite/WalletSuite";
 import { useState } from "react";
 import { FiMenu } from "react-icons/fi";
 import { IoClose } from "react-icons/io5";
 
 export default function DappHead() {
-  useWalletSuite();
   const [navShown, showNav] = useState(false);
 
   function toggleNav() {


### PR DESCRIPTION
## Description of the Problem / Feature
1. charity profiles in Fund profile causes excessive cyclical rerender with `<DappHead/>` when user connects wallet while in the Fund Profile page

## Explanation of the solution
1. move `useWalletSuite` hook closer to <WalletProvider/> since wallet state is not handled in `store` so not to be affected by lower level components render

## Instructions on making this work
N.A
## UI changes for review
N.A
