### PR TITLE
RC-v1.6: remove hardcoded NUM_ID

### DIFF
--- a/src/pages/Admin/reviewer/Applications/Table/Application/useProposeStatusChange.ts
+++ b/src/pages/Admin/reviewer/Applications/Table/Application/useProposeStatusChange.ts
@@ -12,7 +12,6 @@ import Registrar from "contracts/Registrar";
 import { cleanObject } from "helpers/admin/cleanObject";
 import { logStatusUpdateProposal } from "./logStatusUpdateProposal";
 
-const NUM_ID = 15; //TODO: get this from ap (not yet present)
 export default function useProposeStatusChange(app: CharityApplication) {
   const dispatch = useSetter();
   const { wallet } = useGetWallet();
@@ -22,7 +21,7 @@ export default function useProposeStatusChange(app: CharityApplication) {
   function updateStatus(status: Extract<EndowmentStatusNum, 1 | 3>) {
     const statusChangePayload: StatusChangePayload = {
       status,
-      endowment_id: NUM_ID,
+      endowment_id: app.EndowmentId,
     };
     const statusWord = status === 1 ? "Approve" : "Reject";
 
@@ -35,7 +34,7 @@ export default function useProposeStatusChange(app: CharityApplication) {
     const statusUpdateMeta: EndowmentStatusMeta = {
       type: "reg_endow_status",
       data: {
-        id: NUM_ID,
+        id: app.EndowmentId,
         fromStatus: "Inactive",
         toStatus: `${status}`,
       },

--- a/src/types/aws/ap/registration.ts
+++ b/src/types/aws/ap/registration.ts
@@ -190,4 +190,5 @@ export type UpdateDocumentationResult = {
 export type CharityApplication = Registration & {
   PK: string;
   poll_id?: number;
+  EndowmentId: number;
 };


### PR DESCRIPTION
ClickUp ticket: <ticket_link>
had to hardcode endowmentId before to test endowment approval

## Explanation of the solution
remove hardcoded endowmentId and replace with one from application record

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
