### PR TITLE
Wallet: loader for my endowment link

### DIFF
--- a/src/components/WalletSuite/Portal.tsx
+++ b/src/components/WalletSuite/Portal.tsx
@@ -8,9 +8,15 @@ export default function Portal() {
   const wallet = useConnectedWallet();
   const isTestNet = wallet?.network.chainID === chainIDs.testnet;
   //on testnet --> url resolves to endpoint/endowments/testnet
-  const { data } = useLookupQuery(isTestNet);
+  const { data, isLoading, isFetching } = useLookupQuery(isTestNet);
+
   const endowmentAddr = data?.[wallet?.terraAddress || ""];
-  if (!endowmentAddr) {
+  if (isLoading || isFetching) {
+    //subtle skeleton
+    return (
+      <div className="ml-2 animate-pulse bg-angel-blue bg-opacity-20 w-28 h-6 rounded-md"></div>
+    );
+  } else if (!endowmentAddr) {
     return null;
   } else {
     return (

--- a/src/services/aws/endowments/endowments.ts
+++ b/src/services/aws/endowments/endowments.ts
@@ -14,7 +14,7 @@ import { AWSQueryRes } from "services/aws/types";
 export const endowments_api = aws.injectEndpoints({
   endpoints: (builder) => ({
     lookup: builder.query<Lookup, boolean>({
-      query: (isTest) => `endowments${isTest ? "/testnet" : ""}?except_tier=1`,
+      query: (isTest) => `endowments${isTest ? "/testnet" : ""}`,
       transformResponse: (res: AWSQueryRes<Endowment[]>) => {
         const _lookup: Lookup = {};
         res.Items.forEach((endowment) => {


### PR DESCRIPTION
## Description of the Problem / Feature
`useLookUpQuery` takes noticeable amount of time to load data and should hint charity owners that 
the link to their endowment account is still loading

## Explanation of the solution
add subtle loader that's telling to owners yet petty to regular users

## Instructions on making this work
N.A

## UI changes for review
skeleton loader with class `animate-pulse` 
![image](https://user-images.githubusercontent.com/89639563/154404560-481c144c-3ffa-44ce-b510-ffc8d3193d48.png)

