### PR TITLE
Charity Registration: Append 'http://' to website url if missing 

### DIFF
--- a/src/pages/Registration/Documentation/Fields/WebsiteInput.tsx
+++ b/src/pages/Registration/Documentation/Fields/WebsiteInput.tsx
@@ -11,10 +11,7 @@ export default function WebsiteInput() {
   return (
     <InputRow htmlFor="website" label="Website of your organization" required>
       <input
-        {...register("website", {
-          setValueAs: (website: string) =>
-            website.startsWith("http") ? website : `http://${website}`,
-        })}
+        {...register("website", { setValueAs: transformUrl })}
         id="website"
         placeholder="Website URL"
         className="h-8 rounded-md outline-none border-none w-full px-2 py-1 text-black"
@@ -28,3 +25,6 @@ export default function WebsiteInput() {
     </InputRow>
   );
 }
+
+const transformUrl = (website: string) =>
+  website.startsWith("http") ? website : `http://${website}`;


### PR DESCRIPTION
ClickUp ticket: https://app.clickup.com/t/28kfq55

## Description of the Problem / Feature
In step # 3 "Website URL" add support for website formats that are missing the "http(s)://" part

## Explanation of the solution
- use _react-hook-form's_ `setValueAs` to append 'http://' to the website URL if missing (this automatically targets the "https" protocol if the website supports it)

## Instructions on making this work
- run the app
- start charity registration
- go to step # 3
- insert a website without the "http(s)://" part, verify form is valid and that it automatically appends the "http://" part to the start of the website.