### PR TITLE
RC-v1.6: typescript error on error msg extraction

### DIFF
--- a/src/pages/Registration/Documentation/Fields/FileDropzones/AuditedFinancialReports.tsx
+++ b/src/pages/Registration/Documentation/Fields/FileDropzones/AuditedFinancialReports.tsx
@@ -1,4 +1,5 @@
-import { FieldError, useFormContext } from "react-hook-form";
+import { ErrorMessage } from "@hookform/error-message";
+import { useFormContext } from "react-hook-form";
 import { DocumentationValues } from "pages/Registration/types";
 import FileDropzone from "components/FileDropzone";
 import { InputRow } from "../../../common";
@@ -19,29 +20,12 @@ export default function AuditedFinancialReport() {
         multiple
         disabled={isSubmitting}
       />
-      {!!errors.auditedFinancialReports?.length &&
-        errors.auditedFinancialReports
-          // Yup assumes wrong field names for errors, so we need to cast them first as "any",
-          // otherwise it would issue a warning
-          .map((fieldError: any) => (fieldError as FieldError).message)
-          .filter(checkUnique)
-          .map((message) => (
-            <p
-              key={message}
-              className="w-full text-xs text-failed-red text-center"
-            >
-              {message}
-            </p>
-          ))}
+      <ErrorMessage
+        className="w-full text-xs text-failed-red text-center"
+        errors={errors}
+        as="p"
+        name="auditedFinancialReports"
+      />
     </InputRow>
   );
-}
-
-// Checks, if the given value is the first occurring. If not, it must be a duplicate.
-function checkUnique(
-  value: string | undefined,
-  index: number,
-  self: (string | undefined)[]
-) {
-  return self.indexOf(value) === index;
 }

--- a/src/pages/Registration/Documentation/Fields/FileDropzones/FinancialStatements.tsx
+++ b/src/pages/Registration/Documentation/Fields/FileDropzones/FinancialStatements.tsx
@@ -1,4 +1,5 @@
-import { FieldError, useFormContext } from "react-hook-form";
+import { ErrorMessage } from "@hookform/error-message";
+import { useFormContext } from "react-hook-form";
 import { DocumentationValues } from "pages/Registration/types";
 import FileDropzone from "components/FileDropzone";
 import { InputRow } from "../../../common";
@@ -19,29 +20,12 @@ export default function FinancialStatements() {
         multiple
         disabled={isSubmitting}
       />
-      {!!errors.financialStatements?.length &&
-        errors.financialStatements
-          // Yup assumes wrong field names for errors, so we need to cast them first as "any",
-          // otherwise it would issue a warning
-          .map((fieldError: any) => (fieldError as FieldError).message)
-          .filter(checkUnique)
-          .map((message) => (
-            <p
-              key={message}
-              className="w-full text-xs text-failed-red text-center"
-            >
-              {message}
-            </p>
-          ))}
+      <ErrorMessage
+        className="w-full text-xs text-failed-red text-center"
+        errors={errors}
+        as="p"
+        name="financialStatements"
+      />
     </InputRow>
   );
-}
-
-// Checks, if the given value is the first occurring. If not, it must be a duplicate.
-function checkUnique(
-  value: string | undefined,
-  index: number,
-  self: (string | undefined)[]
-) {
-  return self.indexOf(value) === index;
 }

--- a/src/pages/Registration/Documentation/Fields/FileDropzones/ProofOfIdentity.tsx
+++ b/src/pages/Registration/Documentation/Fields/FileDropzones/ProofOfIdentity.tsx
@@ -1,4 +1,5 @@
-import { FieldError, useFormContext } from "react-hook-form";
+import { ErrorMessage } from "@hookform/error-message";
+import { useFormContext } from "react-hook-form";
 import { BsX } from "react-icons/bs";
 import { DocumentationValues } from "pages/Registration/types";
 import { useModalContext } from "contexts/ModalContext";
