### PR TITLE
fix zero balance

### DIFF
--- a/src/components/Transactors/Poller/useEstimator.ts
+++ b/src/components/Transactors/Poller/useEstimator.ts
@@ -17,7 +17,7 @@ export default function useEstimator() {
   const { getValues } = useFormContext<Values>();
   const { main: UST_balance } = useBalances(denoms.uusd);
   const dispatch = useSetter();
-  const halo_balance = useHaloBalance();
+  const { haloBalance } = useHaloBalance();
   const wallet = useConnectedWallet();
 
   useEffect(() => {
@@ -32,7 +32,7 @@ export default function useEstimator() {
 
         const amount = Number(getValues("amount"));
         //initial balance check to successfully run estimate
-        if (amount >= halo_balance) {
+        if (amount >= haloBalance) {
           dispatch(setFormError("Not enough halo balance"));
           return;
         }
@@ -72,7 +72,7 @@ export default function useEstimator() {
       dispatch(setFormError(""));
     };
     //eslint-disable-next-line
-  }, [wallet, halo_balance, UST_balance]);
+  }, [wallet, haloBalance, UST_balance]);
 
   //return estimated fee computed using max constraints
 }

--- a/src/components/Transactors/Staker/useStakerBalance.ts
+++ b/src/components/Transactors/Staker/useStakerBalance.ts
@@ -4,12 +4,12 @@ import { useGovStaker, useHaloBalance } from "services/terra/queriers";
 
 export default function useStakerBalance(is_stake: boolean) {
   const gov_staker = useGovStaker();
-  const halo_balance = useHaloBalance();
+  const { haloBalance } = useHaloBalance();
 
   const [balance, locked] = useMemo((): [Dec, Dec] => {
     const staked = new Dec(gov_staker.balance);
     if (is_stake) {
-      return [new Dec(halo_balance).mul(1e6), new Dec(0)];
+      return [new Dec(haloBalance).mul(1e6), new Dec(0)];
     } else {
       //used in voting to a poll
       const vote_locked = gov_staker.locked_balance.reduce(
@@ -18,8 +18,8 @@ export default function useStakerBalance(is_stake: boolean) {
       );
       return [staked, vote_locked];
     }
-    // is_stake ? halo_balance : new Dec(gov_staker.balance).div(1e6).toNumber();
-  }, [gov_staker, halo_balance, is_stake]);
+    // is_stake ? haloBalance : new Dec(gov_staker.balance).div(1e6).toNumber();
+  }, [gov_staker, haloBalance, is_stake]);
 
   return { balance, locked };
 }

