### PR TITLE
Overview tab should be active[blue] when profile is first visited

### DIFF
--- a/src/pages/Profile/Content/Tabs/index.tsx
+++ b/src/pages/Profile/Content/Tabs/index.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 import { charityRoutes } from "constants/routes";
 import Endowment from "./Endowment";
 import Overview from "./Overview";
@@ -7,9 +7,12 @@ export default function CharityTabs() {
   //no need to lazy load this small sub pages
   return (
     <Routes>
-      <Route index element={<Overview />} />
+      <Route path={charityRoutes.overview} element={<Overview />} />
       <Route path={charityRoutes.endowment} element={<Endowment />} />
-      <Route path="*" element={<Overview />} />
+      <Route
+        path="*"
+        element={<Navigate replace to={charityRoutes.overview} />}
+      />
     </Routes>
   );
 }


### PR DESCRIPTION
ClickUp ticket: <[ticket_link](https://app.clickup.com/t/3gpjpc9)>

## Explanation of the solution
- made the `Overview` page the default one on Profile

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify navigating to a profile page auto navigates the user to `http://localhost.../profile/{ID}/overview`

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
