### PR TITLE
account type labels

### DIFF
--- a/src/components/Transactors/Donater/DonateForm/Split.tsx
+++ b/src/components/Transactors/Donater/DonateForm/Split.tsx
@@ -19,14 +19,14 @@ export default function Split() {
           type="liquid"
           border_class="border-angel-blue/80"
           text_class="text-blue-accent uppercase"
-          title="Liquid"
+          title="Current"
           action="Instantly available"
         >
           <Slider />
         </Portion>
       </div>
       <p className="text-xs text-angel-grey text-center">
-        Note: Donations into the endowment provide sustainable financial runaway
+        Note: Donations into the Endowment provide sustainable financial runaway
         and allow your gift to give forever
       </p>
     </div>

--- a/src/pages/Profile/Content/Tabs/Endowment/Account/index.tsx
+++ b/src/pages/Profile/Content/Tabs/Endowment/Account/index.tsx
@@ -18,7 +18,7 @@ export default function Account({ type, balance }: TAcount) {
   return (
     <div className="grid grid-rows-[auto_1fr_auto] rounded-md text-white/80 p-4 border border-zinc-50/20">
       <h3 className="mb-2 text-lg w-full font-bold uppercase flex items-center justify-self-start">
-        <span>{type}</span>
+        <span>{type === "locked" ? "Endowment" : "Current"}</span>
       </h3>
       {((cw20.length > 0 || native.length > 0) && (
         <Holdings balance={balance} />


### PR DESCRIPTION
ClickUp ticket: <ticket_link>

## Explanation of the solution
Fix account balance labels to read correct human wording: 
- Endowment == Locked(backend)
- Current == Liquid(backend)

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
