### PR TITLE
Handle Ethereum `ACTION_REJECTED` error on tx rejected

### DIFF
--- a/src/slices/transaction/transactors/sendEthDonation/handleEthError.ts
+++ b/src/slices/transaction/transactors/sendEthDonation/handleEthError.ts
@@ -28,6 +28,12 @@ export default function handleEthError(error: any, handler: StageUpdater) {
         message: "Transaction timed out.",
       });
       break;
+    case errors.ACTION_REJECTED:
+      handler({
+        step: "error",
+        message: "Transaction cancelled.",
+      });
+      break;
     default:
       handler({
         step: "error",


### PR DESCRIPTION

## Explanation of the solution
- handling the error to improve UX

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to some charity profile, e.g. http://localhost:4200/profile/4
- connect Metamask with ETH in it
- start donation process
- once approve/reject tx in MM appears, reject the tx
- verify appropriate message is displayed in a Popup in webapp