### PR TITLE
Remove bottom border on Profile e Container Header when closed

### DIFF
--- a/src/pages/Profile/Body/GeneralInfo/Content/Container.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/Content/Container.tsx
@@ -27,7 +27,11 @@ function Header(props: {
   onClick: () => void;
 }) {
   return (
-    <div className="flex items-center justify-between px-8 py-5 w-full bg-orange-l5 border-b border-gray-l2 rounded dark:bg-blue-d7 dark:border-bluegray">
+    <div
+      className={`flex items-center justify-between px-8 py-5 w-full bg-orange-l5 border-gray-l2 rounded dark:bg-blue-d7 dark:border-bluegray ${
+        props.isOpen ? "border-b" : ""
+      }`}
+    >
       <span className="font-heading font-bold text-xl">{props.title}</span>
       <button
         onClick={props.onClick}


### PR DESCRIPTION

## Explanation of the solution
[New Figma design](https://www.figma.com/file/sDjoeJ2IFPd9EJ1LI2WMvF/Product-Design?node-id=1257%3A35608) came in, bottom border should be removed from Header when closed.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- open profile page, e.g. http://localhost:4200/profile/4
- close Overview section and verify bottom border no longer appears

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes

Before:
![image](https://user-images.githubusercontent.com/19427053/199242873-944c8bee-5a26-41c3-99ea-126bc78b1cb2.png)

After:
![image](https://user-images.githubusercontent.com/19427053/199242801-621f7979-10ae-4a2d-822f-f8fe8a916922.png)
