### PR TITLE
Move Metamask and Binance providers to WalletProvider

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -2,8 +2,6 @@ import AppFoot from "components/AppFoot/AppFoot";
 import DappHead from "components/DappHead/DappHead";
 import Modal from "components/Modal/Modal";
 import { WalletProvider } from "providers";
-import BinanceWallet from "providers/BinanceWallet/BinanceWallet";
-import Metamask from "providers/Metamask/Metamask";
 import Views from "./Views";
 
 export default function App() {
@@ -11,15 +9,11 @@ export default function App() {
   return (
     <div className="grid grid-rows-a1a bg-gradient-to-b from-blue-accent to-black-blue relative">
       <WalletProvider>
-        <Metamask>
-          <BinanceWallet>
-            <Modal classes="bg-black/50 fixed top-0 right-0 bottom-0 left-0 z-50 grid place-items-center">
-              <DappHead />
-              <Views />
-            </Modal>
-            <AppFoot />
-          </BinanceWallet>
-        </Metamask>
+        <Modal classes="bg-black/50 fixed top-0 right-0 bottom-0 left-0 z-50 grid place-items-center">
+          <DappHead />
+          <Views />
+        </Modal>
+        <AppFoot />
       </WalletProvider>
     </div>
   );

--- a/src/providers/WalletProvider/WalletProvider.tsx
+++ b/src/providers/WalletProvider/WalletProvider.tsx
@@ -4,6 +4,8 @@ import {
 } from "@terra-money/wallet-provider";
 import { createContext, PropsWithChildren } from "react";
 import Loader from "../../components/Loader/Loader";
+import BinanceWallet from "../BinanceWallet/BinanceWallet";
+import Metamask from "../Metamask/Metamask";
 import { IWalletContext } from "./types";
 import useChainOptions from "./useChainOptions";
 import useWalletContext from "./useWalletContext";
@@ -24,7 +26,11 @@ export function WalletProvider(props: PropsWithChildren<{}>) {
 
   return (
     <TerraProvider {...chainOptions}>
-      <WalletProxyProvider>{props.children}</WalletProxyProvider>
+      <Metamask>
+        <BinanceWallet>
+          <WalletProxyProvider>{props.children}</WalletProxyProvider>
+        </BinanceWallet>
+      </Metamask>
     </TerraProvider>
   );
 }


### PR DESCRIPTION

## Description of the Problem / Feature
Move MM and Binance wallet providers to [WalletProvider](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/master/src/providers/WalletProvider/WalletProvider.tsx) to keep wallet provider logic in the same place (and _/src/App/App.tsx_ cleaner)

## Instructions on making this work
- run the app
- verify MM and Binance wallets work as before
