### PR TITLE
Hide Ukraine portal banner in website header

### DIFF
--- a/src/Website/Header/WebHead.tsx
+++ b/src/Website/Header/WebHead.tsx
@@ -61,11 +61,11 @@ export default function WebHead() {
   );
 }
 
-function Word(props: { icon: string; title: string }) {
-  return (
-    <div className="flex items-center mr-2">
-      <img src={props.icon} alt="" className="w-4 h-4 mr-1" />
-      <span className="md:uppercase">{props.title}</span>
-    </div>
-  );
-}
+// function Word(props: { icon: string; title: string }) {
+//   return (
+//     <div className="flex items-center mr-2">
+//       <img src={props.icon} alt="" className="w-4 h-4 mr-1" />
+//       <span className="md:uppercase">{props.title}</span>
+//     </div>
+//   );
+// }


### PR DESCRIPTION
Hiding the Ukraine portal banner in the website header
From:
![Screenshot from 2022-05-20 10-16-10](https://user-images.githubusercontent.com/65009749/169442130-d2c3f90d-232c-4cef-8486-d711f4276ba2.png)

To:
![Screenshot from 2022-05-20 11-04-41](https://user-images.githubusercontent.com/65009749/169442237-1a9edaba-6468-44a1-ae63-3e31bd779e22.png)