### PR TITLE
Update cloudflare-ipfs.com -> ipfs.io as gateway provider

### DIFF
--- a/src/helpers/uploadToIpfs.ts
+++ b/src/helpers/uploadToIpfs.ts
@@ -1,7 +1,7 @@
 import { Web3Storage } from "web3.storage";
 
 //https://docs.ipfs.tech/concepts/ipfs-gateway/#gateway-providers
-export const IPFS_GATEWAY = "https://cloudflare-ipfs.com/ipfs"; //public
+export const IPFS_GATEWAY = "https://ipfs.io/ipfs"; //public
 
 export async function uploadToIpfs(file: File): Promise<string> {
   const client = new Web3Storage({


### PR DESCRIPTION

## Explanation of the solution
Image upload to IPFS again failing with `cloudflare-ipfs.com`, but working with `ipfs.io`
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
