### PR TITLE
hotfix: removing metamask desktop connect on mobile

### DIFF
--- a/src/components/WalletSuite/Connectors/EthConnector.tsx
+++ b/src/components/WalletSuite/Connectors/EthConnector.tsx
@@ -36,7 +36,7 @@ export default function EthConnector() {
          * if there's an existing window.ethereum object
          */
       } else if (
-        deviceType() === DeviceType.MOBILE &&
+        deviceType() !== DeviceType.DESKTOP &&
         !(window as Dwindow).ethereum
       ) {
         showModal(WalletPrompt, {


### PR DESCRIPTION
ClickUp ticket: <ticket_link>
Closes #<GH_issue_number>

## Description of the Problem / Feature

The current MM implementation is for desktop, and on mobile when clicked it redirects to the chrome extension installation page.

## Explanation of the solution

This PR removes MM button on mobile

## Instructions on making this work

## UI changes for review

When major UI changes will happen with this PR, please include links to URLS to compare or screenshots demonstrating the difference and notify design
