### PR TITLE
RC-v1.6: TX error too long

### DIFF
--- a/src/components/Receipter/useRequestReceipt.tsx
+++ b/src/components/Receipter/useRequestReceipt.tsx
@@ -26,7 +26,7 @@ export default function useRequestReceipt() {
       updateStage({ step: "initial", kycData: kycData });
       return;
     }
-    const { chainId, txHash } = prevTxDetails;
+    const { txHash } = prevTxDetails;
     updateStage({ step: "submit", message: "Submitting receipt request" });
     const response = await submitRequest(data);
 
@@ -34,8 +34,8 @@ export default function useRequestReceipt() {
       updateStage({
         step: "error",
         message: `Error processing your receipt`,
-        txHash,
-        chainId,
+        //TODO: include Chain in PrevTxDetails
+        //can't show prev tx link with just txHash and chainId, needs Chain
       });
       return;
     }

--- a/src/contracts/Contract.ts
+++ b/src/contracts/Contract.ts
@@ -14,6 +14,7 @@ import {
   isDeliverTxFailure,
 } from "@cosmjs/stargate";
 import { TxOptions } from "slices/transaction/types";
+import { Chain } from "types/aws";
 import { EmbeddedBankMsg, EmbeddedWasmMsg } from "types/contracts";
 import { Dwindow } from "types/ethereum";
 import { WalletState } from "contexts/WalletContext/WalletContext";
@@ -34,6 +35,7 @@ const GAS_PRICE = IS_TEST
 
 // This is the multiplier used when auto-calculating the fees
 // https://github.com/cosmos/cosmjs/blob/5bd6c3922633070dbb0d68dd653dc037efdf3280/packages/stargate/src/signingstargateclient.ts#L290
+const GAS_ADJUSTMENT = 1.3;
 
 export default class Contract {
   wallet: WalletState | undefined;
@@ -62,7 +64,7 @@ export default class Contract {
       msgs,
       undefined
     );
-    return calculateFee(Math.round(gasEstimation * 1.3), GAS_PRICE);
+    return calculateFee(Math.round(gasEstimation * GAS_ADJUSTMENT), GAS_PRICE);
   }
 
   async signAndBroadcast({ msgs, fee }: TxOptions) {
@@ -70,7 +72,7 @@ export default class Contract {
     const { chain_id, rpc_url } = this.wallet!.chain;
     const client = await getKeplrClient(chain_id, rpc_url);
     const result = await client.signAndBroadcast(this.walletAddress, msgs, fee);
-    return validateTransactionSuccess(result, chain_id);
+    return validateTransactionSuccess(result, this.wallet!.chain);
   }
 
   createExecuteContractMsg(
@@ -148,15 +150,14 @@ export default class Contract {
 
 function validateTransactionSuccess(
   result: DeliverTxResponse,
-  chain_id: string
+  chain: Chain
 ): DeliverTxResponse {
   if (isDeliverTxFailure(result)) {
     throw new TxResultFail(
-      chain_id,
-      result.transactionHash,
-      result.height,
-      result.code,
-      result.rawLog
+      //DeliverTxResponse already has a hash, link of tx should be available to user
+      //pass Chain so getTxUrl can get appropriate explorer link
+      chain,
+      result.transactionHash
     );
   }
 

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -1,3 +1,4 @@
+import { Chain } from "types/aws";
 import { EXPECTED_NETWORK_TYPE } from "constants/env";
 
 export const AP_ERROR_DISCRIMINATOR = "AP_ERROR_DISCRIMINATOR";
@@ -93,21 +94,14 @@ export class UnsupportedNetworkError extends APError {
 }
 
 export class TxResultFail extends Error {
-  chainId: string;
+  chain: Chain;
   txHash: string;
-  constructor(
-    chainId: string,
-    txHash: string,
-    height: number,
-    code: number,
-    rawLog?: string
-  ) {
-    super(
-      `Error when broadcasting tx ${txHash} at height ${height}. Code: ${code}; Raw log: ${rawLog}`
-    );
-    this.chainId = chainId;
+  constructor(chain: Chain, txHash: string) {
+    //No need to dump to user technical details of why result failed, a link to failed tx is sufficient
+    super("Failed to broadcast transaction");
+    this.chain = chain;
     this.txHash = txHash;
-    this.name = "TxResultFailt";
+    this.name = "TxResultFail";
   }
 }
 

--- a/src/slices/transaction/handleTxError.ts
+++ b/src/slices/transaction/handleTxError.ts
@@ -32,20 +32,18 @@ export default function handleTxError(error: any, handler: StageUpdater) {
       step: "error",
       message: error.message,
       txHash: error.txHash,
-      chainId: error.chainId,
+      chain: error.chain,
     });
   } else if (error instanceof LogDonationFail) {
     handler({
       step: "error",
       message: error.message,
       txHash: error.txHash,
-      chainId: error.chainId,
     });
   } else if (error instanceof LogApplicationUpdateError) {
     handler({
       step: "error",
       message: error.message,
-      chainId: error.chainId,
     });
   } else if (error instanceof Timeout || error instanceof TimeoutError) {
     handler({ step: "error", message: error.message });

--- a/src/slices/transaction/transactors/sendCosmosDonation.ts
+++ b/src/slices/transaction/transactors/sendCosmosDonation.ts
@@ -75,7 +75,7 @@ export const sendCosmosDonation = createAsyncThunk(
           step: "error",
           message: "Transaction failed",
           txHash: response.transactionHash,
-          chainId: args.wallet.chain.chain_id,
+          chain: args.wallet.chain,
         });
       }
     } catch (err) {

--- a/src/slices/transaction/transactors/sendCosmosTx.ts
+++ b/src/slices/transaction/transactors/sendCosmosTx.ts
@@ -65,7 +65,7 @@ export const sendCosmosTx = createAsyncThunk(
           step: "error",
           message: "Transaction failed",
           txHash: response.transactionHash,
-          chainId: args.wallet.chain.chain_id,
+          chain: args.wallet.chain,
         });
       }
     } catch (err) {

--- a/src/slices/transaction/transactors/sendTerraDonation/sendTerraDonation.ts
+++ b/src/slices/transaction/transactors/sendTerraDonation/sendTerraDonation.ts
@@ -100,7 +100,7 @@ export const sendTerraDonation = createAsyncThunk(
             step: "error",
             message: "Transaction failed",
             txHash: txInfo.txhash,
-            chainId: args.wallet.network.chainID,
+            chain: args.chain,
           });
         }
       }

--- a/src/slices/transaction/types.ts
+++ b/src/slices/transaction/types.ts
@@ -70,9 +70,9 @@ export type SuccessStage = {
 export type ErrorStage = {
   step: "error";
   message: string;
+  //supply these two if want to show tx link
   txHash?: string;
-  chainId?: string;
-  chain?: never;
+  chain?: Chain;
 };
 
 export type KYCStage = {


### PR DESCRIPTION
ClickUp ticket: [<ticket_link>](https://app.clickup.com/t/3cyd9kk)
Tx prompt not displaying link on failed transactions

## Explanation of the solution
add generic message and show failed tx link to user

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## Verification step
in `src/contract/Contract` set `GAS_ADJUSTMENT` to `0.9` to force out of gas tx
donate, should be able to see error
![image](https://user-images.githubusercontent.com/89639563/188054008-15f1832c-a33c-41a7-9d9f-18092cb44f86.png)

