### PR TITLE
update endowment query to reflect contract refactors

### DIFF
--- a/src/constants/contracts.ts
+++ b/src/constants/contracts.ts
@@ -22,21 +22,21 @@ export const contracts: Contracts = IS_TEST
       //TESTNET CONTRACTS
       //core
       index_fund:
-        "juno107zpvrdyww48d0fylez3lxjf87qwwh8r5nphcdzlwnepnm2kga5q36quta",
+        "juno1jxgswmw6kndcqtp545pt0wn4m2rqunf7mzaxncyguuc9nx2tycgqalxeg6",
       registrar:
-        "juno13ufhg4xjdzylk9mhayc8khmgg25tl2vs42pzala9x53vxa8ppjkschfr0x",
+        "juno1dmry032p0khv2d5knrtf8q5hzcnv06f8ps24naw9hrpv699zw9xqad4jma",
       accounts:
-        "juno1prqanslytzwtrext3qpfy4p83ld7yw04ga06n6yufg53fukf4x0q0udwj2",
+        "juno1ltu4ng2gnm5zs3gnmww89udr0kknd5hlds44lq48guem5xxf4nzsawa9sc",
 
       // Admin
       cw3ApTeam:
-        "juno1pgedpd8m0g76ckxd6fduwpnm6x4g6fzsg0xj4u3xdchvjdxuzckqdhjv9a",
+        "juno189gdk2aczgkx7p0cyll2whah5afazazhmaw4rmfhh7lda2twyrxseq76zw",
       cw4GrpApTeam:
-        "juno13mk4dzwc5qdz7fxcrnkyj448lvap06rp7aw5h34xkcudrm98yv2sz4fysa",
+        "juno1ptpsp2shhyqqesd52gwtj0lele46sl3wp3myvxa46zq3r0g596wsztqvur",
       cw3ReviewTeam:
-        "juno13mlk69qjx2cm8upx3d04h9dxh78mzhfksxrrnuyjk2l5s5wknl8skvkjhp",
+        "juno1dkt5kujyd876wf0xgv3sedsjh6nzlhtdyykaz2e6tmnamzwphryqvaayaj",
       cw4GrpReviewTeam:
-        "juno1h94wjgxv32zsg64f34retxudwd4nppslwm4glvu2jld9vrqh7k6srzjhcj",
+        "juno129g6ldqjnfpgzyxn3lm5yr67r2zl7e35upsrswejdds49q5s60dqnttzx9",
 
       //terraswap
       halo_token: "",

--- a/src/pages/Market/Market.tsx
+++ b/src/pages/Market/Market.tsx
@@ -8,8 +8,7 @@ import Index from "./Index";
 export default function Market() {
   const { data: endowments = {} as CategorizedEndowments, isLoading } =
     useCategorizedEndowmentsQuery({
-      endow_type: "charity",
-      status: "1",
+      limit: 80, // MAX_LIMIT we return per query (at this time)
     });
 
   return (

--- a/src/types/contracts/account.ts
+++ b/src/types/contracts/account.ts
@@ -4,7 +4,6 @@ import {
   Asset,
   Categories,
   EndowmentStatus,
-  EndowmentStatusStrNum,
   EndowmentTier,
   EndowmentType,
   SocialMedialUrls,
@@ -91,12 +90,9 @@ export interface Source {
 }
 
 export type EndowmentQueryOptions = {
-  name?: string;
-  owner?: string;
-  status?: EndowmentStatusStrNum;
-  tier?: EndowmentTier;
-  endow_type?: EndowmentType;
   proposal_link?: number;
+  start_after?: number;
+  limit?: number;
 };
 
 export type EndowmentEntry = {


### PR DESCRIPTION
ClickUp ticket: <ticket_link>

## Explanation of the solution
Accounts contracts were running out of gas on Endowment List queries and needed refactoring. 
New Accounts EndowmentList query supports limits and pagination, taking the following, all optional, arguments:
- limit: number (qty to return [default == 15; max == 80;])
- start_after: number (endow ID)
- proposal_id: number (the only original query arg remaining)

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
None