### PR TITLE
Make index.html non-cacheable

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <!-- Cache control for newer browsers-->
+    <meta
+      http-equiv="Cache-control"
+      content="no-cache, no-store, must-revalidate"
+    />
+    <!-- Cache control for older browsers-->
+    <meta http-equiv="Pragma" content="no-cache" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
ClickUp ticket: <[ticket_link](https://app.clickup.com/t/3gw219c)>

## Explanation of the solution
The most likely culprit for this error occurring is that we are updating the production code often. 

Explanation: the webapp code is broken down into multiple files that the browser reads to display the website to the user. These files contain an entry file (downloaded first) and "chunk" files (basically the website components/pages etc, the entry file downloads them as necessary). When loading the page, the browser tries fetching webapp-related files from the server, but at the same time the production code (and its relevant chunk files) are getting updated to the newest version, causing the browser to be unable to find the required (older) chunk files, thus throwing this error.

This error will most likely continue occurring as long as we are making direct changes to the production code this often and should stop occurring afterwards. 

In the meantime, we can make the browser fetch the newest production code *every time*, so we can make sure to avoid this type of error no matter how often we change the code (or at least make it occur less).

SO issue: https://stackoverflow.com/a/34851492
Chunk load error explanation: https://rollbar.com/blog/javascript-chunk-load-error/#

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
