### PR TITLE
Registration Landing Page: Move max-h-96 from LandingPage container to Section styling

### DIFF
--- a/src/pages/Registration/LandingPage/LandingPage.tsx
+++ b/src/pages/Registration/LandingPage/LandingPage.tsx
@@ -14,7 +14,7 @@ export default function LandingPage() {
   };
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 w-full h-full max-h-96 items-center justify-center">
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 w-full h-full items-center justify-center">
       <Section>
         <Heading>
           Thank you for registering, we'd love to have you on board!
@@ -47,7 +47,7 @@ export default function LandingPage() {
 
 function Section({ children }: PropsWithChildren<{}>) {
   return (
-    <div className="flex flex-col gap-3 items-center justify-center h-full w-full p-4 ring-1 ring-angel-blue rounded-md bg-angel-blue/20">
+    <div className="flex flex-col gap-3 items-center justify-center h-full w-full max-h-96 p-4 ring-1 ring-angel-blue rounded-md bg-angel-blue/20">
       {children}
     </div>
   );


### PR DESCRIPTION
ClickUp ticket: [<ticket_link>](https://app.clickup.com/t/3cjz07x)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to http://localhost:4200/register
- verify Landing page sections appear as usual
- open dev console (click F12 on keyboard)
- reduce screen size to < 1023px
- verify Landing page sections collapse into a column and does not render over the footer

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes

Before:
![image](https://user-images.githubusercontent.com/19427053/187493432-2f6be52c-ca69-44bd-ae0a-816134703fb1.png)

After:
![image](https://user-images.githubusercontent.com/19427053/187493426-6b8bc57c-c90c-49b8-b921-f17c88b70419.png)
