### PR TITLE
Move `<ToastContainer />` Declaration to the App Root

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -4,6 +4,7 @@ import AppFoot from "components/Footers/AppFoot";
 import Nodal from "components/Nodal/Nodal";
 import Views from "./Views";
 import DappHead from "components/Headers/DappHead";
+import { ToastContainer } from "react-toastify";
 
 export default function App() {
   //TODO: refactor non-terra providers to redux
@@ -18,6 +19,7 @@ export default function App() {
           <Views />
         </Nodal>
         <AppFoot />
+        <ToastContainer />
       </TerraProvider>
     </div>
   );

--- a/src/pages/Admin/Login/AdminLogin.tsx
+++ b/src/pages/Admin/Login/AdminLogin.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
-import { ToastContainer } from "react-toastify";
 import eyeIcon from "assets/images/eye.png";
 import eyeSlashIcon from "assets/images/eye-slash.png";
 import {
@@ -105,7 +104,6 @@ const AdminLogin = () => {
       >
         learn more about angel protocol
       </Link>
-      <ToastContainer />
     </div>
   );
 };

--- a/src/pages/Charity/Charity.tsx
+++ b/src/pages/Charity/Charity.tsx
@@ -11,7 +11,6 @@ import CharityProfileEditForm from "./CharityProfileEditForm";
 import { Profile } from "services/aws/endowments/types";
 import CharityUpdateSuite from "components/CharityForm/CharityUpdateSuite";
 import { useConnectedWallet } from "@terra-money/wallet-provider";
-import { ToastContainer } from "react-toastify";
 import { profile as profile_placeholder } from "services/aws/endowments/placeholders";
 import { useProfileQuery } from "services/aws/endowments/endowments";
 import ImageWrapper from "components/ImageWrapper/ImageWrapper";
@@ -84,7 +83,6 @@ const Charity = (props: RouteComponentProps<CharityParam>) => {
           />
         </div>
       </div>
-      <ToastContainer />
     </section>
   );
 };

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Formik, Form, Field, ErrorMessage } from "formik";
-import { ToastContainer } from "react-toastify";
 import eyeIcon from "assets/images/eye.png";
 import eyeSlashIcon from "assets/images/eye-slash.png";
 import useLogin from "./useLogin";
@@ -93,7 +92,6 @@ const Login = () => {
           learn more about angel protocol
         </Link>
       </div>
-      <ToastContainer />
     </section>
   );
 };

--- a/src/pages/registration/ConfirmEmail.tsx
+++ b/src/pages/registration/ConfirmEmail.tsx
@@ -1,6 +1,6 @@
 import { useHistory, useLocation } from "react-router-dom";
 import banner2 from "assets/images/banner-register-2.jpg";
-import { toast, ToastContainer } from "react-toastify";
+import { toast } from "react-toastify";
 import Action from "../../components/ActionButton/Action";
 import { useGetter, useSetter } from "store/accessors";
 import { useRequestEmailMutation } from "services/aws/registration";
@@ -90,7 +90,6 @@ const ConfirmEmail = () => {
           classes="bg-thin-blue w-48 h-12 text-sm"
         />
       </div>
-      <ToastContainer />
     </div>
   );
 };

--- a/src/pages/registration/ContactDetails.tsx
+++ b/src/pages/registration/ContactDetails.tsx
@@ -1,5 +1,4 @@
 import { ContactDetailsForm } from "components/ContactDetailsForm/ContactDetailsForm";
-import { ToastContainer } from "react-toastify";
 import { useGetter } from "store/accessors";
 
 const ContactDetails = () => {
@@ -16,7 +15,6 @@ const ContactDetails = () => {
           "This information will let us know more about your organization and who you are. Once this form is submitted, you will be able to resume your registration if it gets interrupted in the future."}
       </p>
       <ContactDetailsForm contactData={user} />
-      <ToastContainer />
     </div>
   );
 };

--- a/src/pages/registration/Registration.tsx
+++ b/src/pages/registration/Registration.tsx
@@ -1,7 +1,6 @@
 import { useHistory, useRouteMatch } from "react-router-dom";
 import { registration } from "types/routes";
 import banner1 from "assets/images/banner-register-1.jpg";
-import { ToastContainer } from "react-toastify";
 import Action from "../../components/ActionButton/Action";
 import { useSetter } from "store/accessors";
 import { removeUserData } from "services/user/userSlice";
@@ -93,7 +92,6 @@ const Registration = () => {
       <p className="text-base mt-6">
         Can't find a registration file with this reference?
       </p>
-      <ToastContainer />
     </div>
   );
 };

