### PR TITLE
Display High Level Donations Metrics in the Leaderboard Page

### DIFF
--- a/src/pages/Leaderboard/DonationMetrics.tsx
+++ b/src/pages/Leaderboard/DonationMetrics.tsx
@@ -1,0 +1,30 @@
+import { useMetricsListQuery } from "services/aws/business_metrics/business_metrics";
+import { dummyDonationsMetricList as metricsPlaceholder } from "services/aws/business_metrics/placeholders";
+
+export default function DonationMetrics() {
+  // The parameter passed to the function is a list of attrs that we want to display
+  // It is a single string with the attrs being comma-separated because it will go to the request's url
+  const { data: metrics = metricsPlaceholder } = useMetricsListQuery(
+    "donations_total_amount,donations_daily_count,donations_daily_amount"
+  );
+
+  return (
+    <div className="text-center text-white-grey">
+      <h2 className="my-3 text-3xl font-extrabold">
+        Total Donations: ${" "}
+        {`${Number(
+          metrics.donations_total_amount.toFixed(2)
+        ).toLocaleString()}`}
+      </h2>
+      <h3 className="text-xl font-semibold">
+        Daily Donations Total: ${" "}
+        {`${Number(
+          metrics.donations_daily_amount.toFixed(2)
+        ).toLocaleString()}`}
+      </h3>
+      <h3 className="text-xl font-semibold">
+        Daily Donations Count: {`${metrics.donations_daily_count}`}
+      </h3>
+    </div>
+  );
+}

--- a/src/pages/Leaderboard/Leaderboard.tsx
+++ b/src/pages/Leaderboard/Leaderboard.tsx
@@ -1,8 +1,10 @@
 import CharityLeaderboard from "./Board";
+import DonationMetrics from "./DonationMetrics";
 
 export default function Leaderboard() {
   return (
     <section className="grid content-start padded-container">
+      <DonationMetrics />
       <h3 className="mt-6 uppercase text-white-grey text-3xl font-bold">
         Leaderboard
       </h3>

--- a/src/services/aws/business_metrics/business_metrics.ts
+++ b/src/services/aws/business_metrics/business_metrics.ts
@@ -1,0 +1,18 @@
+import { aws } from "../aws";
+import { DonationsMetricList } from "./types";
+
+const business_metrics_api = aws.injectEndpoints({
+  endpoints: (builder) => ({
+    metricsList: builder.query<DonationsMetricList, string>({
+      // Argument attrList is a string of attributes that will be returned by the api
+      query: (attrList) => {
+        return {
+          url: `metrics?keys=${attrList}`,
+          method: "GET",
+        };
+      },
+    }),
+  }),
+});
+
+export const { useMetricsListQuery } = business_metrics_api;

--- a/src/services/aws/business_metrics/placeholders.ts
+++ b/src/services/aws/business_metrics/placeholders.ts
@@ -1,0 +1,7 @@
+import { DonationsMetricList } from "./types";
+
+export const dummyDonationsMetricList: DonationsMetricList = {
+  donations_daily_count: 0,
+  donations_daily_amount: 0,
+  donations_total_amount: 0,
+};

--- a/src/services/aws/business_metrics/types.ts
+++ b/src/services/aws/business_metrics/types.ts
@@ -1,0 +1,5 @@
+export interface DonationsMetricList {
+  donations_daily_count: number;
+  donations_daily_amount: number;
+  donations_total_amount: number;
+}


### PR DESCRIPTION
Closes #728 

## Description of the Problem / Feature
To display the donations that go through Angel Protocol.

## Explanation of the solution
Three metrics are updated daily that keep track of donations, `"donations_total_amount" , "donations_daily_count", "donations_daily_amount"`. The endpoint used is `GET /metrics?keys=<metric_one>,<metric_two>`

## Instructions on making this work
Checkout this branch and install all dependencies. Then open the app and go to the Leaderboard page.

## UI changes for review
![Screenshot from 2022-03-08 09-37-01](https://user-images.githubusercontent.com/65009749/157156682-cc0cbb53-a2f5-4d5b-8f15-c35f8a35a443.png)
