### PR TITLE
Leaderboard title points to profile page

### DIFF
--- a/src/pages/Leaderboard/Description.tsx
+++ b/src/pages/Leaderboard/Description.tsx
@@ -1,8 +1,9 @@
+import { Link } from "react-router-dom";
 import { useConnectedWallet } from "@terra-money/wallet-provider";
 import { chainIDs } from "constants/chainIDs";
 import { useAccountsQuery } from "services/aws/endowments/endowments";
 import { charity_details } from "services/aws/endowments/placeholders";
-import { app, site } from "types/routes";
+import { app } from "types/routes";
 
 type Props = { address: string };
 
@@ -22,12 +23,12 @@ export default function Description(props: Props) {
         } p-3 rounded-sm object-contain mr-4 m-1`}
       />
 
-      <a
-        href={`${site.app}/${app.charity}/${props.address}`}
+      <Link
+        to={`${app.charity}/${props.address}`}
         className="col-start-2 text-lg text-angel-grey hover:text-angel-blgue active:text-angel-blue font-bold pt-2 mb-1"
       >
         {details.name}
-      </a>
+      </Link>
       <p className="relative pr-16 text-sm text-angel-grey  leading-normal mb-2 line-clamp-3">
         {details.description}
       </p>


### PR DESCRIPTION
## Description of the Problem / Feature
Point leaderboard title links to respective profile page. 

## Explanation of the solution
- Change link URL to profile url
- Link opens in same window

## Instructions on making this work
Click charity name on Leaderboard and you should be taken to that charity's profile page.