### PR TITLE
Charity Registration: Send an Email to AP Team when User Clicks on "Please Help Me" Button

### DIFF
--- a/src/pages/registration/ConfirmEmail.tsx
+++ b/src/pages/registration/ConfirmEmail.tsx
@@ -58,51 +58,43 @@ const ConfirmEmail = () => {
   }, [user, dispatch]);
 
   return (
-    <div>
+    <div className="flex flex-col gap-4 font-bold">
       {is_sent && (
-        <div className="rounded-xl mb-5">
-          <img src={banner2} width="100%" className="rounded-xl" alt="" />
-        </div>
+        <img src={banner2} width="100%" className="rounded-xl" alt="" />
       )}
       {is_sent ? (
-        <div>
-          <p className="text-4xl font-bold">Hi {user.FirstName}!</p>
-          <span className="text-4xl font-bold">
+        <div className="text-4xl">
+          <p>Hi {user.FirstName}!</p>
+          <span>
             We're still waiting for you to confirm your email address.
           </span>
         </div>
       ) : (
-        <div>
-          <p className="text-2xl font-bold">Thank you for registering</p>
-          <p className="text-2xl font-bold mb-10">
-            {user.FirstName}, {user.CharityName}!{" "}
+        <div className="text-2xl">
+          <p>Thank you for registering</p>
+          <p className="mb-10">
+            {user.FirstName}, {user.CharityName}!
           </p>
-          <p className="text-2xl font-bold">Your registration reference is</p>
-          <p className="text-orange text-2xl font-bold">{user.PK || ""}</p>
+          <p>Your registration reference is</p>
+          <p className="text-orange">{user.PK}</p>
         </div>
       )}
-      <div className="mt-3 mb-10">
-        <span className="text-base">
-          Please click on the link in the email and you'll be able to continue
-          with the registration of {user.CharityName} on Angel.
-        </span>
-      </div>
-      <div className="mb-2">
+      <span className="font-normal">
+        Please click on the link in the email and you'll be able to continue
+        with the registration of {user.CharityName} on Angel.
+      </span>
+      <div className="flex flex-col gap-1 items-center mt-3">
         <Action
           onClick={resendVerificationEmail}
           classes="bg-orange w-64 h-12 text-sm"
           title="Resend verification email"
           isLoading={isLoading}
         />
-      </div>
-      <div className="mb-2">
         <Action
           onClick={sendEmailNoticeToAPTeam}
           title="I'm having trouble with my email"
           classes="bg-yellow-blue w-80 h-12 text-sm"
         />
-      </div>
-      <div className="mb-2">
         <Action
           onClick={returnMain}
           title="close"


### PR DESCRIPTION
Closes #593

## Description of the Problem / Feature
Currently when the user submits their contact details, we send a verification email and display to said user a page with three buttons:
- Resend verification email
- I'm having trouble with my email
- Close

The second button currently resends the verification email. It should be updated to send an email to the AP team at support@angelprotocol.io with the content being a placeholder for now, and to display to the user that the AP team is looking into their issue.



## Explanation of the solution
- added the missing method
- improved performance by utilizing `useCallback` for more complex functions
- refactored the component design

## Instructions on making this work
- run the app
- go to /app/register & click 'Start'
- fill the form data & click 'Continue'
- after navigating to _ConfirmEmail_ page, confirm L&F (look&feel) is the same
- verify AP team receives the email when clicking "I'm having trouble with my email"

