### PR TITLE
RC-v1.6: selector disabled state

### DIFF
--- a/src/pages/Registration/common/FormInput.tsx
+++ b/src/pages/Registration/common/FormInput.tsx
@@ -41,7 +41,7 @@ export default function FormInput<T extends FieldValues>(
         id={props.fieldName}
         type={type}
         disabled={disabled || isSubmitting}
-        className={`rounded-md outline-none border-none w-full px-3 py-2 text-black ${
+        className={`rounded-md outline-none border-none w-full px-3 py-2 text-black bg-zinc-50 disabled:bg-zinc-50/10 ${
           props.mono ? "font-mono" : ""
         }`}
         {...register(props.fieldName)}

--- a/src/pages/Registration/common/Selector.tsx
+++ b/src/pages/Registration/common/Selector.tsx
@@ -25,11 +25,14 @@ export default function Selector<T extends FieldValues>(props: Props<T>) {
   );
 
   return (
-    <Listbox value={value} onChange={onChange} as="div" className="relative">
-      <Listbox.Button
-        disabled={props.disabled || isSubmitting}
-        className="flex items-center bg-white text-left rounded-md outline-none border-none w-full px-3 py-2 text-black"
-      >
+    <Listbox
+      disabled={isSubmitting || props.disabled}
+      value={value}
+      onChange={onChange}
+      as="div"
+      className="relative"
+    >
+      <Listbox.Button className="flex items-center bg-zinc-50 disabled:bg-zinc-50/10 text-left rounded-md outline-none border-none w-full px-3 py-2 text-black">
         {({ open }) => (
           <>
             <span>{display}</span>


### PR DESCRIPTION
ClickUp ticket:[ <ticket_link>](https://app.clickup.com/t/3bp550r)

## Explanation of the solution
1. add disabled classes on registration selector
2. add explicit bg and disabled bg on `FormInput`

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
selectors now disabled on submit
![image](https://user-images.githubusercontent.com/89639563/185906302-0bbb1e79-fe5d-4692-a17d-77edc1de0e54.png)


When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
