### PR TITLE
Update terra finder links and  transaction url format

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -46,7 +46,7 @@ export const eth_rpcs: URL_GROUP = {
     "https://kovan.infura.io/v3/f7ca16d6c4704dee939ca7557896cf07",
 };
 
-export const TERRA_FINDER = "https://finder.extraterrestrial.money/";
+export const TERRA_FINDER = "https://terrascope.info/";
 
 type URL_GROUP = {
   [index: string]: string;

--- a/src/helpers/getTxUrl.ts
+++ b/src/helpers/getTxUrl.ts
@@ -4,8 +4,9 @@ import { TERRA_FINDER } from "constants/urls";
 export default function getTxUrl(chainID: chainIDs, txhash: string) {
   switch (chainID) {
     case chainIDs.mainnet:
+      return `${TERRA_FINDER}mainnet/tx/${txhash}`;
     case chainIDs.testnet:
-      return `${TERRA_FINDER}${chainID}/tx/${txhash}`;
+      return `${TERRA_FINDER}testnet/tx/${txhash}`;
     case chainIDs.eth_ropsten:
       return `https://ropsten.etherscan.io/tx/${txhash}`;
     case chainIDs.eth_main:

--- a/src/pages/LBP/AuctionDetails.tsx
+++ b/src/pages/LBP/AuctionDetails.tsx
@@ -108,17 +108,17 @@ export default function AuctionDetails() {
           <AuctionLink
             content="HALO Token on ET Finder"
             PreIcon={"/favicon.png"}
-            url="https://finder.extraterrestrial.money/mainnet/address/terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
+            url="https://terrascope.info/mainnet/address/terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
           />
           <AuctionLink
             content="HaloSwap Owner on ET Finder"
             PreIcon={"/favicon.png"}
-            url="https://finder.extraterrestrial.money/mainnet/address/terra1numzqm5mgr56ftd4y8mfen7705nfs4vpz5jf0s"
+            url="https://terrascope.info/mainnet/address/terra1numzqm5mgr56ftd4y8mfen7705nfs4vpz5jf0s"
           />
           <AuctionLink
             content="HaloSwap Pair  on ET Finder"
             PreIcon={"/favicon.png"}
-            url="https://finder.extraterrestrial.money/mainnet/address/terra1hhpgcp2stvzx952zfxtxg4dhgf60yfzchesj3e"
+            url="https://terrascope.info/mainnet/address/terra1hhpgcp2stvzx952zfxtxg4dhgf60yfzchesj3e"
           />
           <AuctionLink
             content="HaloSwap Documentation"


### PR DESCRIPTION
ClickUp ticket: [<ticket_link>](https://app.clickup.com/t/2ayh8zw)

## Description of the Problem / Feature
Domain changed from [https://finder.extraterrestrial.money](https://extraterrestrial.money/) >> https://terrascope.info/
While they appear to have 301 redirects in place, all URLs should be changed accordingly to be safe.
