### PR TITLE
HOT FIX: edit profile button

### DIFF
--- a/src/pages/Charity/Charity.tsx
+++ b/src/pages/Charity/Charity.tsx
@@ -22,14 +22,9 @@ const Charity = () => {
       >
         <Icon type="ArrowBack" size={15} /> back to marketplace
       </Link>
-      <CharityHeader {...{ ...profile }} />
-      <CharityContent
-        {...{
-          ...profile,
-          classes: "row-span-2",
-        }}
-      />
-      <CharityStats {...{ ...profile, classes: "hidden lg:block mt-4" }} />
+      <CharityHeader {...profile} />
+      <CharityContent {...profile} classes="row-span-2" />
+      <CharityStats {...profile} classes="hidden lg:block mt-4" />
     </section>
   );
 };

--- a/src/pages/Charity/CharityHeader/CharityHeader.tsx
+++ b/src/pages/Charity/CharityHeader/CharityHeader.tsx
@@ -1,5 +1,10 @@
 import useDonater from "components/Transactors/Donater/useDonater";
+import { app, site } from "constants/routes";
 import { unsdgs } from "constants/unsdgs";
+import useWalletContext from "hooks/useWalletContext";
+import React from "react";
+import { Link } from "react-router-dom";
+import { LinkProps } from "react-router-dom";
 import { Profile } from "services/aws/endowments/types";
 import CharityLinks from "./CharityLinks";
 
@@ -8,7 +13,9 @@ export default function CharityHeader(props: Profile) {
     to: "charity",
     receiver: props.endowment_address!,
   });
+  const { wallet } = useWalletContext();
   const sdg = unsdgs[+props.un_sdg];
+  const isEndowmentOwner = wallet?.address === props.charity_owner;
 
   return (
     <div className="flex flex-col items-start gap-2">
@@ -25,15 +32,28 @@ export default function CharityHeader(props: Profile) {
       </h3>
 
       <div className="flex items-center gap-2 flex-wrap">
-        <button
-          disabled={props.is_placeholder}
-          onClick={showDonater}
-          className="disabled:bg-grey-accent uppercase bg-orange hover:bg-angel-orange font-heading text-white font-semibold rounded-xl px-6 py-3"
-        >
+        <Button disabled={props.is_placeholder} onClick={showDonater}>
           DONATE NOW
-        </button>
+        </Button>
+        {isEndowmentOwner && (
+          <LinkButton
+            to={`${site.app}/${app.charity_edit}/${props.endowment_address}`}
+          >
+            EDIT PROFILE
+          </LinkButton>
+        )}
         <CharityLinks />
       </div>
     </div>
   );
+}
+
+const buttonStyle =
+  "disabled:bg-grey-accent uppercase bg-orange hover:bg-angel-orange font-heading text-white font-semibold rounded-xl px-6 py-3";
+
+function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return <button {...props} className={buttonStyle} />;
+}
+function LinkButton(props: LinkProps) {
+  return <Link {...props} className={buttonStyle} />;
 }

--- a/src/pages/Charity/CharityHeader/CharityLinks.tsx
+++ b/src/pages/Charity/CharityHeader/CharityLinks.tsx
@@ -1,16 +1,11 @@
-import { useConnectedWallet } from "@terra-money/wallet-provider";
 import Icon, { IconTypes } from "components/Icons/Icons";
-import { app, site } from "constants/routes";
-import { Link } from "react-router-dom";
-import { LinkProps, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useProfileState } from "services/aws/endowments/states";
 import { CharityParam } from "../types";
 
 export default function CharityLinks(props: { classes?: string }) {
   const { address: charity_addr } = useParams<CharityParam>();
   const { profileState } = useProfileState(charity_addr!);
-  const wallet = useConnectedWallet();
-  const isCharityOwner = wallet?.walletAddress === profileState.charity_owner;
 
   return (
     <div className={`${props.classes || ""} flex gap-2 items-center`}>
@@ -35,12 +30,6 @@ export default function CharityLinks(props: { classes?: string }) {
       {profileState.url && (
         <IconLink _iconType="Globe" href={profileState.url} />
       )}
-      {isCharityOwner && (
-        <IconRouteLink
-          _iconType="Edit"
-          to={`${site.app}/${app.charity_edit}/${charity_addr}`}
-        />
-      )}
     </div>
   );
 }
@@ -56,26 +45,12 @@ function IconLink({
       {...restProps}
       target="_blank"
       rel="noopener noreferrer"
-      className={linkStyle}
+      className="h-10 w-10 p-2 rounded-full text-angel-blue inline-flex items-center border border-angel-blue hover:border-light-grey focus:border-light-grey"
     >
       <Icon type={_iconType} size={25} />
     </a>
   );
 }
-
-function IconRouteLink({
-  _iconType,
-  ...restProps
-}: LinkProps & { _iconType: IconTypes }) {
-  return (
-    <Link {...restProps} className={linkStyle}>
-      <Icon type={_iconType} size={25} />
-    </Link>
-  );
-}
-
-const linkStyle =
-  "h-10 w-10 p-2 rounded-full text-angel-blue inline-flex items-center border border-angel-blue hover:border-light-grey focus:border-light-grey";
 
 //<props.Icon color="#3FA9F5" size={props.size} />
 function formatUrl(


### PR DESCRIPTION
ClickUp ticket: <ticket_link>
Closes #<GH_issue_number>

## Description of the Problem / Feature
users can't see edit button because it was replaced by edit icon

## Explanation of the solution
revert edit button with full text

## Instructions on making this work
N.A

## UI changes for reviewed
edit button wide screen
<img width="1644" alt="image" src="https://user-images.githubusercontent.com/89639563/163699561-ba97681a-1a1b-45fb-8d0f-e013efca4fc4.png">

edit button medium screen
<img width="641" alt="image" src="https://user-images.githubusercontent.com/89639563/163699577-de2f9047-acfb-4af9-81d8-96adca5b6bdf.png">

small screen
<img width="379" alt="image" src="https://user-images.githubusercontent.com/89639563/163699582-845a8c72-79c5-4978-94e4-47b328aae283.png">
