### PR TITLE
Admin Resources: Un-serialized errors

### DIFF
--- a/src/pages/Admin/Charity/EditProfile/useEditProfile.ts
+++ b/src/pages/Admin/Charity/EditProfile/useEditProfile.ts
@@ -25,7 +25,7 @@ import { cleanObject, genDiffMeta, getPayloadDiff } from "helpers/admin";
 const PLACEHOLDER_OVERVIEW = "[text]";
 
 export default function useEditProfile() {
-  const { endowmentId, cw3, proposal } = useAdminResources();
+  const { endowmentId, cw3, successLink, successMessage } = useAdminResources();
   const {
     handleSubmit,
     formState: { isSubmitting, isDirty },
@@ -129,7 +129,8 @@ export default function useEditProfile() {
               { type: junoTags.admin, id: adminTags.proposals },
             ]),
           ],
-          ...proposal("Profile update"),
+          successLink,
+          successMessage,
         })
       );
       showModal(TransactionPrompt, {});

--- a/src/pages/Admin/Charity/Templates/account/EndowmentStatus/useUpdateStatus.ts
+++ b/src/pages/Admin/Charity/Templates/account/EndowmentStatus/useUpdateStatus.ts
@@ -22,7 +22,7 @@ import { cleanObject } from "helpers/admin/cleanObject";
 export default function useUpdateStatus() {
   const { handleSubmit } = useFormContext<EndowmentUpdateValues>();
   const dispatch = useSetter();
-  const { cw3, proposal, role } = useAdminResources();
+  const { cw3, role, successLink, successMessage } = useAdminResources();
   const { wallet } = useGetWallet();
   const { showModal } = useModalContext();
 
@@ -105,7 +105,8 @@ export default function useUpdateStatus() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Endowment status update"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPrompt, {});

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/useWithdraw.ts
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/useWithdraw.ts
@@ -22,8 +22,8 @@ export default function useWithdraw() {
     formState: { isValid, isDirty, isSubmitting },
   } = useFormContext<WithdrawValues>();
 
-  const { cw3, endowmentId, endowment, proposal } = useAdminResources();
-  const adminProposal = proposal;
+  const { cw3, endowmentId, endowment, successLink, successMessage } =
+    useAdminResources();
   const { wallet } = useGetWallet();
   const dispatch = useSetter();
 
@@ -75,7 +75,6 @@ export default function useWithdraw() {
           JSON.stringify(meta)
         );
 
-    const prop = adminProposal("Withdraw proposal");
     dispatch(
       sendCosmosTx({
         wallet,
@@ -87,13 +86,14 @@ export default function useWithdraw() {
           ]),
         ],
         //Juno withdrawal
-        ...prop,
+        successLink,
+        successMessage,
         onSuccess: isJuno
           ? undefined //no need to POST to AWS if destination is juno
           : (response) =>
               logWithdrawProposal({
                 res: response,
-                proposalLink: prop.successLink,
+                proposalLink: successLink,
                 wallet: wallet!, //wallet is defined at this point
                 endowment_multisig: cw3,
                 proposal_chain_id: chainIds.juno,

--- a/src/pages/Admin/Core/Templates/index-fund/Alliance/useEditAlliance.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/Alliance/useEditAlliance.ts
@@ -15,7 +15,7 @@ import IndexFund from "contracts/IndexFund";
 
 export default function useEditAlliance() {
   const { trigger, reset, getValues } = useFormContext<AllianceEditValues>();
-  const { proposal, cw3 } = useAdminResources();
+  const { cw3, successLink, successMessage } = useAdminResources();
   const { wallet } = useGetWallet();
   const { members: allianceMembers, isEditingMember } = useGetter(
     (state) => state.admin.allianceMembers
@@ -95,7 +95,8 @@ export default function useEditAlliance() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Alliance member update"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPromp, {});

--- a/src/pages/Admin/Core/Templates/index-fund/Config/useConfigureFund.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/Config/useConfigureFund.ts
@@ -19,7 +19,7 @@ import { cleanObject } from "helpers/admin/cleanObject";
 type Key = keyof FundConfig;
 type Value = FundConfig[Key];
 export default function useConfigureFund() {
-  const { proposal, cw3 } = useAdminResources();
+  const { cw3, successLink, successMessage } = useAdminResources();
   const { wallet } = useGetWallet();
   const {
     handleSubmit,
@@ -74,7 +74,8 @@ export default function useConfigureFund() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Config update"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPrompt, {});

--- a/src/pages/Admin/Core/Templates/index-fund/CreateFund/useCreateFund.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/CreateFund/useCreateFund.ts
@@ -17,7 +17,7 @@ import { cleanObject } from "helpers/admin/cleanObject";
 import { INIT_SPLIT } from ".";
 
 export default function useCreateFund() {
-  const { cw3, proposal } = useAdminResources();
+  const { cw3, successLink, successMessage } = useAdminResources();
   const { wallet } = useGetWallet();
   const { showModal } = useModalContext();
   const dispatch = useSetter();
@@ -96,7 +96,8 @@ export default function useCreateFund() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Create fund"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPrompt, {});

--- a/src/pages/Admin/Core/Templates/index-fund/IndexFundOwner/useUpdateOwner.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/IndexFundOwner/useUpdateOwner.ts
@@ -14,7 +14,7 @@ import CW3 from "contracts/CW3";
 import IndexFund from "contracts/IndexFund";
 
 export default function useUpdateOwner() {
-  const { cw3, proposal } = useAdminResources();
+  const { cw3, successLink, successMessage } = useAdminResources();
   const { wallet } = useGetWallet();
   const {
     handleSubmit,
@@ -58,7 +58,8 @@ export default function useUpdateOwner() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Owner update"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPrompt, {});

--- a/src/pages/Admin/Core/Templates/index-fund/Members/useUpdateFund.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/Members/useUpdateFund.ts
@@ -16,7 +16,7 @@ import IndexFund from "contracts/IndexFund";
 
 export default function useUpdateFund() {
   const { trigger, reset, getValues } = useFormContext<FundUpdateValues>();
-  const { cw3, proposal } = useAdminResources();
+  const { cw3, successLink, successMessage } = useAdminResources();
   const { wallet } = useGetWallet();
   const [isLoading, setIsLoading] = useState(false);
   const fundMembers = useGetter((state) => state.admin.fundMembers);
@@ -89,7 +89,8 @@ export default function useUpdateFund() {
               { type: junoTags.admin, id: adminTags.proposals },
             ]),
           ],
-          ...proposal("Fund member"),
+          successLink,
+          successMessage,
         })
       );
       setIsLoading(false);

--- a/src/pages/Admin/Core/Templates/index-fund/RemoveFund/useDestroyFund.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/RemoveFund/useDestroyFund.ts
@@ -19,7 +19,7 @@ export default function useDestroyFund() {
   } = useFormContext<FundDestroyValues>();
   const dispatch = useSetter();
   const { showModal } = useModalContext();
-  const { cw3, proposal } = useAdminResources();
+  const { cw3, successLink, successMessage } = useAdminResources();
   const { wallet } = useGetWallet();
 
   async function destroyFund(data: FundDestroyValues) {
@@ -56,7 +56,8 @@ export default function useDestroyFund() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Fund deletion"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPrompt, {});

--- a/src/pages/Admin/Core/Templates/registrar/Config/useConfigureRegistrar.ts
+++ b/src/pages/Admin/Core/Templates/registrar/Config/useConfigureRegistrar.ts
@@ -20,7 +20,7 @@ import { cleanObject, genDiffMeta, getPayloadDiff } from "helpers/admin";
 type Key = keyof RegistrarConfigPayload;
 type Value = RegistrarConfigPayload[Key];
 export default function useConfigureRegistrar() {
-  const { cw3, proposal } = useAdminResources();
+  const { cw3, successLink, successMessage } = useAdminResources();
   const { wallet } = useGetWallet();
   const {
     handleSubmit,
@@ -78,7 +78,8 @@ export default function useConfigureRegistrar() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Config update"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPrompt, {});

--- a/src/pages/Admin/Core/Templates/registrar/Owner/useUpdateOwner.ts
+++ b/src/pages/Admin/Core/Templates/registrar/Owner/useUpdateOwner.ts
@@ -13,7 +13,7 @@ import CW3 from "contracts/CW3";
 import Registrar from "contracts/Registrar";
 
 export default function useUpdateOwner() {
-  const { cw3, proposal } = useAdminResources();
+  const { cw3, successLink, successMessage } = useAdminResources();
   const { wallet } = useGetWallet();
   const {
     handleSubmit,
@@ -57,7 +57,8 @@ export default function useUpdateOwner() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Owner update"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPrompt, {});

--- a/src/pages/Admin/templates/cw3/Config/usePropose.ts
+++ b/src/pages/Admin/templates/cw3/Config/usePropose.ts
@@ -20,7 +20,7 @@ type Key = keyof FormCW3Config;
 type Value = FormCW3Config[Key];
 
 export default function usePropose() {
-  const { cw3, proposal } = useAdminResources();
+  const { cw3, successLink, successMessage } = useAdminResources();
   const { wallet } = useGetWallet();
   const {
     getValues,
@@ -80,7 +80,8 @@ export default function usePropose() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Config update"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPrompt, {});

--- a/src/pages/Admin/templates/cw3/FundSender/Form/useTransferFunds.ts
+++ b/src/pages/Admin/templates/cw3/FundSender/Form/useTransferFunds.ts
@@ -23,7 +23,7 @@ export default function useTransferFunds() {
     formState: { isSubmitting, isValid, isDirty },
   } = useFormContext<FundSendValues>();
   const dispatch = useSetter();
-  const { cw3, proposal } = useAdminResources();
+  const { cw3, successLink, successMessage } = useAdminResources();
   //TODO: use wallet token[] to list amounts to transfer
   const { wallet } = useGetWallet();
   const { showModal } = useModalContext();
@@ -83,7 +83,8 @@ export default function useTransferFunds() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Fund transfer"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPrompt, {});

--- a/src/pages/Admin/templates/cw4/Members/useUpdateMembers.ts
+++ b/src/pages/Admin/templates/cw4/Members/useUpdateMembers.ts
@@ -15,7 +15,7 @@ import CW4 from "contracts/CW4";
 
 export default function useUpdateMembers() {
   const { trigger, reset, getValues } = useFormContext<MemberUpdatorValues>();
-  const { cw3, cw4, proposal } = useAdminResources();
+  const { cw3, cw4, successLink, successMessage } = useAdminResources();
   const apCW4Members = useGetter((state) => state.admin.apCW4Members);
   const { wallet } = useGetWallet();
   const { showModal } = useModalContext();
@@ -85,7 +85,8 @@ export default function useUpdateMembers() {
             { type: junoTags.admin, id: adminTags.proposals },
           ]),
         ],
-        ...proposal("Group member update"),
+        successLink,
+        successMessage,
       })
     );
     showModal(TransactionPromp, {});

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,4 +1,4 @@
-import { SendCosmosTxArgs } from "slices/transaction/types";
+import { SendCosmosTxArgs, SuccessLink } from "slices/transaction/types";
 import { Token } from "types/aws";
 import {
   AdminVoteInfo,
@@ -29,11 +29,8 @@ export type AdminResources = {
   endowment: EndowmentDetails;
   cw3config: CW3Config;
   role: AdminRoles;
-  //proposal method to collate proposal resources
-  //use SendCosmosTxArgs types so to just spread it later on fn call
-  proposal(
-    proposalName: string
-  ): Pick<SendCosmosTxArgs, "successMessage" | "successLink">;
+  successLink: SuccessLink;
+  successMessage: string;
 };
 
 export type ProposalDetails = Proposal & {


### PR DESCRIPTION
ClickUp ticket: https://app.clickup.com/t/3kqnfte

## Explanation of the solution
- Simplify this a bit by removing the custom naming inputs for proposals altogether. 
- Use a basic class to handle building the right success link/message when the getAdminResources is called. 
- Switched back to having two "success" items returned from admin resources for use in pages vs adding more complexity needlessly with a wrapper class/function/etc. (A/N: If we need more items to display those modals, then consider using a custom `proposalDisplay` object or something more complex.)

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp