### PR TITLE
Staging via endow-bal-caching: bug fixes and enchacements

### DIFF
--- a/src/components/Donater/useUSTEstimator.ts
+++ b/src/components/Donater/useUSTEstimator.ts
@@ -27,6 +27,7 @@ export default function useUSTEstimator() {
   const receiver = watch("receiver");
   const debounced_amount = useDebouncer(amount, 500);
   const debounced_split = useDebouncer(split_liq, 500);
+  console.log(debounced_split);
 
   useEffect(() => {
     (async () => {

--- a/src/components/Staker/Amount.tsx
+++ b/src/components/Staker/Amount.tsx
@@ -1,3 +1,4 @@
+import { Dec } from "@terra-money/terra.js";
 import { ErrorMessage } from "@hookform/error-message";
 import { currency_text, denoms } from "constants/currency";
 import { useFormContext } from "react-hook-form";
@@ -15,7 +16,7 @@ export default function Amount() {
   const is_stake = watch("is_stake");
   const { balance, locked } = useStakerBalance(is_stake);
   const onMaxClick = () => {
-    setValue("amount", balance.sub(locked).div(1e6).toInt().toString());
+    setValue("amount", balance.sub(locked).div(1e6).toFixed(3, Dec.ROUND_DOWN));
   };
   return (
     <div className="grid">

--- a/src/components/Withdraw/Amount.tsx
+++ b/src/components/Withdraw/Amount.tsx
@@ -11,10 +11,10 @@ export default function Amount(props: VaultInfo & { balance: string }) {
     setValue,
     formState: { errors },
   } = useFormContext<Values>();
-  const balance = new Dec(props.balance).div(1e6).toNumber();
+  const balance = new Dec(props.balance).div(1e6);
 
   function setMax() {
-    setValue(props.field_id, toCurrency(balance, 2), {
+    setValue(props.field_id, balance.toFixed(3, Dec.ROUND_DOWN), {
       shouldDirty: true,
       shouldValidate: true,
     });
@@ -37,7 +37,7 @@ export default function Amount(props: VaultInfo & { balance: string }) {
             type="button"
             className="font-bold hover:text-angel-blue"
           >
-            {toCurrency(balance, 2, true)} {props.symbol}
+            {toCurrency(balance.toNumber(), 3, true)} {props.symbol}
           </button>
         </p>
       </div>

--- a/src/components/Withdraw/Misc.tsx
+++ b/src/components/Withdraw/Misc.tsx
@@ -14,22 +14,19 @@ function Misc(props: { title: string; value: string }) {
 
 export function Fee() {
   const { fee } = useGetter((state) => state.transaction);
-  return <Misc title="tx fee" value={`${toCurrency(fee, 2, true)} UST`} />;
+  return <Misc title="tx fee" value={`${toCurrency(fee, 3)} UST`} />;
 }
 
 export function Total() {
   const { watch } = useFormContext<Values>();
   const total_ust = watch("total_ust");
-  return <Misc title="total" value={`${toCurrency(total_ust, 2, true)} UST`} />;
+  return <Misc title="total" value={`${toCurrency(total_ust, 3)} UST`} />;
 }
 
 export function ToReceive() {
   const { watch } = useFormContext<Values>();
   const total_receive = watch("total_receive");
   return (
-    <Misc
-      title="to receive"
-      value={`${toCurrency(total_receive, 2, true)} UST`}
-    />
+    <Misc title="to receive" value={`${toCurrency(total_receive, 3)} UST`} />
   );
 }

--- a/src/components/Withdraw/useWithdraw.ts
+++ b/src/components/Withdraw/useWithdraw.ts
@@ -9,7 +9,7 @@ import useTxErrorHandler from "hooks/useTxErrorHandler";
 import handleTerraError from "helpers/handleTerraError";
 import { Values } from "./types";
 import { terra } from "services/terra/terra";
-import { tags } from "services/terra/tags";
+import { tags, user } from "services/terra/tags";
 
 export default function useWithdrawHoldings() {
   const { reset } = useFormContext<Values>();
@@ -66,8 +66,10 @@ export default function useWithdrawHoldings() {
           );
 
           dispatch(
-            //invalidate all gov related cache
-            terra.util.invalidateTags([{ type: tags.endowment }])
+            terra.util.invalidateTags([
+              { type: tags.endowment },
+              { type: tags.user, id: user.terra_balance },
+            ])
           );
         } else {
           dispatch(

--- a/src/contracts/Account.ts
+++ b/src/contracts/Account.ts
@@ -36,20 +36,22 @@ export default class Account extends Contract {
     splitToLiquid: number
   ): Promise<CreateTxOptions> {
     this.checkWallet();
-    const pctLiquid = splitToLiquid / 100;
-    const pctLocked = 1 - pctLiquid;
+    const pctLiquid = new Dec(splitToLiquid).div(100);
+    const pctLocked = new Dec(1).sub(pctLiquid);
+
     const micro_UST_Amount = new Dec(UST_amount).mul(1e6).toNumber();
     const depositMsg = new MsgExecuteContract(
       this.walletAddr!,
       this.address,
       {
         deposit: {
-          locked_percentage: `${pctLocked}`,
-          liquid_percentage: `${pctLiquid}`,
+          locked_percentage: pctLiquid.toFixed(2),
+          liquid_percentage: pctLocked.toFixed(2),
         },
       },
       [new Coin(denoms.uusd, micro_UST_Amount)]
     );
+
     const fee = await this.estimateFee([depositMsg]);
     // const fee = new StdFee(2500000, [new Coin(denoms.uusd, 1.5e6)]);
     return { msgs: [depositMsg], fee };


### PR DESCRIPTION
## Description of the Problem / Feature
found bug fixes and enchancements will reviewing `endow-bal-caching` and clicking around
1. bug: clicking balance to set max balance on field causes fee estimate to fail
-reason: clicking `1.076k` literally sets field value to `1.076k` which is an invalid amount
-solution: don't truncate set amount

2. bug: some split values on charity causes tx estimate to fail
- reason: JS precision bugs
- solution: use Decimal.js for split calculation
![split bug](https://user-images.githubusercontent.com/89639563/150910094-45b76d85-b256-4afc-a4f4-abba9c1b247d.jpg)


3. enhancement: increases precision of setMax functions (staker & withdraw) to 3 rounded down (rounded up will fail `amount > balance` check)
![max 3 dec round down ](https://user-images.githubusercontent.com/89639563/150910040-c434e414-1fb7-43aa-8647-6dbb5265d167.jpg)
![max 3 dec round down2 ](https://user-images.githubusercontent.com/89639563/150910048-776a4903-2b74-44a0-8a24-874fa2a2770f.jpg)

4. enchancement: don't truncate receive amount on withdraw to show effect of tx fee
![max 3 dec round down and untruncated meta](https://user-images.githubusercontent.com/89639563/150910023-2c32d246-2399-4591-8db4-02e97683d40c.jpg)

4. enhancement: upon completion of withdraw, endowment balance is immediately reflected but increase in wallet balance is not. 
- solution: invalidate user balance cache on succesful transaction



