### PR TITLE
To include wallet address in donation payload

### DIFF
--- a/src/components/Transactors/Donater/useDonationLogger.ts
+++ b/src/components/Transactors/Donater/useDonationLogger.ts
@@ -11,6 +11,7 @@ export default function useDonationLogger() {
     amount: string,
     denom: denoms,
     splitLiq: string,
+    walletAddress: string,
     receipient: string | number
   ) {
     let receiver: Receiver =
@@ -25,6 +26,7 @@ export default function useDonationLogger() {
       denomination: currency_text[denom],
       amount: parseFloat(amount),
       splitLiq,
+      walletAddress,
       chainId,
     };
     return await logTx(txLogPayload);

--- a/src/components/Transactors/Donater/useEthSender.ts
+++ b/src/components/Transactors/Donater/useEthSender.ts
@@ -26,6 +26,7 @@ export default function useEthSender(tx: TransactionRequest) {
           xwindow.xfi?.ethereum!
         );
         const signer = provider.getSigner();
+        const walletAddress = await signer.getAddress();
         const chainNum = await signer.getChainId();
         const chainId = `${chainNum}` as chainIDs;
         const response = await signer.sendTransaction(tx!);
@@ -39,6 +40,7 @@ export default function useEthSender(tx: TransactionRequest) {
             data.amount,
             denoms.ether,
             data.split_liq,
+            walletAddress,
             receiver
           );
 

--- a/src/components/Transactors/Donater/useTerraSender.ts
+++ b/src/components/Transactors/Donater/useTerraSender.ts
@@ -29,6 +29,7 @@ export default function useTerraSender(tx: CreateTxOptions) {
         if (response.success) {
           updateTx({ step: Step.submit, message: "Saving donation details" });
 
+          const walletAddress = wallet.walletAddress;
           const receiver = getValues("receiver");
           const currency = getValues("currency");
           if (typeof receiver !== "undefined") {
@@ -38,6 +39,7 @@ export default function useTerraSender(tx: CreateTxOptions) {
               data.amount,
               currency,
               data.split_liq,
+              walletAddress,
               receiver
             );
 

--- a/src/services/apes/types.ts
+++ b/src/services/apes/types.ts
@@ -4,6 +4,7 @@ export type TxDetails = {
   chainId: string;
   amount: number;
   splitLiq: string;
+  walletAddress: string;
   denomination: string;
 };
 


### PR DESCRIPTION
## Description of the Problem / Feature
We are not including the wallet address of the donor.

## Explanation of the solution
To include it in the payload of the request.

## Instructions on making this work
Try to donate and check the `Network` tab of your browser's dev console. You should be able to see in the request payload the `walletAddress` attribute.

## UI changes for review
None
