### PR TITLE
HOT FIX: belief price

### DIFF
--- a/src/components/Swapper/getSpotPrice.ts
+++ b/src/components/Swapper/getSpotPrice.ts
@@ -1,11 +1,11 @@
 import { Dec } from "@terra-money/terra.js";
 import { Simulation } from "services/terra/types";
-export function getSpotPrice(simul: Simulation, offer = 1_000_000) {
+export function getSpotPrice(simul: Simulation, offer = 1) {
   if (simul.is_placeholder) {
     return new Dec(0);
   }
   const return_amount = new Dec(simul.return_amount);
-  const offer_amount = new Dec(offer);
+  const offer_amount = new Dec(offer).mul(1e6);
 
   return offer_amount.div(return_amount);
 }


### PR DESCRIPTION
## Description of the Problem / Feature
`belief_price` in `swap` message is in `micro_amount` e.g `0.055e-6` instead of just `0.055`
making simulations on lower slippage to fail

## Explanation of the solution
fix mistake on `getSpotPrice` function which is defaulted to a `micro_amount` but accepts `amount` as an input 

correct belief price now on `msg`
<img width="269" alt="image" src="https://user-images.githubusercontent.com/89639563/149664656-01e8ada7-8d5c-4a4c-ae2f-b943c7804a7e.png">
 


## Instructions on making this work
N.A

## UI changes for review
N.A

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design
