### PR TITLE
feat: charity profile url is editable

### DIFF
--- a/src/pages/CharityEdit/CharityEdit.tsx
+++ b/src/pages/CharityEdit/CharityEdit.tsx
@@ -12,7 +12,6 @@ export default function CharityEdit(props: RouteComponentProps<CharityParam>) {
   const {
     //TODO: make EditableAttr warn if omitted types are not removed
     //EditableAttr only warns if required attr is omitted
-    url,
     charity_owner, //terra
     endowment_address, //terra
     total_liq,

--- a/src/pages/CharityEdit/EditForm.tsx
+++ b/src/pages/CharityEdit/EditForm.tsx
@@ -62,6 +62,7 @@ export default function EditForm() {
         placeholder="50 - 100"
       />
       <SectionHeader title="social media" />
+      <TextInput id="url" label="Website" placeholder="https://website.org" />
       <TextInput
         id="facebook_page"
         label="Facebook"

--- a/src/pages/CharityEdit/helpers/removeReadOnlyProfileAttr.ts
+++ b/src/pages/CharityEdit/helpers/removeReadOnlyProfileAttr.ts
@@ -6,7 +6,6 @@ import {
 
 export default function removeReadOnlyProfileAttr(profile: Profile) {
   const objectWithReadOnlyKeys: { [key in ReadOnlyAttr]: "" } = {
-    url: "",
     charity_owner: "",
     endowment_address: "",
     total_liq: "",

--- a/src/services/aws/endowments/types.ts
+++ b/src/services/aws/endowments/types.ts
@@ -51,7 +51,6 @@ export interface Profile {
 }
 
 export type ReadOnlyAttr =
-  | "url"
   | "charity_owner" //terra
   | "endowment_address" //terra
   | "total_liq"


### PR DESCRIPTION
Closes #742 

## Description of the Problem / Feature
Charity profile edit form has a URL field

## Explanation of the solution
- Add TextInput for url field
- exclude url field from removeReadOnlyProfileAttr
- update charity profile url 

## Instructions on making this work


## UI changes for review
<img width="778" alt="Screenshot 2022-02-25 at 00 23 22" src="https://user-images.githubusercontent.com/31709531/155624404-cda66a5a-2b13-4d78-a24a-4b4503f716f0.png">

