### PR TITLE
Charity Profile: Open Country Select In "Request Receipt" so that it's visible on the screen

### DIFF
--- a/src/components/Receipter/ReceiptForm.tsx
+++ b/src/components/Receipter/ReceiptForm.tsx
@@ -89,13 +89,13 @@ export default function ReceiptForm() {
         <div className="form-control rounded-sm bg-gray-200 flex justify-between items-center text-dark-grey">
           <Selector
             name="country"
-            placeholder=""
             options={countries.map((item) => ({
               value: item.label,
               label: item.label,
             }))}
             control={control}
             register={register}
+            menuPlacement="top"
           />
         </div>
         <ErrorMessage

--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -1,14 +1,15 @@
-import Select from "react-select";
+import Select, { MenuPlacement } from "react-select";
 import { Controller } from "react-hook-form";
 
 interface SelectorProps {
   name: string;
-  placeholder: string;
+  placeholder?: string;
   options: any;
   control: any;
   register: Function;
   onChange?: Function;
   isMulti?: boolean;
+  menuPlacement?: MenuPlacement;
 }
 
 export const Selector = (props: SelectorProps) => {
@@ -32,6 +33,7 @@ export const Selector = (props: SelectorProps) => {
             }}
             options={props.options}
             isMulti={props.isMulti}
+            menuPlacement={props.menuPlacement || "auto"}
           />
         );
       }}


### PR DESCRIPTION
Closes #670

## Description of the Problem / Feature
Currently when getting a receipt for a donation and opening the "Country" dropdown, the dropdown open to the bottom and going outside the screen, making it hard for the user to select an image.
We should open it to the top when there is no space to the bottom.



## Explanation of the solution
- Added `menuPlacement` prop to `Select`


## UI changes for review

![image](https://user-images.githubusercontent.com/19427053/153859383-ad8aef49-1aed-4051-afd2-75c1368a3ccf.png)