### PR TITLE
Charity Registration: Remove UUID on POST /registration

### DIFF
--- a/src/pages/Registration/ContactDetails/ContactDetailsForm/useContactDetails.tsx
+++ b/src/pages/Registration/ContactDetails/ContactDetailsForm/useContactDetails.tsx
@@ -5,6 +5,7 @@ import {
   useRequestEmailMutation,
   useUpdatePersonDataMutation,
 } from "services/aws/registration";
+import { ContactDetailsData } from "services/aws/types";
 import { updateUserData } from "services/user/userSlice";
 import { useGetter, useSetter } from "store/accessors";
 import routes, { registerRootPath } from "../../routes";
@@ -22,12 +23,11 @@ export default function useSaveContactDetails() {
     async (contactData: ContactDetails) => {
       // call API to add or update contact details information(contactData)
       const is_create = !contactData?.uniqueID;
-      const postData = {
+      const postData: ContactDetailsData = {
         Registration: {
           CharityName: contactData.charityName,
         },
         ContactPerson: {
-          UUID: contactData.uniqueID,
           FirstName: contactData.firstName,
           LastName: contactData.lastName,
           Email: contactData.email,
@@ -39,6 +39,7 @@ export default function useSaveContactDetails() {
 
       let result: any = {};
       if (is_create) {
+        postData.ContactPerson.UUID = contactData.uniqueID;
         const response: any = await registerCharity(postData);
         result = response.data ? response.data : response.error.data;
       } else {

--- a/src/services/aws/registration.ts
+++ b/src/services/aws/registration.ts
@@ -1,5 +1,6 @@
 import { aws } from "./aws";
 import {
+  ContactDetailsData,
   UpdateAdditionalInformationData,
   UpdateAdditionalInformationResult,
   UpdateDocumentationData,
@@ -58,7 +59,7 @@ const registration_api = aws.injectEndpoints({
       },
       transformResponse: (response: { data: any }) => response,
     }),
-    createNewCharity: builder.mutation<any, any>({
+    createNewCharity: builder.mutation<any, ContactDetailsData>({
       query: (body) => ({
         url: "registration",
         method: "POST",
@@ -66,7 +67,7 @@ const registration_api = aws.injectEndpoints({
       }),
       transformResponse: (response: { data: any }) => response,
     }),
-    updatePersonData: builder.mutation<any, any>({
+    updatePersonData: builder.mutation<any, ContactDetailsData>({
       query: (data) => {
         return {
           url: `registration`,

--- a/src/services/aws/types.ts
+++ b/src/services/aws/types.ts
@@ -4,6 +4,21 @@ export interface AWSQueryRes<T> {
   Items: T;
 }
 
+export type ContactDetailsData = {
+  Registration: {
+    CharityName: string;
+  };
+  ContactPerson: {
+    UUID?: string;
+    FirstName: string;
+    LastName: string;
+    Email: string;
+    PhoneNumber: string;
+    Role: string;
+    OtherRole: string;
+  };
+};
+
 type DocumentObject = { name: string; dataUrl: string };
 
 export type UpdateDocumentationData = {


### PR DESCRIPTION

## Description of the Problem / Feature
Agreed with @jp-mariano that this field is unnecessary when targeting POST /registration endpoint lambda We can remove this attribute when we send a request to the endpoint because it's not used/needed when we upload a charity's registration in our DB. Here is a link of it in [useContactDetails](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/39f4def783eb85ca09d2624ec1613b3847d9e8eb/src/pages/Registration/ContactDetails/ContactDetailsForm/useContactDetails.tsx#L30).

## Explanation of the solution
Removed UUID field when creating new charity and sending verification email (the first time)
## Instructions on making this work
