### PR TITLE
Fix 'gadiv-2' to 'gap-2'

### DIFF
--- a/src/pages/Admin/Proposal/Content/Preview/common/KeyValue.tsx
+++ b/src/pages/Admin/Proposal/Content/Preview/common/KeyValue.tsx
@@ -6,7 +6,7 @@ export default function KeyValue({
   children,
 }: PropsWithChildren<{}> & { _key: string; _classes?: string }) {
   return (
-    <div className={`flex items-baseline gadiv-2 ${_classes} p-0.5`}>
+    <div className={`flex items-baseline gap-2 ${_classes} p-0.5`}>
       <span className="text-xs font-heading uppercase w-48">{_key}</span>
       {children}
     </div>


### PR DESCRIPTION
Fixes error with a `component KeyValue` css className used
