### PR TITLE
Add cursor-pointer to Dropzone

### DIFF
--- a/src/components/FileDropzone/Dropzone.tsx
+++ b/src/components/FileDropzone/Dropzone.tsx
@@ -23,7 +23,9 @@ export default function Dropzone<T extends FieldValues>(props: Props<T>) {
 
   const className = `flex items-center rounded-md border-none w-full px-2 py-1 text-black ${
     isDragActive ? "bg-blue/50 ring ring-blue" : "bg-white outline-none"
-  } ${props.className} ${props.disabled ? "cursor-default bg-gray/40" : ""}`;
+  } ${props.className} ${
+    props.disabled ? "cursor-default bg-gray/40" : "cursor-pointer"
+  }`;
 
   return (
     <div {...getRootProps({ className })}>


### PR DESCRIPTION

## Explanation of the solution
On hovering over file dropzone the cursor turns into a "typing" cursor instead of a pointer. Fixed this.
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to a page containing a Dropzone (e.g. registration > Documentation)
- verify cursor pointer appears on hover
