### PR TITLE
This week deps bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "autoprefixer": "^10.0.2",
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.0",
-    "eslint": "^8.12.0",
+    "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
     "postcss": "^8.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1853,9 +1853,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@eslint/eslintrc@npm:1.2.1"
+"@eslint/eslintrc@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@eslint/eslintrc@npm:1.2.2"
   dependencies:
     ajv: ^6.12.4
     debug: ^4.3.2
@@ -1866,7 +1866,7 @@ __metadata:
     js-yaml: ^4.1.0
     minimatch: ^3.0.4
     strip-json-comments: ^3.1.1
-  checksum: 1f797b9f94d71b965992cf6c44e3bcb574643014fd1e3d4862d25056bd5568f59c488461a7e9a1c1758ca7f0def5d3cb69c3d8b38581bcf4a53af74371243797
+  checksum: d891036bbffb0efec1462aa4a603ed6e349d546b1632dde7d474ddd15c2a8b6895671b25293f1d3ba10ff629c24a3649ad049373fe695a0e44b612537088563c
   languageName: node
   linkType: hard
 
@@ -4627,7 +4627,7 @@ __metadata:
     compress.js: ^1.2.2
     crypto-browserify: ^3.12.0
     draft-js: ^0.11.7
-    eslint: ^8.12.0
+    eslint: ^8.14.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-prettier: ^3.4.0
     ethers: ^5.5.4
@@ -7623,11 +7623,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.12.0, eslint@npm:^8.3.0":
-  version: 8.12.0
-  resolution: "eslint@npm:8.12.0"
+"eslint@npm:^8.14.0, eslint@npm:^8.3.0":
+  version: 8.14.0
+  resolution: "eslint@npm:8.14.0"
   dependencies:
-    "@eslint/eslintrc": ^1.2.1
+    "@eslint/eslintrc": ^1.2.2
     "@humanwhocodes/config-array": ^0.9.2
     ajv: ^6.10.0
     chalk: ^4.0.0
@@ -7664,7 +7664,7 @@ __metadata:
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: 111bf9046b7a463049788dd00d7f4cd91e024029982352dff4811ce5dfa8cb1136aa127cd8a7a91508234d3e1b4fb6f638a1f5ef9ea08b1af93a18703a4a8dc1
+  checksum: 87d2e3e5eb93216d4ab36006e7b8c0bfad02f40b0a0f193f1d42754512cd3a9d8244152f1c69df5db2e135b3c4f1c10d0ed2f0881fe8a8c01af55465968174c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. bump `@tailwind-css/line-clamp` to `v.0.4.0`
2. `react-redux` postponed along with `react` v18 upgrade - [click up task](https://app.clickup.com/t/2q9u1km)
3. `eslint` minor update `8.12.0` to `8.14.0`

tests:
1. line-clamp still working
<img width="267" alt="image" src="https://user-images.githubusercontent.com/89639563/166397108-884a6784-c738-492b-ac3d-88663dbbffb0.png">
2. no `react-app` extend error 
