### PR TITLE
Registration: on `/confirm-email` let user know they can continue the registration without confirming the email immediately

### DIFF
--- a/src/pages/Registration/ConfirmEmail.tsx
+++ b/src/pages/Registration/ConfirmEmail.tsx
@@ -64,10 +64,11 @@ export default function ConfirmEmail() {
             <span>We're waiting for you to confirm your email address.</span>
           </div>
           <span className="font-normal">
-            You can continue to the next registration step, but please note that you will need to verify
-            your email by clicking on the link in the email we've sent you, before the final application submission, in order to be
-            able to register {charity.Registration.CharityName} on Angel
-            Protocol.
+            You can continue to the next registration step, but please note that
+            you will need to verify your email by clicking on the link in the
+            email we've sent you, before the final application submission, in
+            order to be able to register {charity.Registration.CharityName} on
+            Angel Protocol.
           </span>
         </>
       ) : (


### PR DESCRIPTION
ClickUp ticket: <[ticket_link](https://app.clickup.com/t/30cq67z)>

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- start registration process
- verify new message appears on /confirm-email page (if email not verified)
