### PR TITLE
Fix phone field in Contact Details to read correct form field

### DIFF
--- a/src/pages/Registration/ContactDetails/ContactDetailsForm/ContactDetailsForm.tsx
+++ b/src/pages/Registration/ContactDetails/ContactDetailsForm/ContactDetailsForm.tsx
@@ -72,7 +72,7 @@ export default function ContactDetailsForm({ charity }: Props) {
             required
           />
           <FormInput<CD>
-            fieldName="email"
+            fieldName="phone"
             label="Phone number"
             placeholder="Phone number"
           />


### PR DESCRIPTION
## Description
Phone field in "Contact Details form" incorrectly reads/sets the `email` value. We should update this to `phone`.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify phone field reads correct `ContactDetails.phone` value 

