### PR TITLE
UI: claim button refactor

### DIFF
--- a/src/components/Transactors/Airdrop/Catcher.tsx
+++ b/src/components/Transactors/Airdrop/Catcher.tsx
@@ -16,23 +16,29 @@ export default function Catcher(props: Props) {
         {toCurrency(totalClaimable)} HALO
       </p>
 
-      <Action title="claim & stake" onClick={claimAirdrop(true)} />
-      <button
+      <Action
+        title="claim & stake"
+        onClick={claimAirdrop(true)}
+        classes="text-sm"
+      />
+      <Action
         title="claim"
         onClick={claimAirdrop(false)}
-        className="underline text-angel-grey cursor-pointer"
-      >
-        claim
-      </button>
+        classes="bg-angel-grey font-semibold tracking-wide text-xs"
+      />
     </div>
   );
 }
 
-function Action(props: { title: string; onClick: () => void }) {
+function Action(props: {
+  title: string;
+  classes?: string;
+  onClick: () => void;
+}) {
   return (
     <button
       onClick={props.onClick}
-      className="bg-angel-orange text-white-grey hover:opacity-80 disabled:bg-grey-accent w-32 py-2 rounded-md uppercase font-heading text-sm font-bold mb-2"
+      className={`bg-angel-blue text-white-grey hover:opacity-80 disabled:bg-grey-accent w-full py-2 rounded-md uppercase font-heading font-bold mb-2 ${props.classes}`}
     >
       {props.title}
     </button>


### PR DESCRIPTION
Closes #<issue_number>

## Description of the Problem / Feature
From Tim - The claim button currently  looked 'unfinished'. So really needs to be the same format IMO - maybe just smaller. 

## UI changes for review
## Before:
<img width="868" alt="Screenshot 2022-03-08 at 12 07 26" src="https://user-images.githubusercontent.com/31709531/157226715-4cda1076-5bdf-4eec-9091-8d6a7eee2a27.png">

## After:
<img width="868" alt="Screenshot 2022-03-08 at 11 59 22" src="https://user-images.githubusercontent.com/31709531/157226607-7744ee75-ece1-4c12-9cf1-9ac2cdc93e37.png">

