### PR TITLE
Show axlUSDC token by default on Endowment tab on Profile page

### DIFF
--- a/src/pages/Profile/Content/Tabs/Endowment/Account/index.tsx
+++ b/src/pages/Profile/Content/Tabs/Endowment/Account/index.tsx
@@ -1,4 +1,5 @@
 import { GenericBalance } from "types/contracts";
+import { coinAsset, denoms } from "constants/currency";
 import Holdings from "./Holdings";
 
 type Locked = {
@@ -21,7 +22,16 @@ export default function Account({ type, balance }: TAcount) {
       </h3>
       {((cw20.length > 0 || native.length > 0) && (
         <Holdings balance={balance} />
-      )) || <p>0.000</p>}
+      )) || (
+        <span className="flex items-center gap-2">
+          <img
+            className="w-6 h-6 object-contain"
+            src={coinAsset[denoms.axlusdc].icon}
+            alt="axlUSDC"
+          />
+          0.000
+        </span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
ClickUp ticket: <[ticket_link](https://app.clickup.com/t/3gpjpcr)>

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- open a profile with zero balances **OR**
- in [/Endowment/index.tsx](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/master/src/pages/Profile/Content/Tabs/Endowment/index.tsx) comment out the `<QueryLoader...>...</QueryLoader>` part and replace with a placeholder like:
```ts
<>
  <Account type="liquid" balance={{ cw20: [], native: [] }} />
  <Account type="locked" balance={{ cw20: [], native: [] }} />
</>
```
and in [/Profile/index.tsx](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/master/src/pages/Profile/index.tsx#L40) comment out the `isLoading`, `isError` etc. checks (lines 51 and 52) and add a default `PROFILE` value to `useEndowmentProfileQuery` result (set `data: profile = PROFILE`) as:
```ts
const PROFILE: ProfileResponse = {
  categories: { general: [0], sdgs: [1] },
  image: "",
  logo: "",
  name: "nsdfa",
  overview: "",
  social_media_urls: {},
  tier: 1,
};
```
- verify `axlUSDC` appears as icon on empty balances

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes

Before:
![image](https://user-images.githubusercontent.com/19427053/192857654-30a051fc-ab7f-46a6-976e-7afd8356f488.png)

After:
![image](https://user-images.githubusercontent.com/19427053/192858350-5504ed31-81cc-4fb4-bac9-05f38e3f609d.png)
