### PR TITLE
fix: charity title weird word wrapping

### DIFF
--- a/src/pages/Charity/DonationInfo.tsx
+++ b/src/pages/Charity/DonationInfo.tsx
@@ -83,7 +83,7 @@ export function DonationInfo() {
             href={profileState.url || ""}
             target="_blank"
             rel="noreferrer"
-            className={`text-4xl font-bold text-white uppercase tracking-wide break-words ${
+            className={`text-3xl font-bold text-white uppercase tracking-wide break-words ${
               profileState.url && "hover:text-angel-blue"
             }`}
           >


### PR DESCRIPTION
ClickUp ticket: [ticket_link](https://app.clickup.com/t/24xh4jw)

## Description of the Problem / Feature
Charity title/name breaks into multi-lines in a weird way

## Explanation of the solution
- use word-break for breaking longer texts


## UI changes for review
# Before
<img width="576" alt="Screenshot 2022-03-24 at 11 03 28" src="https://user-images.githubusercontent.com/31709531/159892839-5c3a3317-7738-4478-b523-aadfb50e3c22.png">

# After
<img width="576" alt="Screenshot 2022-03-24 at 11 03 36" src="https://user-images.githubusercontent.com/31709531/159892853-219381a4-4b92-45dd-9ec8-8c4f89aac5e1.png">