@@ -9,8 +10,6 @@ export default function ProofOfIdentity() {
   const {
     formState: { errors, isSubmitting },
   } = useFormContext<DocumentationValues>();
-
-  const errorMessage = (errors.proofOfIdentity as FieldError)?.message;
 
   return (
     <InputRow
@@ -24,11 +23,12 @@ export default function ProofOfIdentity() {
         className="h-8"
         disabled={isSubmitting}
       />
-      {errorMessage && (
-        <p className="w-full text-xs text-failed-red text-center">
-          {errorMessage}
-        </p>
-      )}
+      <ErrorMessage
+        errors={errors}
+        name="proofOfIdentity"
+        as="p"
+        className="w-full text-xs text-failed-red text-center"
+      />
     </InputRow>
   );
 }

--- a/src/pages/Registration/Documentation/Fields/FileDropzones/ProofOfRegistration.tsx
+++ b/src/pages/Registration/Documentation/Fields/FileDropzones/ProofOfRegistration.tsx
@@ -1,4 +1,5 @@
-import { FieldError, useFormContext } from "react-hook-form";
+import { ErrorMessage } from "@hookform/error-message";
+import { useFormContext } from "react-hook-form";
 import { DocumentationValues } from "pages/Registration/types";
 import FileDropzone from "components/FileDropzone";
 import { InputRow } from "../../../common";
@@ -7,8 +8,6 @@ export default function ProofOfRegistration() {
   const {
     formState: { errors, isSubmitting },
   } = useFormContext<DocumentationValues>();
-
-  const errorMessage = (errors.proofOfRegistration as FieldError)?.message;
 
   return (
     <InputRow
@@ -21,11 +20,12 @@ export default function ProofOfRegistration() {
         className="h-8"
         disabled={isSubmitting}
       />
-      {errorMessage && (
-        <p className="w-full text-xs text-failed-red text-center">
-          {errorMessage}
-        </p>
-      )}
+      <ErrorMessage
+        errors={errors}
+        as="p"
+        name="proofOfRegistration"
+        className="w-full text-xs text-failed-red text-center"
+      />
     </InputRow>
   );
 }

--- a/src/pages/Registration/Documentation/Fields/UnSdgSelector.tsx
+++ b/src/pages/Registration/Documentation/Fields/UnSdgSelector.tsx
@@ -1,3 +1,4 @@
+import { ErrorMessage } from "@hookform/error-message";
 import { useFormContext } from "react-hook-form";
 import { DocumentationValues } from "pages/Registration/types";
 import Selector from "components/Selector";
@@ -27,11 +28,12 @@ export default function UnSdgSelector() {
         control={control}
         disabled={isSubmitting}
       />
-      {errors.un_sdg?.message && (
-        <p className="w-full text-xs text-failed-red text-center">
-          {errors.un_sdg.message}
-        </p>
-      )}
+      <ErrorMessage
+        errors={errors}
+        as="p"
+        name="un_sdg"
+        className="w-full text-xs text-failed-red text-center"
+      />
     </InputRow>
   );
 }

--- a/src/pages/Registration/Documentation/Fields/WebsiteInput.tsx
+++ b/src/pages/Registration/Documentation/Fields/WebsiteInput.tsx
@@ -1,3 +1,4 @@
+import { ErrorMessage } from "@hookform/error-message";
 import { useFormContext } from "react-hook-form";
 import { DocumentationValues } from "pages/Registration/types";
 import { InputRow } from "../../common";
@@ -17,11 +18,12 @@ export default function WebsiteInput() {
         className="h-8 rounded-md outline-none border-none w-full px-2 py-1 text-black"
         disabled={isSubmitting}
       />
-      {errors.website?.message && (
-        <p className="w-full text-xs text-failed-red text-center">
-          {errors.website.message}
-        </p>
-      )}
+      <ErrorMessage
+        as="p"
+        name="website"
+        errors={errors}
+        className="w-full text-xs text-failed-red text-center"
+      />
     </InputRow>
   );
 }


### PR DESCRIPTION
ClickUp ticket: <ticket_link>
Closes #<GH_issue_number>

## Description of the Problem / Feature
encountered error from latest RC-v1.6
![image](https://user-images.githubusercontent.com/89639563/176656023-6959e750-d061-4524-86cd-48a3b0178a3c.png)

## Explanation of the solution
1. use `<ErrorMessage/>` component instead of custom error extraction (in components that use `useFormContext`)
2. test error validation - ok 

## Instructions on making this work
N.A 


## UI changes for review
N.A

