### PR TITLE
Endowment admin mobile nav fix

### DIFF
--- a/src/pages/Admin/Charity/index.tsx
+++ b/src/pages/Admin/Charity/index.tsx
@@ -1,13 +1,15 @@
 import { AdminMobileNavPortal } from "App/Header/MobileNav";
+import { useAdminResources } from "../Guard";
 import Nav from "./Nav";
 import Views from "./Views";
 
 export default function Charity() {
+  const { endowmentId } = useAdminResources();
   return (
     <div className="padded-container grid grid-rows-[auto_1fr] pb-4 gap-2">
       <Nav />
       <div className="block md:hidden">
-        <AdminMobileNavPortal id={1} />
+        <AdminMobileNavPortal id={endowmentId} />
       </div>
       <Views />
     </div>


### PR DESCRIPTION
ClickUp ticket: <ticket_link>
clicking links on mobile always goes to `endowmentId: 1`

## Explanation of the solution
remove hardcoded `endowmentId`

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
