### PR TITLE
Add missing apteam admin templates nav 

### DIFF
--- a/src/constants/contracts.ts
+++ b/src/constants/contracts.ts
@@ -30,14 +30,14 @@ export const contracts: Contracts = IS_TEST
 
       // Admin
       cw3ApTeam:
-        "juno1vqwwnmzzgeat62rja9e390fe79aqq56lpamtxcq2c7jzsxxtvwpsc8q5mv",
-      cw4GrpApTeam:
         "juno1ytnpxkfnt2qeynyspwzu7hzlyulpu4far5gtu9xppalg2p4neecsgdthpj",
+      cw4GrpApTeam:
+        "juno1vqwwnmzzgeat62rja9e390fe79aqq56lpamtxcq2c7jzsxxtvwpsc8q5mv",
 
       cw3ReviewTeam:
-        "juno1nn0k4sf330qvzk797y068c9hdy75ng9tg3fzpkmafgrepnqcwk3sh5nqer",
-      cw4GrpReviewTeam:
         "juno1sa3mzc7mg7ndlxz0laph3lnvx2v5uwmn286grgyxqurgrztz02hsnnltmx",
+      cw4GrpReviewTeam:
+        "juno1nn0k4sf330qvzk797y068c9hdy75ng9tg3fzpkmafgrepnqcwk3sh5nqer",
 
       //terraswap
       halo_token: "",

--- a/src/pages/Admin/Core/Templates/Nav.tsx
+++ b/src/pages/Admin/Core/Templates/Nav.tsx
@@ -21,11 +21,6 @@ export default function Nav() {
         Fund transfer
       </NavLink>
 
-      <Category title="Endowment" classes="mt-4" />
-      <NavLink to={routes.acc_endow_status} className={styler}>
-        Change Endowment Status
-      </NavLink>
-
       <Category title="Index fund" classes="mt-4" />
       <NavLink to={routes.if_alliance} className={styler}>
         Edit Alliance List

--- a/src/pages/Admin/Core/Templates/index.tsx
+++ b/src/pages/Admin/Core/Templates/index.tsx
@@ -3,6 +3,7 @@ import { templateRoutes as routes } from "../../constants";
 import Config from "../../templates/cw3/Config";
 import FundSender from "../../templates/cw3/FundSender";
 import Members from "../../templates/cw4/Members";
+import Nav from "./Nav";
 import Alliance from "./index-fund/Alliance";
 import FundConfig from "./index-fund/Config";
 import CreateFund from "./index-fund/CreateFund";
@@ -14,25 +15,28 @@ import RegistrarOwner from "./registrar/Owner";
 
 export default function Templates() {
   return (
-    <Routes>
-      {/** _index-fund */}
-      <Route path={routes.if_alliance} element={<Alliance />} />
-      <Route path={routes.if_create} element={<CreateFund />} />
-      <Route path={routes.if_remove} element={<RemoveFund />} />
-      <Route path={routes.if_members} element={<FundMembers />} />
-      <Route path={routes.if_config} element={<FundConfig />} />
-      <Route path={routes.if_owner} element={<IndexFundOwner />} />
+    <div className="grid gap-2 grid-cols-[auto_1fr]">
+      <Nav />
+      <Routes>
+        {/** _index-fund */}
+        <Route path={routes.if_alliance} element={<Alliance />} />
+        <Route path={routes.if_create} element={<CreateFund />} />
+        <Route path={routes.if_remove} element={<RemoveFund />} />
+        <Route path={routes.if_members} element={<FundMembers />} />
+        <Route path={routes.if_config} element={<FundConfig />} />
+        <Route path={routes.if_owner} element={<IndexFundOwner />} />
 
-      {/** _registrar */}
-      <Route path={routes.reg_config} element={<RegistrarConfig />} />
-      <Route path={routes.reg_owner} element={<RegistrarOwner />} />
+        {/** _registrar */}
+        <Route path={routes.reg_config} element={<RegistrarConfig />} />
+        <Route path={routes.reg_owner} element={<RegistrarOwner />} />
 
-      {/**_cw3 */}
-      <Route path={routes.cw3_config} element={<Config />} />
-      <Route path={routes.cw3_transfer} element={<FundSender />} />
+        {/**_cw3 */}
+        <Route path={routes.cw3_config} element={<Config />} />
+        <Route path={routes.cw3_transfer} element={<FundSender />} />
 
-      {/**_cw4 */}
-      <Route path={routes.cw4_members} element={<Members />} />
-    </Routes>
+        {/**_cw4 */}
+        <Route path={routes.cw4_members} element={<Members />} />
+      </Routes>
+    </div>
   );
 }


### PR DESCRIPTION
ClickUp ticket: <ticket_link>
* overlooked nav missing on previous admin refactor

## Explanation of the solution
* re-add nav
![image](https://user-images.githubusercontent.com/89639563/191153860-8d6ce8ff-c544-4eb2-988d-2e89ff908f60.png)

* remove endow status nav entry (transferred to charity admin nav)
* update contracts to recent

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
