### PR TITLE
charity card reuses profiles cache data

### DIFF
--- a/src/pages/Market/CharityCard.tsx
+++ b/src/pages/Market/CharityCard.tsx
@@ -1,9 +1,9 @@
 import { Link } from "react-router-dom";
 import { app, site } from "types/routes";
-import useProfile from "./useProfile";
+import useCharityCard from "./useCharityCard";
 
 export default function CharityCard(props: { address: string }) {
-  const profile = useProfile(props.address);
+  const profile = useCharityCard(props.address);
   return (
     <div className="relative w-72 flex-none break-words">
       <img

--- a/src/pages/Market/useCharityCard.ts
+++ b/src/pages/Market/useCharityCard.ts
@@ -1,0 +1,18 @@
+import { useConnectedWallet } from "@terra-money/wallet-provider";
+import { chainIDs } from "contracts/types";
+import { useProfilesQuery } from "services/aws/endowments/endowments";
+import { profile as profile_placeholder } from "services/aws/endowments/placeholders";
+
+//in displaying marketplace card info, just reuse useProfilesQuery result
+//to avoid each card calling separate API call
+export default function useCharityCard(address: string) {
+  const wallet = useConnectedWallet();
+  const isTest = wallet?.network.chainID === chainIDs.testnet;
+
+  const { profile = profile_placeholder } = useProfilesQuery(isTest, {
+    selectFromResult: ({ data }) => ({
+      profile: data?.find((profile) => profile.endowment_address === address),
+    }),
+  });
+  return profile;
+}


### PR DESCRIPTION
## Description of the Problem / Feature
add more clarity to marketplace query hooks

## Explanation of the solution
created `useCharityCard` hook 
1. useProfiles --> use `useProfilesQuery` to get `profiles[]`
2. useProfile --> use `useProfileQuery` to get `profile` and provides cache invalidation on edit
3. useCharityCard --> reuse `profiles[]` cache data from `useProfilesQuery`

## Instructions on making this work
N.A

## UI changes for review
N.A
