### PR TITLE
Replace phishing link with a link to new terra finder

### DIFF
--- a/src/helpers/getTxUrl.ts
+++ b/src/helpers/getTxUrl.ts
@@ -20,6 +20,6 @@ export default function getTxUrl(chainID: chainIDs, txhash: string) {
     case chainIDs.bnb_main:
       return `https://bscscan.com/tx/${txhash}`;
     default:
-      return `https://notfoundterra.com/home`;
+      return TERRA_FINDER;
   }
 }


### PR DESCRIPTION
ClickUp ticket: [<ticket_link>](https://app.clickup.com/t/2t7dw0d)
Note: Doesn't totally resolve this ticket but addresses an issue

## Description of the Problem / Feature
Replace previous ``not found link`` with the new terra explorer url