### PR TITLE
RC-v1.6: proposal exec tag invalidation

### DIFF
--- a/src/components/Transactors/AdminExecuter/ExecuteForm.tsx
+++ b/src/components/Transactors/AdminExecuter/ExecuteForm.tsx
@@ -1,8 +1,15 @@
+import { TagPayloads } from "services/transaction/types";
 import useExecuteProposal from "./useExecuteProposal";
 
-export type Props = { proposal_id: number };
+export type Props = {
+  proposal_id: number;
+  tagPayloads?: TagPayloads;
+};
 export default function ExecuteForm(props: Props) {
-  const { executeProposal } = useExecuteProposal(props.proposal_id);
+  const { executeProposal } = useExecuteProposal(
+    props.proposal_id,
+    props.tagPayloads
+  );
   return (
     <div className="bg-white grid justify-items-center p-4 rounded-md w-full">
       <p className="text-angel-grey">

--- a/src/components/Transactors/AdminExecuter/useExecuteProposal.ts
+++ b/src/components/Transactors/AdminExecuter/useExecuteProposal.ts
@@ -1,6 +1,5 @@
-import { admin, tags } from "services/terra/tags";
-import { terra } from "services/terra/terra";
 import { sendTerraTx } from "services/transaction/sendTerraTx";
+import { TagPayloads } from "services/transaction/types";
 import { useSetModal } from "components/Modal/Modal";
 import Popup, { PopupProps } from "components/Popup/Popup";
 import TransactionPrompt from "components/TransactionStatus/TransactionPrompt";
@@ -8,7 +7,10 @@ import { useGetter, useSetter } from "store/accessors";
 import Admin from "contracts/Admin";
 import useWalletContext from "hooks/useWalletContext";
 
-export default function useExecuteProposal(proposal_id: number) {
+export default function useExecuteProposal(
+  proposal_id: number,
+  tagPayloads?: TagPayloads
+) {
   const { cwContracts } = useGetter((state) => state.admin.cwContracts);
   const { wallet } = useWalletContext();
   const dispatch = useSetter();
@@ -25,15 +27,7 @@ export default function useExecuteProposal(proposal_id: number) {
       sendTerraTx({
         wallet,
         msgs: [execMsg],
-        tagPayloads: [
-          terra.util.invalidateTags([
-            //TODO: invalidate corresponding cache based on proposal executed
-            { type: tags.admin, id: admin.members },
-            { type: tags.admin, id: admin.member },
-            { type: tags.admin, id: admin.proposal },
-            { type: tags.admin, id: admin.proposals },
-          ]),
-        ],
+        tagPayloads,
       })
     );
     showModal(TransactionPrompt, {});

--- a/src/components/Transactors/AdminExecuter/useProposalExecutor.ts
+++ b/src/components/Transactors/AdminExecuter/useProposalExecutor.ts
@@ -1,15 +1,19 @@
 import { useCallback } from "react";
+import { TagPayloads } from "services/transaction/types";
 import { useSetModal } from "components/Modal/Modal";
 import Transactor, { TxProps } from "../Transactor";
 import ExecuteForm, { Props } from "./ExecuteForm";
 
-export default function useProposalExecutor(proposal_id: number) {
+export default function useProposalExecutor(
+  proposal_id: number,
+  tagPayloads?: TagPayloads
+) {
   const { showModal } = useSetModal();
   const showPollEnder = useCallback(() => {
     showModal<TxProps<Props>>(Transactor, {
       inModal: true,
       Content: ExecuteForm,
-      contentProps: { proposal_id },
+      contentProps: { proposal_id, tagPayloads },
     });
     //eslint-disable-next-line
   }, [proposal_id]);

--- a/src/pages/Admin/Proposals/PollAction.tsx
+++ b/src/pages/Admin/Proposals/PollAction.tsx
@@ -1,11 +1,28 @@
+import { TagDescription } from "@reduxjs/toolkit/dist/query/endpointDefinitions";
 import React, { ReactNode } from "react";
+import {
+  admin,
+  endowment,
+  indexfund,
+  multicall,
+  registrar,
+  tags,
+  user,
+} from "services/terra/tags";
+import { terra } from "services/terra/terra";
 import useProposalExecutor from "components/Transactors/AdminExecuter/useProposalExecutor";
 import useAdminVoter from "components/Transactors/AdminVoter/useAdminVoter";
+import { proposalTypes } from "constants/routes";
+import { ProposalMeta } from "../types";
 import { ProposalDetails } from "./useProposalDetails";
 
 export default function PollAction(props: ProposalDetails) {
   const showAdminVoter = useAdminVoter(props.numId);
-  const showAdminExecuter = useProposalExecutor(props.numId);
+
+  const showAdminExecuter = useProposalExecutor(
+    props.numId,
+    getTagPayloads(props.meta)
+  );
 
   const EXED = props.isExecuted;
   const EX = props.isExecutable;
@@ -44,4 +61,104 @@ function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement>) {
       className="text-xs font-bold uppercase font-heading px-6 pt-1.5 pb-1 rounded-md bg-blue-accent hover:bg-angel-blue border-2 border-white/30"
     />
   );
+}
+/** 
+ *   index = "",
+  //registrar
+  registrar_updateConfig = "registrar-update-config",
+  registrar_updateOwner = "registrar-update-owner",
+*/
+
+function getTagPayloads(proposalMeta: ProposalDetails["meta"]) {
+  const tagsToInvalidate: TagDescription<tags>[] = [
+    //basic tags to invalidate
+    { type: tags.admin, id: admin.proposal },
+    { type: tags.admin, id: admin.proposals },
+  ];
+  if (!proposalMeta) {
+    return [terra.util.invalidateTags(tagsToInvalidate)];
+  }
+  const parsedProposalMeta: ProposalMeta = JSON.parse(proposalMeta);
+  switch (parsedProposalMeta.type) {
+    case proposalTypes.indexFund_allianceEdits:
+      tagsToInvalidate.push({
+        type: tags.indexfund,
+        id: indexfund.alliance_members,
+      });
+      break;
+    case proposalTypes.indexFund_removeFund:
+    case proposalTypes.indexFund_createFund:
+    case proposalTypes.indexFund_updateFundMembers: //fund members shown via selecFromResult (fund_list)
+      tagsToInvalidate.push({
+        type: tags.indexfund,
+        id: indexfund.fund_list,
+      });
+      break;
+
+    case proposalTypes.indexFund_configUpdate:
+    case proposalTypes.indexFund_ownerUpdate:
+      tagsToInvalidate.push({
+        type: tags.indexfund,
+        id: indexfund.config,
+      });
+      break;
+
+    case proposalTypes.adminGroup_updateMembers:
+      tagsToInvalidate.push({
+        type: tags.admin,
+        id: admin.members,
+      });
+      break;
+
+    case proposalTypes.adminGroup_fundTransfer:
+      tagsToInvalidate.push(
+        {
+          type: tags.user,
+          id: user.terra_balance,
+        },
+        {
+          type: tags.user,
+          id: user.halo_balance,
+        }
+      );
+      break;
+
+    case proposalTypes.endowment_updateStatus:
+      tagsToInvalidate.push({
+        type: tags.registrar,
+        id: registrar.endowments, //via selectFromResult (endowments), TODO: convert to {endowment:{}} query
+      });
+      break;
+
+    case proposalTypes.endowment_withdraw:
+      tagsToInvalidate.push(
+        {
+          type: tags.multicall,
+          id: multicall.endowmentBalance,
+        },
+        //edge: user transfers to CW20 or Native to his connected wallet
+        {
+          type: tags.user,
+          id: user.halo_balance,
+        },
+        {
+          type: tags.user,
+          id: user.terra_balance,
+        }
+      );
+      break;
+
+    case proposalTypes.endowment_updateProfile:
+      tagsToInvalidate.push({ type: tags.endowment, id: endowment.profile });
+      break;
+
+    case proposalTypes.registrar_updateOwner:
+    case proposalTypes.registrar_updateConfig:
+      tagsToInvalidate.push({ type: tags.registrar, id: registrar.config });
+      break;
+
+    default:
+      return [terra.util.invalidateTags(tagsToInvalidate)];
+  }
+  return [terra.util.invalidateTags(tagsToInvalidate)];
 }

--- a/src/pages/Admin/Proposals/useProposalDetails.ts
+++ b/src/pages/Admin/Proposals/useProposalDetails.ts
@@ -57,6 +57,7 @@ export default function useProposalDetails(
     numId: idParamToNumber(proposalInfo.id),
     votes,
     userVote,
+    meta: proposalInfo.meta,
   };
 }
 
@@ -76,4 +77,5 @@ export type ProposalDetails = {
   numId: number;
   userVote?: Vote;
   votes: VoteInfo[];
+  meta?: string;
 };

--- a/src/services/terra/admin/admin.ts
+++ b/src/services/terra/admin/admin.ts
@@ -33,7 +33,7 @@ export const admin_api = terra.injectEndpoints({
 
     //CW3
     cw3Config: builder.query<CW3Config, ContractQueryArgs>({
-      providesTags: [{ type: tags.admin, id: admin.member }],
+      providesTags: [{ type: tags.admin, id: admin.config }],
       query: contract_querier,
       transformResponse: (res: QueryRes<CW3Config>) => {
         return res.query_result;

--- a/src/services/terra/indexFund/indexFund.ts
+++ b/src/services/terra/indexFund/indexFund.ts
@@ -1,5 +1,6 @@
 import { FundDetails, FundListRes } from "contracts/types";
 import contract_querier from "../contract_querier";
+import { indexfund, tags } from "../tags";
 import { terra } from "../terra";
 import { ContractQueryArgs, QueryRes } from "../types";
 import { AllianceMember, AllianceMembersRes, IndexFundConfig } from "./types";
@@ -7,18 +8,21 @@ import { AllianceMember, AllianceMembersRes, IndexFundConfig } from "./types";
 export const indexFund_api = terra.injectEndpoints({
   endpoints: (builder) => ({
     fundList: builder.query<FundDetails[], ContractQueryArgs>({
+      providesTags: [{ type: tags.indexfund, id: indexfund.fund_list }],
       query: contract_querier,
       transformResponse: (res: QueryRes<FundListRes>) => {
         return res.query_result.funds;
       },
     }),
     allianceMembers: builder.query<AllianceMember[], ContractQueryArgs>({
+      providesTags: [{ type: tags.indexfund, id: indexfund.alliance_members }],
       query: contract_querier,
       transformResponse: (res: QueryRes<AllianceMembersRes>) => {
         return res.query_result.alliance_members;
       },
     }),
     config: builder.query<IndexFundConfig, ContractQueryArgs>({
+      providesTags: [{ type: tags.indexfund, id: indexfund.config }],
       query: contract_querier,
       transformResponse: (res: QueryRes<IndexFundConfig>) => {
         return res.query_result;

--- a/src/services/terra/registrar/registrar.ts
+++ b/src/services/terra/registrar/registrar.ts
@@ -1,5 +1,5 @@
 import contract_querier from "../contract_querier";
-import { tags } from "../tags";
+import { registrar, tags } from "../tags";
 import { terra } from "../terra";
 import { ContractQueryArgs, QueryRes } from "../types";
 import {
@@ -12,12 +12,14 @@ import {
 export const registrar_api = terra.injectEndpoints({
   endpoints: (builder) => ({
     endowments: builder.query<EndowmentEntry[], ContractQueryArgs>({
+      providesTags: [{ type: tags.registrar, id: registrar.endowments }],
       query: contract_querier,
       transformResponse: (res: QueryRes<EndowmentListRes>) => {
         return res.query_result.endowments;
       },
     }),
     config: builder.query<RegistrarConfig, ContractQueryArgs>({
+      providesTags: [{ type: tags.registrar, id: registrar.config }],
       query: contract_querier,
       transformResponse: (res: QueryRes<RegistrarConfig>) => {
         return res.query_result;
@@ -27,7 +29,7 @@ export const registrar_api = terra.injectEndpoints({
       CategorizedEndowments,
       ContractQueryArgs
     >({
-      providesTags: [{ type: tags.endowment }],
+      providesTags: [{ type: tags.registrar, id: registrar.endowments }],
       query: contract_querier,
       transformResponse: (res: QueryRes<EndowmentListRes>) => {
         return res.query_result.endowments.reduce((result, profile) => {

--- a/src/services/terra/tags.ts
+++ b/src/services/terra/tags.ts
@@ -1,10 +1,12 @@
 export enum tags {
   gov = "gov",
+  indexfund = "indexfund",
   user = "user",
   halo = "halo",
   admin = "admin",
   endowment = "endowment",
   multicall = "multicall",
+  registrar = "registrar",
 }
 
 export enum admin {
@@ -12,6 +14,7 @@ export enum admin {
   proposal = "proposal",
   members = "members",
   member = "member",
+  config = "config",
   votes = "votes",
   applications = "applications",
 }
@@ -23,6 +26,18 @@ export enum gov {
   config = "config",
   halo_balance = "halo_balance",
 }
+
+export enum indexfund {
+  alliance_members = "alliance_members",
+  fund_list = "fund_list",
+  config = "config",
+}
+
+export enum registrar {
+  endowments = "endowments",
+  config = "config",
+}
+
 export enum user {
   terra_balance = "terra_balance",
   halo_balance = "halo_balance",

--- a/src/services/terra/terra.ts
+++ b/src/services/terra/terra.ts
@@ -32,6 +32,8 @@ export const terra = createApi({
   baseQuery: customBaseQuery,
   tagTypes: [
     tags.gov,
+    tags.indexfund,
+    tags.registrar,
     tags.user,
     tags.halo,
     tags.admin,

--- a/src/services/transaction/types.ts
+++ b/src/services/transaction/types.ts
@@ -91,10 +91,14 @@ export type StageUpdator = (update: Stage) => void;
 
 export type WithMsg = { msgs: Msg[]; tx?: never }; //tx created onflight
 export type WithTx = { msgs?: never; tx: CreateTxOptions }; //pre-estimated tx
+export type TagPayloads = PayloadAction<
+  TagDescription<terraTags | awsTags>[],
+  string
+>[];
 
 export type SenderArgs = {
   wallet: WalletProxy | undefined;
-  tagPayloads?: PayloadAction<TagDescription<terraTags | awsTags>[], string>[];
+  tagPayloads?: TagPayloads;
   successMessage?: string;
   successLink?: SuccessLink;
   feedDenom?: denoms;


### PR DESCRIPTION
## Description of the Problem / Feature
when user executes a poll, the poll executer just sends `{execute_poll: {poll_id: x}}` to CW3 contract, after the completion of tx, the executer doesn't know which cache tags needs to be invalidated since `poll_id` is the only thing it knows. Invalidating the whole `admin` cache is inefficient and also ineffective since some queries are from `index_fund`, `registrar` etc. 

## Explanation of the solution
0. add missing tags to new terra endpoints
1. pass proposal meta to `PollAction`
2. parse proposalMeta and determine set of cache tags to invalidate based on its `proposalType`
3. pass determined cache entries to `usePollExecuter`

tests
1. test multisig withdraw - after proposal exec, user wallet balance and endowment balance should be updated
2. test cw3 fund transfer - after  proposal exec, both user wallet balance, and cw3 balance should be updated

## Instructions on making this work
N.A

## UI changes for review
N.A 
