### PR TITLE
fix: reduce transaction state changes during donation as temp fix for memory …

### DIFF
--- a/src/components/Transactors/Donater/useTerraSender.ts
+++ b/src/components/Transactors/Donater/useTerraSender.ts
@@ -23,7 +23,8 @@ export default function useTerraSender(tx: CreateTxOptions) {
           updateTx({ step: Step.error, message: "Wallet is not connected" });
           return;
         }
-        updateTx({ step: Step.submit, message: "Submitting transaction.." });
+        // I think this step is unncessary because the wallet confirmation popup already indicates that(and the user never really sees this step for terra based donations) and for one reason that I am still not sure of yet it causes the memory leak during state transitions
+        // updateTx({ step: Step.submit, message: "Submitting transaction.." });
         const response = await wallet.post(tx!);
         const chainId = wallet.network.chainID as chainIDs;
         if (response.success) {


### PR DESCRIPTION
…leak

Closes #673 

## Description of the Problem / Feature
Memory leak after multiple transaction state changes during a UST and LUNA donation process

## Explanation of the solution
- Reduce number of transaction state changes 
- Remove the unnecessary stage in the terraSender hook
