### PR TITLE
Remove redundant and bug-causing `useEffect` in `useWalletContext`

### DIFF
--- a/src/providers/WalletProvider/useWalletContext/useWalletContext.ts
+++ b/src/providers/WalletProvider/useWalletContext/useWalletContext.ts
@@ -1,11 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
-import { IWalletContext, WalletProxy } from "../types";
+import { useMemo } from "react";
+import { IWalletContext } from "../types";
 import useTerraJsWallet from "./useTerraJsWallet";
 import useTorusWallet from "./useTorusWallet";
 
 export default function useWalletContext(): IWalletContext {
-  const [wallet, setWallet] = useState<WalletProxy>();
-
   const {
     availableInstallations,
     availableWallets,
@@ -18,34 +16,25 @@ export default function useWalletContext(): IWalletContext {
     wallet: walletTorus,
   } = useTorusWallet();
 
-  useEffect(() => {
+  const walletContext: IWalletContext = useMemo(() => {
     // These if-checks are safe for setting connected wallets, because
     // at any point only one will be connected.
-    if (walletTerraJs) {
-      setWallet(walletTerraJs);
-    } else if (walletTorus) {
-      setWallet(walletTorus);
-    } else {
-      setWallet(undefined);
-    }
-  }, [walletTerraJs, walletTorus]);
-
-  const walletContext: IWalletContext = useMemo(
-    () => ({
+    const wallet = walletTerraJs || walletTorus;
+    return {
       wallet,
       availableInstallations,
       availableWallets: availableWallets.concat(availableTorusWallets),
       status: wallet?.connection.type === "TORUS" ? statusTorus : statusTerraJs,
-    }),
-    [
-      wallet,
-      statusTorus,
-      statusTerraJs,
-      availableWallets,
-      availableTorusWallets,
-      availableInstallations,
-    ]
-  );
+    };
+  }, [
+    walletTerraJs,
+    walletTorus,
+    statusTorus,
+    statusTerraJs,
+    availableWallets,
+    availableTorusWallets,
+    availableInstallations,
+  ]);
 
   return walletContext;
 }


### PR DESCRIPTION

## Description of the Problem / Feature
This extra useEffect can cause concurrency issues because it might not be able to update `walletProxy` in time, but still manage to update other fields inside `useMemo` that creates `IWalletContext`. 

Example in this [RegisterWallet](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/e99fb5a8a8dfbd13762c6c9cede5aba9107a55ab/src/pages/Registration/WalletRegistration/RegisterWallet/RegisterWallet.tsx#L20):
- go to this page without connecting the wallet
- `wallet` is `undefined` and `status` is `WALLET_NOT_CONNECTED`
- connect a Terra wallet
- `wallet` becomes defined and `status` becomes `WALLET_CONNECTED` within `useTerraJsWallet`
- `useWalletContext > useEffect` schedules an update for local `wallet` state
- these values are passed to `useWalletContext` and `IWalletContext.status` is updated to correct value, but because local `wallet` field hasn't yet been updated, it keeps its old value (which might even be `undefined`)
- the app breaks because it cannot read `wallet!.address`
## Explanation of the solution
- remove redundant `useEffect`
- assign wallet inside `useMemo`

## Instructions on making this work
- run the app
- verify wallets function as before