### PR TITLE
Donation POST request sent even without KYC

### DIFF
--- a/src/components/Donater/useUSTSender.ts
+++ b/src/components/Donater/useUSTSender.ts
@@ -1,10 +1,13 @@
 import { useConnectedWallet } from "@terra-money/wallet-provider";
 import { useFormContext } from "react-hook-form";
 import { Values } from "components/Donater/types";
+import createAuthToken from "helpers/createAuthToken";
 import handleTerraError from "helpers/handleTerraError";
 import useUSTEstimator from "./useUSTEstimator";
 import Contract from "contracts/Contract";
 import { useSetter } from "store/accessors";
+import { useLogDonationTransactionMutation } from "services/apes/donations";
+import { UserTypes } from "services/user/types";
 import { setStage } from "services/transaction/transactionSlice";
 import { Step } from "services/transaction/types";
 import useTxErrorHandler from "hooks/useTxErrorHandler";
@@ -16,6 +19,7 @@ function useUSTSender() {
   const wallet = useConnectedWallet();
   const tx = useUSTEstimator();
   const handleTxError = useTxErrorHandler();
+  const [logDonationTransaction] = useLogDonationTransactionMutation();
 
   //data:Data
   async function terra_sender() {
@@ -51,23 +55,59 @@ function useUSTSender() {
         const txInfo = await getTxInfo;
 
         if (!txInfo.code) {
-          dispatch(
-            setStage({
-              step: Step.success,
-              content: {
-                message: "Thank you for your donation!",
-                tx: {
-                  txHash: txInfo.txhash,
-                  amount: getValues("amount"),
-                  split_liq: getValues("split_liq"),
-                  to: getValues("to"),
-                  receiver: getValues("receiver"),
-                },
-                url: getFinderUrl(wallet.network.chainID, txInfo.txhash),
-              },
-            })
+          // After confirming that the donation TX is a success, record the TX data in our APES Donations DB
+          const authToken = createAuthToken(UserTypes.WEB_APP);
+          const key = getValues("to") === "charity" ? "charityId" : "fundId";
+          const donationPostData = {
+            token: authToken,
+            body: {
+              amount: Number(getValues("amount")),
+              splitLiq: getValues("split_liq"),
+              transactionDate: new Date().toISOString(),
+              transactionId: txInfo.txhash,
+              chainId: wallet?.network.chainID, //e.g "columbus-5", "bombay-12" or one of chainIDs enum values
+              [key]: getValues("receiver"),
+              denomination: "UST",
+            },
+          };
+          const donationPostResponse: any = await logDonationTransaction(
+            donationPostData
           );
-          reset();
+
+          if (donationPostResponse.data) {
+            // If donation TX database recording is a success
+            dispatch(
+              setStage({
+                step: Step.success,
+                content: {
+                  message:
+                    donationPostResponse?.data.message ||
+                    "Thank you for your donation!",
+                  tx: {
+                    txHash: txInfo.txhash,
+                    amount: getValues("amount"),
+                    to: getValues("to"),
+                    receiver: getValues("receiver"),
+                  },
+                  url: getFinderUrl(wallet.network.chainID, txInfo.txhash),
+                },
+              })
+            );
+            reset();
+          } else {
+            // Donation TX database recording failed
+            dispatch(
+              setStage({
+                step: Step.error,
+                content: {
+                  message:
+                    donationPostResponse?.error.data.message ||
+                    "Transaction was successful but it's not recorded in our database.",
+                  url: getFinderUrl(wallet.network.chainID, txInfo.txhash),
+                },
+              })
+            );
+          }
         } else {
           dispatch(
             setStage({

--- a/src/components/Receipter/Receipter.tsx
+++ b/src/components/Receipter/Receipter.tsx
@@ -3,20 +3,16 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { schema } from "./schema";
 import { Values } from "./types";
 import { useGetter } from "store/accessors";
-import { useConnectedWallet } from "@terra-money/wallet-provider";
 
 export default function Receipter(props: any) {
   const { stage } = useGetter((state) => state.transaction);
-  const wallet = useConnectedWallet();
 
   const methods = useForm<Values>({
     reValidateMode: "onChange",
     defaultValues: {
       amount: parseInt(stage.content?.tx?.amount || ""),
-      splitLiq: stage.content?.tx?.split_liq,
       transactionDate: new Date().toISOString(),
       transactionId: stage.content?.tx?.txHash,
-      chainId: wallet?.network.chainID,
       fullName: "",
       email: "",
       streetAddress: "",
@@ -24,7 +20,6 @@ export default function Receipter(props: any) {
       state: "",
       zipCode: "",
       country: "",
-      denomination: "UST",
     },
     resolver: yupResolver(schema),
   });

--- a/src/components/Receipter/types.ts
+++ b/src/components/Receipter/types.ts
@@ -1,11 +1,7 @@
 export interface Values {
   transactionDate: string; // e.g new Date().toISOString()
   transactionId: string; // tx hash
-  amount: number; // e.g 1000 (shown in form as 1000 UST)
-  splitLiq: string; // % of total amount to be split into the Liquid account (remaining % goes into Locked account)
-  chainId?: string; //e.g "columbus-5", "bombay-12" or one of chainIDs enum values
-  fundId?: number | string; // fundId or charityAddress
-  charityId?: number | string; // fundId or charityAddress
+  amount: number; // e.g 1000 (shown in form as 1000 UST)s
   fullName: string; // "John Doe"
   email: string; // "john@doe.email.com"
   streetAddress: string;
@@ -13,5 +9,17 @@ export interface Values {
   state: string;
   zipCode: string; //2000
   country: string;
-  denomination: string; //"UST"
+}
+
+export interface PutRequestValues {
+  transactionId: string;
+  body: {
+    fullName: string;
+    email: string;
+    streetAddress: string;
+    city: string;
+    state: string;
+    zipCode: string;
+    country: string;
+  };
 }

--- a/src/components/Receipter/useReceiptForm.tsx
+++ b/src/components/Receipter/useReceiptForm.tsx
@@ -10,16 +10,22 @@ export default function useReceiptForm() {
   const [processing, setProcessing] = useState(false);
   const [requestReceipt] = useRequestReceiptMutation();
   const { stage } = useGetter((state) => state.transaction);
-  const endowment_addr = stage.content?.tx?.receiver;
-  const to = stage.content?.tx?.to;
 
   const submitHandler = async (body: Values) => {
-    const key = to === "charity" ? "charityId" : "fundId";
-    const receipt = { ...body, [key]: endowment_addr };
+    const receipt = {
+      transactionId: body.transactionId,
+      body: {
+        fullName: body.fullName,
+        email: body.email,
+        streetAddress: body.streetAddress,
+        city: body.city,
+        state: body.state,
+        zipCode: body.zipCode,
+        country: body.country,
+      },
+    };
     setProcessing(true);
-    const response: any = await requestReceipt({
-      receipt,
-    });
+    const response: any = await requestReceipt({ receipt });
     setProcessing(false);
     if (response.data) {
       dispatch(
@@ -28,8 +34,7 @@ export default function useReceiptForm() {
           content: {
             url: stage.content?.url,
             message:
-              response?.data?.message ||
-              "Receipt request successfully sent, Your receipt will be sent to your email address",
+              "Receipt request successfully sent. Your receipt will be sent to your email address.",
           },
         })
       );
@@ -38,7 +43,9 @@ export default function useReceiptForm() {
         setStage({
           step: Step.error,
           content: {
-            message: "Error processing your receipt,",
+            url: stage.content?.url,
+            message:
+              response?.error.data.message || "Error processing your receipt.",
           },
         })
       );

--- a/src/services/apes/donations.ts
+++ b/src/services/apes/donations.ts
@@ -1,4 +1,4 @@
-import { Values } from "components/Receipter/types";
+import { PutRequestValues } from "components/Receipter/types";
 import createAuthToken from "helpers/createAuthToken";
 import { UserTypes } from "services/user/types";
 import { apes } from "./apes";
@@ -16,14 +16,14 @@ const donations_api = apes.injectEndpoints({
       },
       transformResponse: (response: { data: any }) => response,
     }),
-    requestReceipt: builder.mutation<any, { receipt: Values }>({
+    requestReceipt: builder.mutation<any, { receipt: PutRequestValues }>({
       query: ({ receipt }) => {
         const generatedToken = createAuthToken(UserTypes.WEB_APP);
         return {
-          url: "donation",
-          method: "POST",
+          url: `donation?transactionId=${receipt.transactionId}`,
+          method: "PUT",
           headers: { authorization: generatedToken },
-          body: receipt,
+          body: receipt.body,
         };
       },
       transformResponse: (response: any) => response, // TODO:  assign type to the response object

--- a/src/services/transaction/types.ts
+++ b/src/services/transaction/types.ts
@@ -10,7 +10,6 @@ export enum Step {
 export type Tx = {
   txHash: string;
   amount?: string;
-  split_liq?: string;
   to?: "charity" | "fund" | "tca";
   receiver?: number | string;
 };


### PR DESCRIPTION
Closes #577 

## Description of the Problem / Feature
In our dapp's donation recording process, we only record transactions that request for a tax receipt. If the donor didn't request for a receipt, we do not record it in our donations DB. We need to record all transactions made in our dapp so we can track and record data like total amount of donations. Also, if a donor donated in LUNA or ETH and they did not request for a tax receipt. We would not know of this transaction and we would not be able to do a swap unless we look manually into our AP wallet.

## Explanation of the solution
Once a donation is confirmed in the blockchain, we will invoke the `POST /donation` endpoint. Then we will grab all the necessary on-chain data and record it in our Donations DB. If the recording is a success, they will see an option that they can request for a tax receipt. If they opt-in to submit our light KYC form, we will invoke the `PUT /donation?transactionId=<transactionId>` endpoint. This will update the existing record and we will send them the tax receipt email.

## Instructions on making this work
1. Install all dependencies and make sure you are on `localhost:4200`.
2. Open your browser's dev console (Network tab).
3. Make a donation in the Charity profile page and also make a tax receipt request. 
4. Finally, check your console's Network tab and there should be two donation endpoint requests just like what is said in the explanation.

## UI changes for review
Minor UI changes for the Transaction success modal and tax receipt request error modal.

### Successful donation transaction:
![Screenshot from 2022-01-27 18-36-26](https://user-images.githubusercontent.com/65009749/151342301-fe990a8c-85df-4fad-afdd-a2ee715109ca.png)

### Successful tax receipt request:
![Screenshot from 2022-01-27 18-38-02](https://user-images.githubusercontent.com/65009749/151342619-e24feb70-9e14-4d94-a611-29478c9037e8.png)

### Donation went in but the recording process failed:
![Screenshot from 2022-01-27 18-41-07](https://user-images.githubusercontent.com/65009749/151343223-f6cccb5e-e8ff-4cc2-9dd9-22ab9c02706c.png)

### Invalid transaction ID was used in the `PUT` request:
![Screenshot from 2022-01-27 18-54-13](https://user-images.githubusercontent.com/65009749/151345234-6c990d08-8661-49bd-9f84-02e71436986b.png)
