### PR TITLE
Not Enough Balance to pay for Fees on Donation 

### DIFF
--- a/src/components/Transactors/Donater/DonateForm/useDonate/useEstimator.ts
+++ b/src/components/Transactors/Donater/DonateForm/useDonate/useEstimator.ts
@@ -263,11 +263,11 @@ export default function useEstimator() {
 
           setEVMtx(tx);
         }
-
-        dispatch(setFormLoading(false));
       } catch (err) {
         logger.error(err);
         dispatch(setFormError("tx simulation failed"));
+      } finally {
+        dispatch(setFormLoading(false));
       }
     })();
 


### PR DESCRIPTION
ClickUp ticket: <[ticket_link](https://app.clickup.com/t/3gw321v)>

## Explanation of the solution
Issue seems to have been that when an IBC token was selected for donation, the fee calculation would sum the amount of said token and the fee amount and compare that value to the amount of native currency - causing the form to error out when there was not enough native currency. This happening was a good thing, since the correct calculation would ignore the amount of IBC token selected when calculating if there's enough nat. currency to pay for gas fees.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- connect Keplr wallet
- go to a charity profile page
- click "Donate now" button
- select `$axlUSDC` as the token to donate
- insert amount
- verify fee gets correctly calculated in `$JUNO`
- verify no error appears