### PR TITLE
add a button to gov forum

### DIFF
--- a/src/pages/Governance/Polls.tsx
+++ b/src/pages/Governance/Polls.tsx
@@ -29,8 +29,12 @@ export default function Polls() {
           <SiHiveBlockchain className="mr-1" />
           <span>{toCurrency(+block_height, 0)}</span>
         </p>
-        <div className="flex flex-wrap gap-2 justify-start md:justify-self-end self-end">
-          <a href="https://forum.angelprotocol.io" target="_blank">
+        <div className="flex flex-wrap gap-2 justify-end self-end">
+          <a
+            href="https://forum.angelprotocol.io"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <button className="action-button">Join Forum</button>
           </a>
           <button

--- a/src/pages/Governance/Portal.tsx
+++ b/src/pages/Governance/Portal.tsx
@@ -30,7 +30,7 @@ export default function Portal() {
   }
 
   return (
-    <div className="bg-white bg-opacity-10 border border-opacity-10 shadow-xl w-full col-start-2 row-span-2 rounded-md p-2 p-8 pb-6 grid grid-rows-a1">
+    <div className="bg-white bg-opacity-10 border border-opacity-10 shadow-xl w-full col-start-2 row-span-2 rounded-md p-6 pb-6 grid grid-rows-a1">
       <div className="flex flex-wrap gap-2 items-center mb-10 lg:mb-0">
         <div className="relative">
           <div className="absolute w-full h-full border-4 border-white border-opacity-80 rounded-full animate-pulse shadow-md"></div>
@@ -45,7 +45,7 @@ export default function Portal() {
           {data && `${Number(data.stakingAPR).toFixed(2)}% APR`}
         </span>
       </div>
-      <div className="flex flex-wrap gap-2 justify-start md:justify-self-end self-end">
+      <div className="flex flex-wrap gap-2 self-end justify-end">
         <Action title="Trade Halo" action={showSwapper} />
         <Action title="Stake" action={showStaker} />
         <Action title="Unstake" action={showUnstaker} />


### PR DESCRIPTION
Closes #560

## Description of the Problem / Feature
Need to add a gov forum button

## Explanation of the solution
- Adds "Join Forum" button next to the Create Poll button
- Adds a little more padding around block height number to give buttons breathing room

## Instructions on making this work
1. Go to gov page. 
2. See the new button. 
3. Click said button. 
4. Should take you to the AP Gov Forum.
5. ????
6. Profit :moneybag: 

## UI changes for review
![image](https://user-images.githubusercontent.com/85138450/151097695-f2ead52a-1024-4dc6-bc09-6f7a6d9063fa.png)
