### PR TITLE
Move error msg inside file dropzone

### DIFF
--- a/src/components/FileDropzone/FileDropzone.tsx
+++ b/src/components/FileDropzone/FileDropzone.tsx
@@ -1,5 +1,6 @@
 import { Controller, FieldValues, useFormContext } from "react-hook-form";
 import { BaseProps, FileWrapper } from "./types";
+import { ErrorMessage } from "pages/Registration/common";
 import Dropzone from "./Dropzone";
 
 export default function FileDropzone<T extends FieldValues>(
@@ -8,22 +9,25 @@ export default function FileDropzone<T extends FieldValues>(
   const { control } = useFormContext<T>();
 
   return (
-    <Controller
-      name={props.name}
-      control={control}
-      render={({ field: { onChange, value } }) => (
-        <Dropzone<T>
-          {...props}
-          value={value}
-          onDrop={(acceptedFiles) => {
-            const files = acceptedFiles.map<FileWrapper>((x) => ({
-              file: x,
-              name: x.name,
-            }));
-            onChange(props.multiple ? files : files[0]);
-          }}
-        />
-      )}
-    />
+    <>
+      <Controller
+        name={props.name}
+        control={control}
+        render={({ field: { onChange, value } }) => (
+          <Dropzone<T>
+            {...props}
+            value={value}
+            onDrop={(acceptedFiles) => {
+              const files = acceptedFiles.map<FileWrapper>((x) => ({
+                file: x,
+                name: x.name,
+              }));
+              onChange(props.multiple ? files : files[0]);
+            }}
+          />
+        )}
+      />
+      <ErrorMessage<T> name={props.name} />
+    </>
   );
 }

--- a/src/pages/Registration/Documentation/Fields/FileDropzones/AuditedFinancialReports.tsx
+++ b/src/pages/Registration/Documentation/Fields/FileDropzones/AuditedFinancialReports.tsx
@@ -1,7 +1,7 @@
 import { useFormContext } from "react-hook-form";
 import { DocumentationValues } from "pages/Registration/types";
 import FileDropzone from "components/FileDropzone";
-import { ErrorMessage, InputRow } from "../../../common";
+import { InputRow } from "../../../common";
 
 export default function AuditedFinancialReport() {
   const {
@@ -19,7 +19,6 @@ export default function AuditedFinancialReport() {
         multiple
         disabled={isSubmitting}
       />
-      <ErrorMessage<DocumentationValues> name="auditedFinancialReports" />
     </InputRow>
   );
 }

--- a/src/pages/Registration/Documentation/Fields/FileDropzones/FinancialStatements.tsx
+++ b/src/pages/Registration/Documentation/Fields/FileDropzones/FinancialStatements.tsx
@@ -1,7 +1,7 @@
 import { useFormContext } from "react-hook-form";
 import { DocumentationValues } from "pages/Registration/types";
 import FileDropzone from "components/FileDropzone";
-import { ErrorMessage, InputRow } from "../../../common";
+import { InputRow } from "../../../common";
 
 export default function FinancialStatements() {
   const {
@@ -19,7 +19,6 @@ export default function FinancialStatements() {
         multiple
         disabled={isSubmitting}
       />
-      <ErrorMessage<DocumentationValues> name="financialStatements" />
     </InputRow>
   );
 }

--- a/src/pages/Registration/Documentation/Fields/FileDropzones/ProofOfIdentity.tsx
+++ b/src/pages/Registration/Documentation/Fields/FileDropzones/ProofOfIdentity.tsx
@@ -4,7 +4,7 @@ import { BsX } from "react-icons/bs";
 import { DocumentationValues } from "pages/Registration/types";
 import { useModalContext } from "contexts/ModalContext";
 import FileDropzone from "components/FileDropzone";
-import { Button, ErrorMessage, InputRow } from "../../../common";
+import { Button, InputRow } from "../../../common";
 
 export default function ProofOfIdentity() {
   const {
@@ -23,7 +23,6 @@ export default function ProofOfIdentity() {
         className="h-8"
         disabled={isSubmitting}
       />
-      <ErrorMessage<DocumentationValues> name="proofOfIdentity" />
     </InputRow>
   );
 }

--- a/src/pages/Registration/Documentation/Fields/FileDropzones/ProofOfRegistration.tsx
+++ b/src/pages/Registration/Documentation/Fields/FileDropzones/ProofOfRegistration.tsx
@@ -1,7 +1,7 @@
 import { useFormContext } from "react-hook-form";
 import { DocumentationValues } from "pages/Registration/types";
 import FileDropzone from "components/FileDropzone";
-import { ErrorMessage, InputRow } from "../../../common";
+import { InputRow } from "../../../common";
 
 export default function ProofOfRegistration() {
   const {
@@ -19,7 +19,6 @@ export default function ProofOfRegistration() {
         className="h-8"
         disabled={isSubmitting}
       />
-      <ErrorMessage<DocumentationValues> name="proofOfRegistration" />
     </InputRow>
   );
 }

--- a/src/pages/Registration/WalletRegistration/RegisteredWallet.tsx
+++ b/src/pages/Registration/WalletRegistration/RegisteredWallet.tsx
@@ -26,7 +26,6 @@ export default function RegisteredWallet(props: { onChange: () => void }) {
           {charity.Metadata.JunoWallet}
         </p>
       </div>
-      {/**TODO: must be disabled at some registration point */}
       <Button
         onClick={props.onChange}
         className="btn-outline-secondary uppercase font-heading text-xs px-2 py-1"

--- a/src/pages/Registration/common/ErrorMessage.tsx
+++ b/src/pages/Registration/common/ErrorMessage.tsx
@@ -8,6 +8,9 @@ import {
 
 type Props<T extends FieldValues> = { name: keyof T & string };
 
+/** TODO: put this component in components/FileDropzone since it's the only one who needs to use this.
+ *  due to files[] errors
+ * Revert other components to using @hookform/<ErrorMessage/>  */
 export function ErrorMessage<T extends FieldValues>(props: Props<T>) {
   const {
     formState: { errors },


### PR DESCRIPTION
ClickUp ticket: [<ticket_link>](https://app.clickup.com/t/30jc53b)

## Explanation of the solution
* move custom `<ErrorMessage/>` inside `FileDropzone`
* remove use of `<ErrorMessage/>` adjacent to `FileDropzone`
* test errors - ok

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
