### PR TITLE
feat: turn profile name to link if charity has a url field

### DIFF
--- a/src/pages/Charity/DonationInfo.tsx
+++ b/src/pages/Charity/DonationInfo.tsx
@@ -2,7 +2,12 @@
 import { useConnectedWallet } from "@terra-money/wallet-provider";
 import useProfile from "pages/Market/useProfile";
 import { useMemo } from "react";
-import { FaFacebookSquare, FaLinkedinIn, FaTwitter } from "react-icons/fa";
+import {
+  FaFacebookSquare,
+  FaLink,
+  FaLinkedinIn,
+  FaTwitter,
+} from "react-icons/fa";
 import { useRouteMatch } from "react-router-dom";
 import { CharityParam } from "./types";
 
@@ -86,9 +91,20 @@ export function DonationInfo({ openModal }: DonationInfoProps) {
         {/* <span className="inline-block text-center text-sm py-3 px-3 max-w-250 font-semibold uppercase text-gray-200 bg-angel-blue bg-opacity-50 hover:bg-opacity-30 rounded-2xl border-t border-b border-opacity-20 2xl:-mt-4">
           SDG #{profile.un_sdg}: {sdg.title}
         </span> */}
-        <h2 className="text-4xl font-bold text-white uppercase tracking-wide">
-          {profile.charity_name}
-        </h2>
+        {profile.url ? (
+          <a
+            href="##"
+            target="_blank"
+            rel="noreferrer"
+            className="text-4xl font-bold text-white uppercase tracking-wide hover:text-angel-blue"
+          >
+            <span>{profile.charity_name}</span> <FaLink size={20} />
+          </a>
+        ) : (
+          <h2 className="text-4xl font-bold text-white uppercase tracking-wide">
+            {profile.charity_name}
+          </h2>
+        )}
         <div className="flex flex-col sm:flex-row lg:flex-col gap-2 mt-4">
           {isCharityOwner && (
             <button

--- a/src/services/aws/endowments/types.ts
+++ b/src/services/aws/endowments/types.ts
@@ -18,6 +18,7 @@ export interface Details {
 }
 
 export interface Profile {
+  url?: string;
   charity_image?: string; //url of image
   charity_owner: string; // charity owner wallet address
   charity_registration_number: string; //"CN201225725"


### PR DESCRIPTION
Closes #612 

## Description of the Problem / Feature
Charity Name title made into a link to Charity's website (if available)

## Explanation of the solution
- if url field is present in returned charity profile data
- turn name into a link with an icon to show link availability

## Instructions on making this work


## UI changes for review

# With  profile url
<img width="548" alt="Screenshot 2022-02-01 at 11 59 06" src="https://user-images.githubusercontent.com/31709531/151957177-6239c7d6-f56d-482c-b84b-f09f9ce374e4.png">

# With  profile url on hover
<img width="548" alt="Screenshot 2022-02-01 at 11 59 13" src="https://user-images.githubusercontent.com/31709531/151957191-77f42b4c-90ad-456b-aca3-a7cbacd24a0f.png">

