### PR TITLE
Test: Copier component & Hot Fix: `title` attribute

### DIFF
--- a/src/Website/WebFoot.tsx
+++ b/src/Website/WebFoot.tsx
@@ -32,11 +32,7 @@ export default function WebFoot() {
         </ul>
         <div className="flex flex-wrap gap-4">
           <a
-<<<<<<< HEAD
-            href="https://storageapi2.fleek.co/57b943eb-ed70-478a-8899-c7859400f77b-bucket/documents/ap-litepaper.pdf"
-=======
             href={LITEPAPER}
->>>>>>> RC-v1.6
             className="mt-2 mb-1 font-semibold text-sm uppercase text-white-grey text-center"
             target="_blank"
             rel="noreferrer"
@@ -44,11 +40,7 @@ export default function WebFoot() {
             Download Litepaper
           </a>
           <a
-<<<<<<< HEAD
-            href="https://storageapi2.fleek.co/57b943eb-ed70-478a-8899-c7859400f77b-bucket/documents/Website and WebApp Privacy Policy (v.110121).docx"
-=======
             href={PRIVACY_POLICY}
->>>>>>> RC-v1.6
             target="_blank"
             rel="noreferrer"
             className="mt-2 mb-1 font-semibold text-sm uppercase text-white-grey text-center"

--- a/src/components/Copier/Copier.tsx
+++ b/src/components/Copier/Copier.tsx
@@ -14,7 +14,7 @@ export default function Copier(props: { text: string; colorClass: string }) {
       )) || (
         <Icon
           type="Copy"
-          className={`${props.colorClass} hover:text-orange"`}
+          className={`${props.colorClass} hover:text-orange`}
           title="Copy Address"
         />
       )}


### PR DESCRIPTION
ClickUp ticket: https://app.clickup.com/t/2khqbu0

## Description of the Problem / Feature
Test for the Copier component. A hot fix for the `Icon` component's `title` attribute has been implemented. Previously it was inside the `className` attribute which does nothing.

## Explanation of the solution
The test simulates the copy button/icon:
- [x] Renders the said component
- [x] Invokes the mock copy function and changes component's appearance

## Instructions on making this work
1. Install dependencies using `./bin/setup` and run `yarn test` then hit `a` to run tests.
2. To check the `title` attribute, run `yarn start`, go to the Marketplace and connect your wallet. Hover your mouse over the copy icon and you should be able to read "Copy Address".