### PR TITLE
Make Logo position part of regular layout (non-absolute)

### DIFF
--- a/src/pages/Profile/Logo.tsx
+++ b/src/pages/Profile/Logo.tsx
@@ -1,32 +1,33 @@
 import Icon from "components/Icon";
 import { useProfileContext } from "./ProfileContext";
 
+const anchorStyle =
+  "flex items-center justify-center w-full h-0 overflow-visible isolate lg:justify-start lg:pl-20";
+
 const logoStyle =
-  "box-border h-40 w-40 sm:h-44 sm:w-44 border border-gray-l2 rounded-full dark:border-bluegray-d1";
+  "box-border h-40 w-40 sm:h-44 sm:w-44 border border-gray-l2 rounded-full object-contain dark:border-bluegray-d1";
 
-type Props = { className?: string };
-
-export default function Logo({ className = "" }: Props) {
+export default function Logo() {
   const { logo } = useProfileContext();
 
   if (!logo) {
     return (
-      <div
-        className={`${logoStyle} ${className} flex items-center justify-center`}
-      >
-        <Icon
-          type="Picture"
-          className="w-9 h-9 bg-blue-l3 text-white dark:bg-blue dark:text-blue-l3"
-        />
+      <div className={anchorStyle}>
+        <div
+          className={`${logoStyle} flex items-center justify-center bg-blue-l3 dark:bg-blue`}
+        >
+          <Icon
+            type="Picture"
+            className="w-9 h-9 bg-blue-l3 text-white dark:bg-blue dark:text-blue-l3"
+          />
+        </div>
       </div>
     );
   }
 
   return (
-    <img
-      className={`${logoStyle} ${className} bg-white object-contain`}
-      alt="logo"
-      src={logo}
-    />
+    <div className={anchorStyle}>
+      <img className={`${logoStyle} bg-white`} alt="logo" src={logo} />
+    </div>
   );
 }

--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -41,11 +41,10 @@ export default function Profile() {
         id: numId,
       }}
     >
-      <section className="flex flex-col items-center isolate relative w-full h-full">
+      <section className="grid grid-rows-[auto_auto_1fr] items-center isolate w-full h-full">
         <Banner />
+        <Logo />
         <Body />
-
-        <Logo className="absolute left-auto top-32 z-10 sm:left-20 sm:top-48" />
       </section>
     </ProfileContext.Provider>
   );


### PR DESCRIPTION
ClickUp ticket: <[ticket_link](https://app.clickup.com/t/3207y53)>

## Explanation of the solution
Made `Logo` always appear at the right height by utilizing:
- a full-width-zero-height component (between `Banner` and `Body` of the page), taking up no physical space but ensuring the correct position of `Logo`
- setting `overflow: visible` on `Logo` ensuring it gets displayed despite the parent component not being visible (previous point)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to profile page e.g. http://localhost:4200/profile/4
- verify Logo has the same position as before on all screen types