--- a/src/pages/registration/RegistrationStatus.tsx
+++ b/src/pages/registration/RegistrationStatus.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useHistory } from "react-router-dom";
-import { toast, ToastContainer } from "react-toastify";
+import { toast } from "react-toastify";
 import { registration } from "types/routes";
 import Action from "../../components/ActionButton/Action";
 import maskAddress from "helpers/maskAddress";
@@ -267,7 +267,6 @@ const RegistrationStatus = () => {
         />
         <p className="mt-3 text-sm uppercase">coming soon</p>
       </div>
-      <ToastContainer />
     </div>
   );
 };

--- a/src/pages/registration/VerifiedEmail.tsx
+++ b/src/pages/registration/VerifiedEmail.tsx
@@ -2,7 +2,7 @@ import { useHistory } from "react-router-dom";
 import jwtDecode from "jwt-decode";
 import { FaCheck, FaExclamation } from "react-icons/fa";
 import { app, registration, site } from "types/routes";
-import { toast, ToastContainer } from "react-toastify";
+import { toast } from "react-toastify";
 import Action from "../../components/ActionButton/Action";
 import { useRequestEmailMutation } from "services/aws/registration";
 import { useSetter } from "store/accessors";
@@ -108,7 +108,6 @@ const VerifiedEmail = () => {
           />
         )}
       </div>
-      <ToastContainer />
     </div>
   );
 };

--- a/src/pages/registration/charity-profile/Update-profile.tsx
+++ b/src/pages/registration/charity-profile/Update-profile.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useLocation } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
 import { useGetCharityDataQuery } from "services/aws/charity";
 import { updateUserData } from "services/user/userSlice";
 import { useGetter, useSetter } from "store/accessors";
@@ -105,7 +104,6 @@ const UpdateProfile = () => {
           />
         )}
       </div>
-      <ToastContainer />
     </div>
   );
 };

--- a/src/pages/registration/connect-wallet/ConnectWallet.tsx
+++ b/src/pages/registration/connect-wallet/ConnectWallet.tsx
@@ -5,7 +5,7 @@ import {
   useAddCharityMetadataMutation,
   useGetCharityDataQuery,
 } from "services/aws/charity";
-import { toast, ToastContainer } from "react-toastify";
+import { toast } from "react-toastify";
 import Action from "../../../components/ActionButton/Action";
 import { registration } from "types/routes";
 import { useHistory } from "react-router-dom";
@@ -148,7 +148,6 @@ const ConnectWallet = () => {
           </form>
         </div>
       </div>
-      <ToastContainer />
     </div>
   );
 };

--- a/src/pages/registration/keyPerson-profile/KeyPersonProfile.tsx
+++ b/src/pages/registration/keyPerson-profile/KeyPersonProfile.tsx
@@ -7,7 +7,6 @@ import {
 } from "./useKeyPersonProfile";
 import { DropzoneArea } from "material-ui-dropzone";
 import { useState } from "react";
-import { ToastContainer } from "react-toastify";
 import Action from "../../../components/ActionButton/Action";
 import { useGetter, useSetter } from "store/accessors";
 import { updateUserData } from "services/user/userSlice";
@@ -249,7 +248,6 @@ const KeyPersonProfile = () => {
           </div>
         </form>
       </div>
-      <ToastContainer />
     </div>
   );
 };

--- a/src/pages/registration/register-docs/Steps-docs.tsx
+++ b/src/pages/registration/register-docs/Steps-docs.tsx
@@ -4,7 +4,6 @@ import { registration } from "types/routes";
 import { DropzoneDialog } from "material-ui-dropzone";
 import { useUploadFiles } from "./useUploadFiles";
 import Action from "../../../components/ActionButton/Action";
-import { ToastContainer } from "react-toastify";
 import { useGetter, useSetter } from "store/accessors";
 import { updateUserData } from "services/user/userSlice";
 
@@ -199,7 +198,6 @@ const StepsDocs = () => {
         showFileNamesInPreview={true}
         filesLimit={1}
       />
-      <ToastContainer />
     </div>
   );
 };


### PR DESCRIPTION
Closes #587

## Description of the Problem / Feature
`<ToastContainer />` should be declared only once as per the [official docs](https://fkhadra.github.io/react-toastify/installation).
In our app, it's declared on almost every component that uses it.

## Instructions on making this work
- run the app
- perform an action that should trigger a toastr to appear (check code for such actions)
