### PR TITLE
Charity Registration: Remove unnecessary data from verify-email request

### DIFF
--- a/src/pages/Registration/ContactDetails/ContactDetailsForm/useContactDetails.tsx
+++ b/src/pages/Registration/ContactDetails/ContactDetailsForm/useContactDetails.tsx
@@ -97,11 +97,15 @@ export default function useSaveContactDetails() {
         return;
       }
 
+      // Extracting SK, EmailVerified so that 'contactPerson' does not include them
+      const { PK, SK, EmailVerified, ...contactPerson } =
+        dataResult.data.ContactPerson;
+
       await resendEmail({
-        uuid: dataResult.data.ContactPerson.PK,
+        uuid: PK,
         type: "verify-email",
         body: {
-          ...dataResult.data.ContactPerson,
+          ...contactPerson,
           CharityName: dataResult.data.Registration.CharityName,
         },
       });


### PR DESCRIPTION

## Description of the Problem / Feature
Sending `SK`, `EmailVerified` and `PK` to `POST /registration/build-email` causes the email link created to be broken
## Explanation of the solution
- removed `SK`, `EmailVerified` and `PK` from the body of the request to `POST /registration/build-email`
## Instructions on making this work
- run the app
- start reg. process
- submit step 1
- open email from step 1
- click link
- verify no error appears
