### PR TITLE
HOT-FIX: non endowment owners can edit charity profile

### DIFF
--- a/src/pages/CharityEdit/CharityEdit.tsx
+++ b/src/pages/CharityEdit/CharityEdit.tsx
@@ -1,15 +1,21 @@
 import { useParams } from "react-router-dom";
 import { useProfile } from "services/aws/endowments/queriers";
-import Loader from "components/Loader/Loader";
 import CharityEditor from "./CharityEditor";
 import EditForm from "./EditForm";
 import { CharityParam } from "./types";
+import ContentLoader from "components/ContentLoader/ContentLoader";
+import Icon from "components/Icons/Icons";
+import useWalletContext from "hooks/useWalletContext";
 
 export default function CharityEdit() {
+  const { wallet } = useWalletContext();
   const { address: endowment_addr } = useParams<CharityParam>();
   const { profile, isProfileLoading, isProfileError } = useProfile(
     endowment_addr!
   );
+
+  const isEndowmentOwner = wallet?.address === profile.charity_owner;
+
   const {
     //TODO: make EditableAttr warn if omitted types are not removed
     //EditableAttr only warns if required attr is omitted
@@ -23,23 +29,46 @@ export default function CharityEdit() {
     ...editableAttr
   } = profile;
 
-  if (isProfileLoading) {
-    return (
-      <Loader bgColorClass="bg-white-grey" gapClass="gap-4" widthClass="w-4" />
-    );
-  } else if (isProfileError) {
-    return (
-      <div className="grid place-items-center text-red-300">
-        Failed to get profile data
+  if (!wallet)
+    return <FormError message="Please connect wallet to view this page" />;
+  if (isProfileLoading) return <FormSkeleton />;
+  if (isProfileError) return <FormError message="Failed to load profile" />;
+  if (!isEndowmentOwner)
+    return <FormError message="You are not authorized to view this page" />;
+
+  return (
+    <div className="grid padded-container justify-items-center">
+      <CharityEditor {...editableAttr}>
+        <EditForm />
+      </CharityEditor>
+    </div>
+  );
+}
+
+function FormError(props: { message: string }) {
+  return (
+    <div className="grid padded-container place-items-center content-center">
+      <p className="flex gap-2 items-center text-red-400/90">
+        <Icon type="Warning" />
+        <span>{props.message}</span>
+      </p>
+    </div>
+  );
+}
+
+function FormSkeleton() {
+  return (
+    <div className="grid padded-container justify-items-center">
+      <div className="grid content-start gap-4 max-w-3xl w-full opacity-20">
+        <ContentLoader className="h-12 w-30 rounded-md" />
+        <ContentLoader className="h-52 w-full rounded-md" />
+        <ContentLoader className="h-12 w-full rounded-md" />
+        <ContentLoader className="h-12 w-full rounded-md" />
+        <ContentLoader className="h-12 w-full rounded-md" />
+        <ContentLoader className="h-12 w-full rounded-md" />
+        <ContentLoader className="h-12 w-full rounded-md" />
+        <ContentLoader className="h-12 w-full rounded-md" />
       </div>
-    );
-  } else {
-    return (
-      <div className="grid padded-container justify-items-center">
-        <CharityEditor {...editableAttr}>
-          <EditForm />
-        </CharityEditor>
-      </div>
-    );
-  }
+    </div>
+  );
 }


### PR DESCRIPTION
ClickUp ticket: [<ticket_link>](https://app.clickup.com/t/2ba2ruj)

## Description of the Problem / Feature
non endowment owners can edit charity profile

## Explanation of the solution
add ownership checks

## Instructions on making this work
N.A

## UI changes for review
skeleton on form loading
![image](https://user-images.githubusercontent.com/89639563/162379766-f6847ed2-441a-4378-9251-98f858ae08cb.png)

wallet error 
![image](https://user-images.githubusercontent.com/89639563/162379829-2798f5ac-5024-49fe-9f1a-419963e75b80.png)


profile load error ( user visits page with incorrect charity addr path )
![image](https://user-images.githubusercontent.com/89639563/162380060-c166659f-e1f2-42ed-a119-7e5190c67f60.png)

user tries to edit other charity
![image](https://user-images.githubusercontent.com/89639563/162380165-2e3b1da0-cb13-4b92-a0b2-347b80600e90.png)

