### PR TITLE
all dapp donation msgs use charityIds for now..

### DIFF
--- a/src/slices/transaction/transactors/sendCosmosDonation.ts
+++ b/src/slices/transaction/transactors/sendCosmosDonation.ts
@@ -36,11 +36,7 @@ export const sendCosmosDonation = createAsyncThunk(
         updateStage({ step: "submit", message: "Saving donation details" });
 
         const { receiver, token, amount, split_liq } = args.donateValues;
-
-        const receipient: Receiver =
-          typeof receiver === "string"
-            ? { charityId: receiver }
-            : { fundId: receiver };
+        const receipient: Receiver = { charityId: receiver };
 
         if (typeof receiver !== "undefined") {
           await logDonation({


### PR DESCRIPTION
ClickUp ticket: <ticket_link>

## Explanation of the solution
- all dapp donations should use `charityId`, as there are no `fund` donations from there today. 
- fixes bug where the integer Endowment ID causes the ID to be labeled as `fundId` (due to Fund IDs being integers as well) 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
