### PR TITLE
Web-app: this week bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-icons": "^4.2.0",
     "react-redux": "^7.2.5",
     "react-router-dom": "^6.2.0",
-    "react-select": "^5.2.1",
+    "react-select": "^5.3.0",
     "react-select-country-list": "^2.2.3",
     "recharts": "^2.1.9",
     "yup": "^0.32.9"
@@ -75,7 +75,7 @@
     "@babel/plugin-transform-react-jsx": "^7.17.3",
     "@peculiar/webcrypto": "^1.1.7",
     "@tailwindcss/line-clamp": "^0.3.0",
-    "@testing-library/dom": "^8.12.0",
+    "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,7 +2991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^8.0.0, @testing-library/dom@npm:^8.12.0":
+"@testing-library/dom@npm:^8.0.0":
   version: 8.12.0
   resolution: "@testing-library/dom@npm:8.12.0"
   dependencies:
@@ -3004,6 +3004,22 @@ __metadata:
     lz-string: ^1.4.4
     pretty-format: ^27.0.2
   checksum: 2bbf5fa5c1e883571c440ccee76c0568fa5153b43c097456dd7146797256687352bfca9db574e0e78a022ce14722a6acaaba5f680ee16b95e12405501713d34d
+  languageName: node
+  linkType: hard
+
+"@testing-library/dom@npm:^8.13.0":
+  version: 8.13.0
+  resolution: "@testing-library/dom@npm:8.13.0"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^4.2.0
+    aria-query: ^5.0.0
+    chalk: ^4.1.0
+    dom-accessibility-api: ^0.5.9
+    lz-string: ^1.4.4
+    pretty-format: ^27.0.2
+  checksum: 880f1872b9949800d4444e3bdbd03df86d6f41ec7c27136dff1da29e87d2df2d7ee904afcdf895ffce351c25bd12119117eae023354d50e707ad56d43b2ed3ed
   languageName: node
   linkType: hard
 
@@ -4449,7 +4465,7 @@ __metadata:
     "@tailwindcss/line-clamp": ^0.3.0
     "@terra-money/terra.js": ^3.0.7
     "@terra-money/wallet-provider": ^3.8.0
-    "@testing-library/dom": ^8.12.0
+    "@testing-library/dom": ^8.13.0
     "@testing-library/jest-dom": ^5.16.2
     "@testing-library/react": ^12.1.3
     "@testing-library/user-event": ^13.5.0
@@ -4487,7 +4503,7 @@ __metadata:
     react-redux: ^7.2.5
     react-router-dom: ^6.2.0
     react-scripts: ^5.0.0
-    react-select: ^5.2.1
+    react-select: ^5.3.0
     react-select-country-list: ^2.2.3
     recharts: ^2.1.9
     stream-browserify: ^3.0.0
@@ -12770,9 +12786,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-select@npm:^5.2.1":
-  version: 5.2.2
-  resolution: "react-select@npm:5.2.2"
+"react-select@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "react-select@npm:5.3.0"
   dependencies:
     "@babel/runtime": ^7.12.0
     "@emotion/cache": ^11.4.0
@@ -12782,9 +12798,9 @@ __metadata:
     prop-types: ^15.6.0
     react-transition-group: ^4.3.0
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-    react-dom: ^16.8.0 || ^17.0.0
-  checksum: 02cf76a31df6d957b15e8664957ece85afb0e9538f0686f77e8dd7cdc47cb59b71e295cd373912f2dd641724f140a1f701c91e7e7f89bb7e845a04bf5d6c67ad
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 4a37248c6f711c7b0ffe2c3414abc501d36b65ef8a51ac3962d850a713f5dec3d9ce8b38f88909b3731e9295def5279240ad2e421db866a52c868d7a5f58321d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
ClickUp ticket: <ticket_link>
Closes #<GH_issue_number>

## Description of the Problem / Feature
bumps for this week

## Explanation of the solution
### bump notes
1. @types/react for React 18 - ignored major version bump
2. @types/react-dom - ignored major version bump
3. eslint 8.12 -> 8.13 - causes error `ERROR in Failed to load config "react-app" to extend from`   can be fixed by deleting yarn.lock and reinstalling deps (nope atm)
4. @testing-library/user-event 14.1 - ignored major version bump (breaks current tests). we’ll just wait atm what correct versions of these packages go along with React-18 in releases of `create-react-app`
5. @testing-library/dom - ok 
6. react-select - ok 

