### PR TITLE
remove default styles inut radio

### DIFF
--- a/src/components/Transactors/Donater/DonateForm/Currency.tsx
+++ b/src/components/Transactors/Donater/DonateForm/Currency.tsx
@@ -30,7 +30,7 @@ function Currency(props: Props) {
         {...register("currency")}
         value={props.currency}
         type="radio"
-        className="w-0 h-0"
+        className="w-0 h-0 appearance-none"
       />
       <label
         htmlFor={props.currency}


### PR DESCRIPTION
## Description of the Problem / Feature
radio bullet shows in firefox
![image](https://user-images.githubusercontent.com/89639563/152926982-5c7e8dba-ad81-4d97-8684-f9c16b03e138.png)


## Explanation of the solution
remove browser styling of `<input type="radio"/>` via class `appearance-none`

## Instructions on making this work
pull latest from this branch

## UI changes for review
fire fox currency list without tickmarks
<img width="350" alt="image" src="https://user-images.githubusercontent.com/89639563/152927097-e18d51c9-8b0b-40a9-a1f0-16f663f1f970.png">

