### PR TITLE
Charity Registration: Add contact email to ConfirmEmail when resending email

### DIFF
--- a/src/pages/Registration/ConfirmEmail.tsx
+++ b/src/pages/Registration/ConfirmEmail.tsx
@@ -39,7 +39,7 @@ export default function ConfirmEmail() {
     response.data
       ? showModal<PopupProps>(Popup, {
           message:
-            "We have sent you another verification email. If you still don't receive anything, please get in touch with us.",
+            "We have sent you another verification email. If you still don't receive anything, please get in touch with us at support@angelprotocol.io",
         })
       : showModal<PopupProps>(Popup, {
           message: response.error.data.message,


### PR DESCRIPTION
ClickUp ticket: https://app.clickup.com/t/2aztqpu

## Explanation of the solution
- added "at support@angelprotocol.io" to the end of the popup text
## Instructions on making this work
- run the app
- start registration and finish step 1
- on `ConfirmEmail` screen click "Resend verification email"
- verify text with contact email appears in popup
 
## UI changes for review
![image](https://user-images.githubusercontent.com/19427053/167827370-124e1ac2-f73c-4158-aa75-a6c69b86df1d.png)