--- a/src/components/Transactors/Swapper/Balance.tsx
+++ b/src/components/Transactors/Swapper/Balance.tsx
@@ -5,10 +5,10 @@ import { denoms } from "constants/currency";
 import { Values } from "./types";
 export default function Balance() {
   const { watch, setValue } = useFormContext<Values>();
-  const halo_balance = useHaloBalance();
+  const { haloBalance } = useHaloBalance();
   const { main: ust_balance } = useBalances(denoms.uusd);
   const is_buy = watch("is_buy");
-  const balance = is_buy ? ust_balance : halo_balance;
+  const balance = is_buy ? ust_balance : haloBalance;
 
   function setAmount() {
     setValue("amount", `${balance}`);

--- a/src/components/Transactors/Swapper/useEstimator.ts
+++ b/src/components/Transactors/Swapper/useEstimator.ts
@@ -21,7 +21,7 @@ export default function useEstimator() {
   const [tx, setTx] = useState<CreateTxOptions>();
   const dispatch = useSetter();
   const { main: UST_balance } = useBalances(denoms.uusd);
-  const halo_balance = useHaloBalance();
+  const { haloBalance } = useHaloBalance();
 
   const wallet = useConnectedWallet();
   // const simul = usePairSimul(3000);
@@ -55,7 +55,7 @@ export default function useEstimator() {
             return;
           }
         } else {
-          if (amount > halo_balance) {
+          if (amount > haloBalance) {
             dispatch(setFormError("Not enough HALO"));
             return;
           }

--- a/src/components/Transactors/Voter/useEstimator.ts
+++ b/src/components/Transactors/Voter/useEstimator.ts
@@ -21,7 +21,7 @@ export default function useEstimator() {
   const [tx, setTx] = useState<CreateTxOptions>();
   const dispatch = useSetter();
   const { main: UST_balance } = useBalances(denoms.uusd);
-  const halo_balance = useHaloBalance();
+  const { haloBalance } = useHaloBalance();
   const wallet = useConnectedWallet();
   const gov_staker = useGovStaker();
   const amount = Number(watch("amount")) || 0;
@@ -112,7 +112,7 @@ export default function useEstimator() {
     debounced_id,
     wallet,
     UST_balance,
-    halo_balance,
+    haloBalance,
     gov_staker,
   ]);
 

--- a/src/components/WalletSuite/Details.tsx
+++ b/src/components/WalletSuite/Details.tsx
@@ -27,8 +27,8 @@ export default function Details(props: { closeHandler: () => void }) {
 
   const isEmpty = filtered_coins.length <= 0;
   const handleDisconnect = () => {
-    disconnect();
     dispatch(resetWallet());
+    disconnect();
   };
 
   return (

--- a/src/components/WalletSuite/useWalletUpdator.ts
+++ b/src/components/WalletSuite/useWalletUpdator.ts
@@ -13,8 +13,8 @@ import { useSetter } from "store/accessors";
 export default function useWalletUpdator(activeProvider: Providers) {
   const dispatch = useSetter();
   const wallet = useConnectedWallet();
-  const { main, others } = useBalances(denoms.uusd);
-  const halo_balance = useHaloBalance();
+  const { main, others, terraBalancesLoading } = useBalances(denoms.uusd);
+  const { haloBalance, haloBalanceLoading } = useHaloBalance();
 
   //updator for terra-station and wallet connect
   useEffect(() => {
@@ -35,19 +35,21 @@ export default function useWalletUpdator(activeProvider: Providers) {
     ) {
       return;
     }
-
-    dispatch(setIsUpdating(true));
+    if (terraBalancesLoading || haloBalanceLoading) {
+      dispatch(setIsUpdating(true));
+      return;
+    }
     //append halo balance
     const coinsWithHalo = [
       ...others,
-      { amount: halo_balance, denom: denoms.uhalo },
+      { amount: haloBalance, denom: denoms.uhalo },
     ];
     dispatch(
       setWalletDetails({
         id: wallet.connection.identifier || TerraIdentifiers.terra_wc,
         icon: wallet.connection.icon,
         displayCoin: { amount: main, denom: denoms.uusd },
-        coins: halo_balance !== 0 ? coinsWithHalo : others,
+        coins: haloBalance !== 0 ? coinsWithHalo : others,
         address: wallet.walletAddress,
         chainId: wallet.network.chainID as chainIDs,
         supported_denoms: [denoms.uusd, denoms.uluna],
@@ -55,7 +57,7 @@ export default function useWalletUpdator(activeProvider: Providers) {
     );
     dispatch(setIsUpdating(false));
     //eslint-disable-next-line
-  }, [main, others, wallet, activeProvider, halo_balance]);
+  }, [wallet, activeProvider, terraBalancesLoading, haloBalanceLoading]);
 
   //updator of xdefi
   useEffect(() => {
@@ -75,7 +77,10 @@ export default function useWalletUpdator(activeProvider: Providers) {
           return;
         }
 
-        dispatch(setIsUpdating(true));
+        if (terraBalancesLoading || haloBalanceLoading) {
+          dispatch(setIsUpdating(true));
+          return;
+        }
         const xwindow: XdefiWindow = window;
         //xwindow.xfi.ethereum is guaranteed to be defined here since it's available on
         //wallet connection selection
@@ -113,5 +118,5 @@ export default function useWalletUpdator(activeProvider: Providers) {
       }
     })();
     //eslint-disable-next-line
-  }, [main, others, wallet, activeProvider, halo_balance]);
+  }, [wallet, activeProvider, haloBalanceLoading, terraBalancesLoading]);
 }

--- a/src/services/terra/queriers.ts
+++ b/src/services/terra/queriers.ts
@@ -29,7 +29,11 @@ export function useLatestBlock() {
 export function useBalances(main: denoms, others?: denoms[]) {
   const wallet = useConnectedWallet();
   const { useBalancesQuery } = terra;
-  const { data = [] } = useBalancesQuery(wallet?.walletAddress, {
+  const {
+    data = [],
+    isLoading,
+    isFetching,
+  } = useBalancesQuery(wallet?.walletAddress, {
     skip: wallet === undefined,
   });
 
@@ -45,7 +49,11 @@ export function useBalances(main: denoms, others?: denoms[]) {
     others ? others.includes(coin.denom) : true
   );
 
-  return { main: _main, others: _others };
+  return {
+    main: _main,
+    others: _others,
+    terraBalancesLoading: isLoading || isFetching,
+  };
 }
 
 export function useHaloInfo() {
@@ -62,7 +70,11 @@ export function useHaloInfo() {
 export function useHaloBalance() {
   const { useHaloBalanceQuery } = terra;
   const { wallet, contract } = useHaloContract();
-  const { data = 0 } = useHaloBalanceQuery(
+  const {
+    data = 0,
+    isLoading,
+    isFetching,
+  } = useHaloBalanceQuery(
     {
       address: contract.token_address,
       //this query will only run if wallet is not undefined
@@ -71,7 +83,7 @@ export function useHaloBalance() {
     { skip: wallet === undefined }
   );
 
-  return data;
+  return { haloBalance: data, haloBalanceLoading: isLoading || isFetching };
 }
 
 export function useGovStaker() {


### PR DESCRIPTION
## Description of the Problem / Feature
-when user connects, sometimes show `0` balance

## Explanation of the solution
-`useWalletUpdator` re-updates wallet details based on changes in `halo balance : number` or `terra balances : {amount, denom}[]`, which isn't reliable `flag` 
-re-update wallet details based not on balance values but balance loading states

## Instructions on making this work
pull latest from this branch

## UI changes for review
-connecting using terra station now renders loading UI (previously more obvious in xdefi because it also fetches `eth` balance ), which would only stop if `halo` and terra balances `ust, luna etc..` are all fetched accordingly 

on first page visit, no cache entry, all balances are fetched
<img width="172" alt="image" src="https://user-images.githubusercontent.com/89639563/152915635-119c4c6c-b5d7-4d80-9933-138ceff31f32.png">

on second reconnect, loading is still rendered, even there's a `ust` cache value - meaning, `halo` must be being refetched (due to change in halo contract address)
<img width="185" alt="image" src="https://user-images.githubusercontent.com/89639563/152915376-e6deb0c3-d5bc-4f51-8de1-77e1d37fd127.png">


When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design
