### PR TITLE
RC-v1.6: overview limit on charity registration

### DIFF
--- a/src/contexts/WalletContext/constants.ts
+++ b/src/contexts/WalletContext/constants.ts
@@ -1,5 +1,5 @@
 import { ProviderId } from "./types";
-import { Chain, Token } from "types/server/aws";
+import { Chain } from "types/server/aws";
 import tokenLogo from "assets/icons/currencies/token.svg";
 import binanceWalletIcon from "assets/icons/wallets/binance.png";
 import keplr from "assets/icons/wallets/keplr.png";

--- a/src/contracts/Contract.ts
+++ b/src/contracts/Contract.ts
@@ -32,7 +32,6 @@ const GAS_PRICE = IS_TEST
 
 // This is the multiplier used when auto-calculating the fees
 // https://github.com/cosmos/cosmjs/blob/5bd6c3922633070dbb0d68dd653dc037efdf3280/packages/stargate/src/signingstargateclient.ts#L290
-const GAS_MULTIPLIER = 1.3;
 
 export default class Contract {
   contractAddress: string;

--- a/src/pages/Governance/useGov.ts
+++ b/src/pages/Governance/useGov.ts
@@ -2,7 +2,6 @@ import Decimal from "decimal.js";
 import { useEffect, useMemo, useState } from "react";
 import { useGovHaloBalance, useHaloInfo } from "services/juno/gov/queriers";
 import { usePairSimul } from "services/juno/lp/queriers";
-import { useGetWallet } from "contexts/WalletContext/WalletContext";
 import { getSpotPrice } from "components/Transactors/Swapper/getSpotPrice";
 
 export default function useGov() {

--- a/src/pages/Registration/AdditionalInformation/additionalnfoSchema.ts
+++ b/src/pages/Registration/AdditionalInformation/additionalnfoSchema.ts
@@ -2,6 +2,7 @@ import * as Yup from "yup";
 import { AdditionalInfoValues } from "../types";
 import { FileWrapper } from "components/FileDropzone/types";
 import { SchemaShape } from "schemas/types";
+import { stringByteSchema } from "schemas/string";
 
 const VALID_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
@@ -27,7 +28,7 @@ const FILE_SCHEMA = Yup.mixed<FileWrapper>()
   });
 
 const additionalnfoShape: SchemaShape<AdditionalInfoValues> = {
-  charityOverview: Yup.string().required("Organization description required"),
+  charityOverview: stringByteSchema("overview", 4, 1024),
   charityLogo: FILE_SCHEMA.test({
     name: "fileSize",
     message: "Image size must be smaller than 1MB",


### PR DESCRIPTION
ClickUp ticket: <https://app.clickup.com/t/36ape3n>

## Description of the Problem / Feature
charity overview must have byte limits since it will be saved on-chain

## Explanation of the solution
udpated schema

error when user reaches byte size limit
![image](https://user-images.githubusercontent.com/89639563/184290371-f1d6f3c2-817b-41de-b950-0eb1ee70acbd.png)

