### PR TITLE
Make header logo navigate to root URL

### DIFF
--- a/src/App/Header/index.tsx
+++ b/src/App/Header/index.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import betaWhiteLogo from "assets/images/angelprotocol-beta-horiz-wht.png";
 import TransactionHint from "components/Transactor/TransactionHint";
 import Airdrop from "components/Transactors/Airdrop/Airdrop";
@@ -8,13 +9,9 @@ import DappMenu from "./Nav";
 export default function Header() {
   return (
     <header className="mb-4 grid grid-cols-[auto_1fr_auto] items-center w-full padded-container pt-3">
-      <a
-        rel="noreferrer"
-        href="https://angelprotocol.io/"
-        title="Go to Marketing page"
-      >
-        <img src={betaWhiteLogo} alt="" className="w-32 sm:w-36" />
-      </a>
+      <Link rel="noreferrer" to="/" title="Go to Marketing page">
+        <img src={betaWhiteLogo} alt="logo" className="w-32 sm:w-36" />
+      </Link>
       <DappMenu />
       <div className="ml-auto grid grid-cols-[auto_1fr_auto]">
         <TransactionHint />


### PR DESCRIPTION
## Explanation of the solution
The logo in question is:
![image](https://user-images.githubusercontent.com/19427053/193754116-0278fc8e-17b8-4c89-a77e-f803864f81a4.png)

Clicking on it when running the app locally would navigate the user to https://app.angelprotocol.io, but the expected root URL would be http://localhost:4200

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify clicking on Logo navigates to root URL, which are:
  - production: https://app.angelprotocol.io
  - test: https://rc-v1-7.dpspevs7tj1ov.amplifyapp.com/
  - local: http://localhost:4200