### PR TITLE
Turn redundant JSX template literals into regular strings

### DIFF
--- a/src/Admin/Admin.tsx
+++ b/src/Admin/Admin.tsx
@@ -27,7 +27,7 @@ const Admin = () => {
   );
 
   return (
-    <div className={`grid bg-gradient-to-b from-blue-accent to-black-blue`}>
+    <div className="grid bg-gradient-to-b from-blue-accent to-black-blue">
       <WalletProvider
         defaultNetwork={mainnet}
         walletConnectChainIds={walletConnectChainIds}

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -8,9 +8,7 @@ import DappHead from "components/Headers/DappHead";
 export default function App() {
   //TODO: refactor non-terra providers to redux
   return (
-    <div
-      className={`grid grid-rows-a1a bg-gradient-to-b from-blue-accent to-black-blue relative`}
-    >
+    <div className="grid grid-rows-a1a bg-gradient-to-b from-blue-accent to-black-blue relative">
       <TerraProvider
         defaultNetwork={mainnet}
         walletConnectChainIds={walletConnectChainIds}

--- a/src/Website/Website.tsx
+++ b/src/Website/Website.tsx
@@ -26,7 +26,7 @@ const Website = () => {
   );
 
   return (
-    <div className={`grid grid-rows-1a bg-white`}>
+    <div className="grid grid-rows-1a bg-white">
       <WebHead />
       <Suspense fallback={<LoaderComponent />}>
         <Switch>

--- a/src/components/DonateForm/Currency.tsx
+++ b/src/components/DonateForm/Currency.tsx
@@ -34,7 +34,7 @@ function Currency(props: Props) {
       />
       <label
         htmlFor={props.currency}
-        className={`uppercase flex items-center text-sm`}
+        className="uppercase flex items-center text-sm"
       >
         <img
           src={currency_icons[props.currency]}

--- a/src/components/Donator/Popup.tsx
+++ b/src/components/Donator/Popup.tsx
@@ -28,7 +28,7 @@ export default function Popup(props: Props) {
 
   return (
     <div className="p-6 grid grid-rows-1a place-items-center  bg-white-grey w-full max-w-xs min-h-115  rounded-xl shadow-lg overflow-hidden relative">
-      <button className={`absolute top-3 right-3`} onClick={closePopup}>
+      <button className="absolute top-3 right-3" onClick={closePopup}>
         <IoClose className="text-angel-grey" />
       </button>
       <p className="my-6 text-angel-grey text-center font-semibold font-heading">

--- a/src/components/Donator/UserForm.tsx
+++ b/src/components/Donator/UserForm.tsx
@@ -55,7 +55,7 @@ export default function UserForm(props: Props) {
             )) || (
               <label
                 htmlFor="custom"
-                className={`text-angel-grey w-52 rounded-md pl-2 py-2 bg-white`}
+                className="text-angel-grey w-52 rounded-md pl-2 py-2 bg-white"
               >
                 other amount
               </label>

--- a/src/components/Headers/DappHead.tsx
+++ b/src/components/Headers/DappHead.tsx
@@ -16,13 +16,11 @@ export default function DappHead() {
   }
 
   return (
-    <header
-      className={`mb-4 grid grid-cols-a1a lg:grid-cols-aa1 items-center w-full z-10 padded-container pt-3`}
-    >
+    <header className="mb-4 grid grid-cols-a1a lg:grid-cols-aa1 items-center w-full z-10 padded-container pt-3">
       <Logo />
       <DappMenu />
       <WalletSuite />
-      <button className={`text-white-grey ml-2 lg:hidden`} onClick={toggleNav}>
+      <button className="text-white-grey ml-2 lg:hidden" onClick={toggleNav}>
         {navShown ? (
           <IoClose className="text-2xl" />
         ) : (

--- a/src/components/Headers/WebHead.tsx
+++ b/src/components/Headers/WebHead.tsx
@@ -18,13 +18,13 @@ export default function WebHead() {
   return (
     <header
       ref={shadowRef}
-      className={`grid fixed bg-white w-full h-24 z-10 transition-shadow `}
+      className="grid fixed bg-white w-full h-24 z-10 transition-shadow "
     >
       <nav className="w-full grid grid-cols-a1a items-center justify-items-end md:justify-items-center padded-container">
         <Logo />
         <WebMenu />
         <button
-          className={`text-angel-grey block md:hidden ml-5`}
+          className="text-angel-grey block md:hidden ml-5"
           onClick={toggleNav}
         >
           <FiMenu className="text-2xl" />

--- a/src/components/MobileNav/MobileDappNav.tsx
+++ b/src/components/MobileNav/MobileDappNav.tsx
@@ -7,9 +7,7 @@ export default function MobileDappNav() {
     className: `text-white hover:text-opacity-75 uppercase inline-flex items-center font-heading`,
   };
   return (
-    <nav
-      className={`lg:hidden flex flex-col items-end col-span-3 rounded-sm w-full font-extrabold text-base gap-1 pt-2`}
-    >
+    <nav className="lg:hidden flex flex-col items-end col-span-3 rounded-sm w-full font-extrabold text-base gap-1 pt-2">
       <Link rel="noreferrer" to={`${site.home}`} {...linkStyles}>
         About us
       </Link>

--- a/src/components/MobileNav/MobileNav.tsx
+++ b/src/components/MobileNav/MobileNav.tsx
@@ -10,9 +10,7 @@ export default function MobileNav() {
   };
 
   return (
-    <ul
-      className={`text-angel-blue bg-white md:hidden p-5 rounded-sm shadow-lg fixed top-28 right-0 flex flex-col items-end w-full max-w-xs font-body text-base`}
-    >
+    <ul className="text-angel-blue bg-white md:hidden p-5 rounded-sm shadow-lg fixed top-28 right-0 flex flex-col items-end w-full max-w-xs font-body text-base">
       <li className="mr-4">
         <NavLink to={`${url}${web.charities}`} {...linkStyles}>
           For Charities

--- a/src/components/NavMenus/DappMenu.tsx
+++ b/src/components/NavMenus/DappMenu.tsx
@@ -8,9 +8,7 @@ export default function DappMenu() {
   };
 
   return (
-    <nav
-      className={`hidden lg:flex lg:row-start-1 lg:col-span-1 lg:col-start-2 flex gap-2 justify-self-end items-center font-body text-sm lg:text-base ml-2`}
-    >
+    <nav className="hidden lg:flex lg:row-start-1 lg:col-span-1 lg:col-start-2 flex gap-2 justify-self-end items-center font-body text-sm lg:text-base ml-2">
       <Link className={linkStyles.className} to={`${site.home}`}>
         About us
       </Link>

--- a/src/components/NavMenus/WebMenu.tsx
+++ b/src/components/NavMenus/WebMenu.tsx
@@ -9,9 +9,7 @@ export default function WebMenu() {
     activeClassName: "font-bold",
   };
   return (
-    <ul
-      className={`hidden md:flex justify-self-end items-center font-body text-sm lg:text-base`}
-    >
+    <ul className="hidden md:flex justify-self-end items-center font-body text-sm lg:text-base">
       <li className="mr-4">
         <NavLink to={`${url}${web.charities}`} {...linkStyles}>
           For Charities

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -10,14 +10,14 @@ export default function Search() {
 
   return (
     <div className="flex flex-row items-center">
-      <BsFilterRight className={`text-white text-xl`} />
+      <BsFilterRight className="text-white text-xl" />
       <button onClick={toggleSearch}>
-        <FiSearch className={`text-white text-xl mx-2 hover:text-orange`} />
+        <FiSearch className="text-white text-xl mx-2 hover:text-orange" />
       </button>
       {isOpenSearch && (
-        <div className={`rounded-xl h-8 border border-white p-1 bg-white mr-1`}>
+        <div className="rounded-xl h-8 border border-white p-1 bg-white mr-1">
           <input
-            className={`text-sm md:text-base outline-none text-black w-52 pl-1`}
+            className="text-sm md:text-base outline-none text-black w-52 pl-1"
             type="text"
             placeholder="Search"
             name="searchkey"

--- a/src/components/Subscriber/Popup.tsx
+++ b/src/components/Subscriber/Popup.tsx
@@ -23,7 +23,7 @@ export default function Popup(props: Props) {
   //To use formik context, make sure Popup is also inside <Formik/> tree
   return (
     <div className="p-4 grid grid-rows-1a place-items-center  bg-white-grey w-full max-w-xs min-h-115  rounded-xl shadow-lg overflow-hidden relative">
-      <button className={`absolute top-3 right-3`} onClick={closePopup}>
+      <button className="absolute top-3 right-3" onClick={closePopup}>
         <IoClose className="text-angel-grey" />
       </button>
       <p className="text-angel-grey text-center my-18">{props?.message}</p>

--- a/src/components/TerraStation/TerraAction.tsx
+++ b/src/components/TerraStation/TerraAction.tsx
@@ -20,7 +20,7 @@ export default function TerraAction(props: Props) {
     <button
       disabled={isLoading}
       onClick={handleClick}
-      className={`transform active:translate-x-1 bg-thin-blue disabled:bg-grey-accent text-angel-grey hover:bg-angel-blue hover:text-white flex items-center gap-2 rounded-full items-center p-1 pr-4 shadow-md`}
+      className="transform active:translate-x-1 bg-thin-blue disabled:bg-grey-accent text-angel-grey hover:bg-angel-blue hover:text-white flex items-center gap-2 rounded-full items-center p-1 pr-4 shadow-md"
     >
       <img
         src={icons[props.icon]}

--- a/src/pages/Admin/CharityApps/CharityApps.tsx
+++ b/src/pages/Admin/CharityApps/CharityApps.tsx
@@ -63,9 +63,7 @@ export default function CharityApps() {
         </h2>
         <div className="flex justify-between w-full mt-3">
           <div className="search px-3 py-2 flex items-center bg-white rounded-md border-gray-200 w-80">
-            <FiSearch
-              className={`text-gray-600 text-xl mr-2 hover:text-orange`}
-            />
+            <FiSearch className="text-gray-600 text-xl mr-2 hover:text-orange" />
             <input
               type="text"
               value={searchWord}

--- a/src/pages/Charities/Access.tsx
+++ b/src/pages/Charities/Access.tsx
@@ -36,12 +36,10 @@ export default function Access() {
             className="w-full max-w-lg shadow-md flex flex-col items-center p-6 border-4 border-blue-accent"
           >
             <img className="w-32 h-32" src={article.icon} alt="" />
-            <h4
-              className={`uppercase text-lg lg:text-xl text-center font-bold text-angel-grey my-4`}
-            >
+            <h4 className="uppercase text-lg lg:text-xl text-center font-bold text-angel-grey my-4">
               {article.title}
             </h4>
-            <p className={`text-angel-grey text-center`}>{article.desc}</p>
+            <p className="text-angel-grey text-center">{article.desc}</p>
           </article>
         ))}
       </div>

--- a/src/pages/Charities/Info.tsx
+++ b/src/pages/Charities/Info.tsx
@@ -25,12 +25,10 @@ export default function Info() {
           Direction.fromRight
         )} justify-self-center lg:justify-self-start max-w-2xl mt-5 lg:mt-0 lg:pl-2`}
       >
-        <h3
-          className={`text-xl sm:text-2xl font-semibold text-white font-body mb-3 relative transition-all uppercase`}
-        >
+        <h3 className="text-xl sm:text-2xl font-semibold text-white font-body mb-3 relative transition-all uppercase">
           High-yield, low-risk
         </h3>
-        <p className={`text-white-grey mb-3 text-xl`}>
+        <p className="text-white-grey mb-3 text-xl">
           Angel Protocol leverages decentralized financial products and offers
           them to charities through a simple platform. Your endowment earns{" "}
           <span className="font-semibold">~20%</span> interest through a savings

--- a/src/pages/Charity/CharityInfoNav.tsx
+++ b/src/pages/Charity/CharityInfoNav.tsx
@@ -20,7 +20,7 @@ export default function CharityInfoNav({
 
   return (
     <nav className="overflow-y-hidden overflow-x-scroll scroll-hidden grid items-start justify-stretch lg:padded-container my-5 lg:mb-0 md:pl-0">
-      <ul className={`flex font-body text-sm lg:text-base ml-1 block w-full`}>
+      <ul className="flex font-body text-sm lg:text-base ml-1 block w-full">
         <li className="mr-1 flex block w-full">
           {/**just use buttons since page switching is programmatic and no involved page semantics*/}
           <button

--- a/src/pages/Charity/DonationInfo.tsx
+++ b/src/pages/Charity/DonationInfo.tsx
@@ -88,7 +88,7 @@ export function DonationInfo({ openModal }: DonationInfoProps) {
           <button
             disabled={profile.is_placeholder}
             onClick={openModal}
-            className={`disabled:bg-grey-accent uppercase bg-orange text-white font-semibold rounded-xl md:w-48 w-52 h-12 d-flex justify-center items-center mb-4`}
+            className="disabled:bg-grey-accent uppercase bg-orange text-white font-semibold rounded-xl md:w-48 w-52 h-12 d-flex justify-center items-center mb-4"
           >
             DONATE NOW
           </button>

--- a/src/pages/Donors/Accepted.tsx
+++ b/src/pages/Donors/Accepted.tsx
@@ -24,12 +24,10 @@ export default function Accepted() {
             Direction.fromRight
           )} justify-self-center lg:justify-self-start max-w-2xl mt-5 lg:mt-0 lg:pl-2`}
         >
-          <h3
-            className={`uppercase text-2xl sm:text-3xl font-bold text-white font-body mb-3 relative transition-all`}
-          >
+          <h3 className="uppercase text-2xl sm:text-3xl font-bold text-white font-body mb-3 relative transition-all">
             Accepted Cryptocurrency
           </h3>
-          <p className={`text-white-grey mb-3 text-xl`}>
+          <p className="text-white-grey mb-3 text-xl">
             Angel Protocol currently accepts donations to charitable
             organizations in TerraUSD <span className="font-bold">UST</span>.
             Our team is working to offer donation capability for other

--- a/src/pages/Donors/Alignment.tsx
+++ b/src/pages/Donors/Alignment.tsx
@@ -25,19 +25,17 @@ export default function Alignment() {
           Direction.fromRight
         )} justify-self-center lg:justify-self-start max-w-2xl mt-5 lg:mt-0 lg:pl-4`}
       >
-        <h3
-          className={`text-xl sm:text-2xl font-semibold text-white font-body mb-3 relative transition-all`}
-        >
+        <h3 className="text-xl sm:text-2xl font-semibold text-white font-body mb-3 relative transition-all">
           Alignment to the United Nations Sustainable Development Goals
         </h3>
-        <p className={`text-white-grey mb-3 text-base lg:text-lg`}>
+        <p className="text-white-grey mb-3 text-base lg:text-lg">
           We are passionate about making the most impact and doing it
           sustainably. Rather than creating our own charitable interest
           categories for donors to choose from, all charities in our donor
           marketplace are aligned to one of the 17 United Nations Sustainable
           Development Goals (UN SDGs).
         </p>
-        <p className={`text-white-grey mb-3 text-base lg:text-lg`}>
+        <p className="text-white-grey mb-3 text-base lg:text-lg">
           The UN SDGs are goals that layout a blueprint for peace and prosperity
           for people and the planet, now and into the future.
         </p>

--- a/src/pages/Donors/Ways.tsx
+++ b/src/pages/Donors/Ways.tsx
@@ -26,12 +26,10 @@ export default function Ways() {
             key={article.id}
             className="w-full max-w-lg shadow-md flex flex-col items-start p-6 border-4 border-blue-accent"
           >
-            <h4
-              className={`uppercase text-lg lg:text-xl font-bold text-angel-grey my-4`}
-            >
+            <h4 className="uppercase text-lg lg:text-xl font-bold text-angel-grey my-4">
               {article.title}
             </h4>
-            <p className={`text-angel-grey `}>{article.desc}</p>
+            <p className="text-angel-grey ">{article.desc}</p>
           </article>
         ))}
       </div>

--- a/src/pages/Endowment_Admin/Popup.tsx
+++ b/src/pages/Endowment_Admin/Popup.tsx
@@ -4,7 +4,7 @@ import { PopupProps } from "./types";
 export default function Popup(props: PopupProps) {
   return (
     <div className="p-3 md:p-6 bg-white-grey w-full max-w-xs rounded-xl shadow-lg overflow-hidden relative">
-      <button className={`absolute top-3 right-3`} onClick={props.onCloseModal}>
+      <button className="absolute top-3 right-3" onClick={props.onCloseModal}>
         <IoClose className="text-angel-grey" />
       </button>
       <h3 className="my-5 text-lg text-angel-grey text-center items-center font-semibold font-heading">

--- a/src/pages/Fund/Fund.tsx
+++ b/src/pages/Fund/Fund.tsx
@@ -48,9 +48,7 @@ export default function Fund(props: RouteComponentProps<{ id?: string }>) {
           >
             {isDonating ? "Back to Index" : "Donate"}
           </button>
-          <button
-            className={`ml-2 bg-angel-blue uppercase text-white text-sm w-36 py-2 rounded-lg font-semibold shadow-md`}
-          >
+          <button className="ml-2 bg-angel-blue uppercase text-white text-sm w-36 py-2 rounded-lg font-semibold shadow-md">
             Share
           </button>
         </div>

--- a/src/pages/Governance/PollAction.tsx
+++ b/src/pages/Governance/PollAction.tsx
@@ -79,7 +79,7 @@ function Action(props: ActionProps) {
     <button
       disabled={props.disabled}
       onClick={props.action}
-      className={`text-xs font-bold uppercase font-heading px-6 pt-1.5 pb-1 rounded-md bg-blue-accent hover:bg-angel-blue border-2 border-opacity-30`}
+      className="text-xs font-bold uppercase font-heading px-6 pt-1.5 pb-1 rounded-md bg-blue-accent hover:bg-angel-blue border-2 border-opacity-30"
     >
       {props.title}
     </button>

--- a/src/pages/Home/Info.tsx
+++ b/src/pages/Home/Info.tsx
@@ -18,19 +18,15 @@ export default function Info() {
           Direction.fromRight
         )} justify-self-center lg:justify-self-start max-w-2xl mt-5 lg:mt-0 lg:pl-2`}
       >
-        <h3
-          className={`text-xl sm:text-2xl font-semibold text-blue-accent font-body mb-3 relative transition-all`}
-        >
+        <h3 className="text-xl sm:text-2xl font-semibold text-blue-accent font-body mb-3 relative transition-all">
           Endowments are the future of giving
         </h3>
-        <p className={`text-angel-grey mb-3 leading-relaxed `}>
+        <p className="text-angel-grey mb-3 leading-relaxed ">
           Less than 60% of charities have enough saved in their reserves to
           cover more than one year of operating costs. Angel Protocol plays a
           critical role in solving this challenge.
         </p>
-        <p
-          className={`text-angel-grey leading-relaxed relative transition-all`}
-        >
+        <p className="text-angel-grey leading-relaxed relative transition-all">
           Endowments are a powerful tool that charities use to grow their
           donations. However, traditional endowments can be expensive to set up,
           access, and maintain. Angel Protocol has developed a platform

--- a/src/pages/Home/Process.tsx
+++ b/src/pages/Home/Process.tsx
@@ -36,9 +36,7 @@ export default function Process() {
             >
               <div className="bg-gray-50 bg-opacity-30 relative rounded-full shadow-lg backdrop-blur-xl">
                 <img src={icon} alt="" className="w-14 m-8" />
-                <span
-                  className={`font-bold uppercase text-xs text-angel-grey absolute top-1 -right-6 bg-angel-orange py-2 px-4 rounded-full shadow-md`}
-                >
+                <span className="font-bold uppercase text-xs text-angel-grey absolute top-1 -right-6 bg-angel-orange py-2 px-4 rounded-full shadow-md">
                   {toolkit}
                 </span>
               </div>

--- a/src/pages/LBP/Auction.tsx
+++ b/src/pages/LBP/Auction.tsx
@@ -58,7 +58,7 @@ function AuctionStats() {
     <div className="w-full flex flex-wrap gap-5 mt-3">
       <StatsDetails
         title="Duration"
-        value={`3 days`}
+        value="3 days"
         Icon={FaClock}
         exClass="duration"
       />
@@ -68,7 +68,7 @@ function AuctionStats() {
         Icon={FaStopwatch}
         exClass="ends-in"
       />
-      <StatsDetails title="Price" value={`UST 0.074994`} />
+      <StatsDetails title="Price" value="UST 0.074994" />
     </div>
   );
 }

--- a/src/pages/Leaderboard/Description.tsx
+++ b/src/pages/Leaderboard/Description.tsx
@@ -29,9 +29,7 @@ export default function Description(props: Props) {
       >
         {details.name}
       </a>
-      <p
-        className={`relative pr-16 text-sm text-angel-grey  leading-normal mb-2 line-clamp-3`}
-      >
+      <p className="relative pr-16 text-sm text-angel-grey  leading-normal mb-2 line-clamp-3">
         {details.description}
       </p>
     </div>

--- a/src/pages/Leaderboard/Heading.tsx
+++ b/src/pages/Leaderboard/Heading.tsx
@@ -2,9 +2,7 @@ type Props = { text: string };
 
 export default function Heading(props: Props) {
   return (
-    <th
-      className={`text-left uppercase font-heading text-md p-2 pl-0 text-angel-grey`}
-    >
+    <th className="text-left uppercase font-heading text-md p-2 pl-0 text-angel-grey">
       {props.text}
     </th>
   );

--- a/src/pages/Market/CharityCard.tsx
+++ b/src/pages/Market/CharityCard.tsx
@@ -13,7 +13,7 @@ export default function CharityCard(props: { address: string }) {
       />
       <Link
         to={`${site.app}/${app.charity}/${props.address}`}
-        className={`block cursor-pointer font-heading text-white-grey hover:text-angel-orange font-bold text-sm uppercase mt-1.5`}
+        className="block cursor-pointer font-heading text-white-grey hover:text-angel-orange font-bold text-sm uppercase mt-1.5"
       >
         {profile.charity_name}
       </Link>

--- a/src/pages/Market/Index.tsx
+++ b/src/pages/Market/Index.tsx
@@ -21,7 +21,7 @@ export default function Index(props: { id: number }) {
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseLeave}
         onMouseMove={handleMouseMove}
-        className={`flex flex-row gap-4 overflow-x-scroll scroll-hidden ml-0 sm:ml-4`}
+        className="flex flex-row gap-4 overflow-x-scroll scroll-hidden ml-0 sm:ml-4"
       >
         {profiles.map((profile) => (
           <CharityCard

--- a/src/pages/Market/IndexCard.tsx
+++ b/src/pages/Market/IndexCard.tsx
@@ -10,7 +10,7 @@ export default function IndexCard(props: { id: number }) {
         className="hidden sm:block w-36 h-16 object-contain img-no-drag object-left"
         alt="icon representing category"
       />
-      <p className={`font-heading font-bold uppercase mt-2 text-left`}>
+      <p className="font-heading font-bold uppercase mt-2 text-left">
         {sdg.title}
       </p>
       <p className="text-sm mb-1.5 line-clamp-2 text-left">{sdg.desc}</p>


### PR DESCRIPTION
Closes #489

## Description of the Problem / Feature
There are a lot of unnecessary template literals in our code-base that should be turned into a regular string.

## Explanation of the solution
Replaced all ``<Component prop={`((unnecessary template literal with no string interpolation))`} />`` with a simple double-quote string

## Instructions on making this work
- run the app
- check any of the affected pages

