### PR TITLE
turn registration links back on

### DIFF
--- a/src/App/Header/MobileNav.tsx
+++ b/src/App/Header/MobileNav.tsx
@@ -51,9 +51,9 @@ function AppLinks() {
       <NavLink to={appRoutes.leaderboard} className={styler}>
         Leaderboard
       </NavLink>
-      {/*<NavLink to={appRoutes.register} className={styler}>
+      <NavLink to={appRoutes.register} className={styler}>
         Register
-      </NavLink>*/}
+      </NavLink>
     </div>
   );
 }

--- a/src/App/Header/Nav.tsx
+++ b/src/App/Header/Nav.tsx
@@ -16,9 +16,9 @@ export default function Nav() {
       <NavLink to={appRoutes.leaderboard} className={styler}>
         Leaderboard
       </NavLink>
-      {/*<NavLink to={appRoutes.register} className={styler}>
+      <NavLink to={appRoutes.register} className={styler}>
         Register
-      </NavLink>*/}
+      </NavLink>
     </nav>
   );
 }

--- a/src/App/__tests__/App.test.tsx
+++ b/src/App/__tests__/App.test.tsx
@@ -74,16 +74,16 @@ describe("App.tsx tests", () => {
       name: /leaderboard/i,
     });
 
-    // const registerLink = await screen.findByRole("link", {
-    //   name: /register/i,
-    // });
+    const registerLink = await screen.findByRole("link", {
+      name: /register/i,
+    });
 
     //view is finally loaded
     expect(await screen.findByText(marketText1)).toBeInTheDocument();
     expect(await screen.findByText(marketText2)).toBeInTheDocument();
     expect(marketplaceLink).toBeInTheDocument();
     expect(leaderboardLink).toBeInTheDocument();
-    // expect(registerLink).toBeInTheDocument();
+    expect(registerLink).toBeInTheDocument();
 
     //user goes to Leaderboard
     userEvent.click(leaderboardLink);
@@ -94,10 +94,10 @@ describe("App.tsx tests", () => {
     ).toBeInTheDocument();
 
     //user goes to Registration
-    // userEvent.click(registerLink);
-    // expect(
-    //   await screen.findByRole("button", { name: /start/i })
-    // ).toBeInTheDocument();
+    userEvent.click(registerLink);
+    expect(
+      await screen.findByRole("button", { name: /start/i })
+    ).toBeInTheDocument();
 
     //user goes to back to Leaderboard
     userEvent.click(leaderboardLink);

--- a/src/pages/Market/Banner.tsx
+++ b/src/pages/Market/Banner.tsx
@@ -21,8 +21,7 @@ export default function Banner() {
             further, connections run deeper, and access is available to all.
           </span>{" "}
           <span className="md:leading-normal xl:leading-relaxed font-bold">
-            Donate below!
-            {/*or{" "}
+            Donate below or{" "}
             <a
               href="https://app.angelprotocol.io/register"
               target="_blank"
@@ -30,7 +29,7 @@ export default function Banner() {
               className="underline"
             >
               register today!
-            </a>*/}
+            </a>
           </span>
         </p>
       </div>


### PR DESCRIPTION
ClickUp ticket: <ticket_link>

## Explanation of the solution
Turns on and adds back in all relevant Registration Portal links, copy & tests. 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp