### PR TITLE
Update Profile holding balance format to use precision of 2

### DIFF
--- a/src/pages/Profile/Content/Tabs/Endowment/Account/Holdings.tsx
+++ b/src/pages/Profile/Content/Tabs/Endowment/Account/Holdings.tsx
@@ -29,7 +29,7 @@ function Balance(props: CW20 | Coin) {
         <span>{tokens[id].symbol}</span>
       </div>
 
-      <div className="text-right">{humanize(condense(props.amount), 4)}</div>
+      <div className="text-right">{humanize(condense(props.amount))}</div>
     </Cells>
   );
 }


### PR DESCRIPTION
ClickUp ticket: <[ticket_link](https://app.clickup.com/t/3m8v7qr)>

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- open profile page, e.g. http://localhost:4200/profile/3/endowment
- open "Endowment" tab
- verify balance amounts appear with 2 decimals

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes

Before:
![image](https://user-images.githubusercontent.com/19427053/198530342-7d7e30be-d6ac-4ed5-99eb-bb606d0f5301.png)

After:
![image](https://user-images.githubusercontent.com/19427053/198530625-45f4790e-0b31-463a-a369-424f7e04f78c.png)
