### PR TITLE
Update package.json scripts with GENERATE_SOURCEMAP env. var

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "GENERATE_SOURCEMAP=false react-app-rewired --max_old_space_size=4096 build",
-    "analyze": "GENERATE_SOURCEMAP=true react-app-rewired --max_old_space_size=4096 build && source-map-explorer 'build/static/js/*.js'",
+    "build": "react-app-rewired --max_old_space_size=4096 build",
+    "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "GENERATE_SOURCEMAP=false react-app-rewired start",
     "test": "react-app-rewired test --colors",
     "lint": "eslint 'src/**/*.{ts,tsx}'",


### PR DESCRIPTION

## Description of the Problem / Feature
Unnecessarily generating source maps during development when starting the webapp slows down the startup time significantly.
Turning this off in the `package.json` scripts and enabling it only when analyzing the bundle size increases dev speed.

We should probably remove `GENERATE_SOURCEMAP=false` from production builds at some point as it can enable [better debugging in production](https://css-tricks.com/should-i-use-source-maps-in-production/) (at the cost of longer compilation time and potential memory allocation issues on AWS).
