### PR TITLE
Removed unnecessary query param in donation POST endpoint

### DIFF
--- a/src/services/apes/donations.ts
+++ b/src/services/apes/donations.ts
@@ -11,7 +11,6 @@ const donations_api = apes.injectEndpoints({
         return {
           url: "donation",
           method: "POST",
-          params: { app: "angel-protocol" },
           headers: { authorization: generatedToken },
           body: txPayload,
         };


### PR DESCRIPTION
## Description of the Problem / Feature
The `POST /donation` endpoint only requires that a query param, `app` be used if the request comes from a 3rd party app. The endpoint will know it came from our web app if there's no query param passed.

## Explanation of the solution
Removed it as part of the request.

## Instructions on making this work
Make a donation and check your browser's dev console's Network tab. After that just to make sure, request for a tax receipt. Doing so will tell you that the `POST` request really did save the TX in our DB.

## UI changes for review
None
