### PR TITLE
Master: add leap-wallet

### DIFF
--- a/src/components/InstallWalletPopup.tsx
+++ b/src/components/InstallWalletPopup.tsx
@@ -1,9 +1,11 @@
 import { Dialog } from "@headlessui/react";
-import { ProviderId } from "contexts/WalletContext/types";
+import { WithoutInstallers } from "contexts/WalletContext/types";
 import { WALLET_METADATA } from "contexts/WalletContext/constants";
 import Icon from "./Icon";
 
-export default function InstallWalletPopup(props: { providerId: ProviderId }) {
+export default function InstallWalletPopup(props: {
+  providerId: WithoutInstallers;
+}) {
   const { installUrl, logo, name } = WALLET_METADATA[props.providerId];
 
   return (

--- a/src/components/WalletSuite/WalletSelector/Connector.tsx
+++ b/src/components/WalletSuite/WalletSelector/Connector.tsx
@@ -33,7 +33,7 @@ export default function Connector(props: Connection) {
         <button
           className={`${
             isOpen ? "" : "border-b border-zinc-900/10"
-          } p-2 flex items-center gap-2 w-full items-center`}
+          } p-2 flex items-center gap-2 w-full`}
           onClick={toggle}
         >
           <Logo logo={props.logo} />
@@ -53,7 +53,7 @@ export default function Connector(props: Connection) {
 
   return (
     <Menu.Item
-      className={`group p-2 flex items-center gap-2 w-full items-center ${
+      className={`group p-2 flex items-center gap-2 w-full ${
         props.network ? "" : "border-b last:border-none "
       } border-zinc-900/10`}
       onClick={handleConnect}

--- a/src/contexts/WalletContext/WalletContext.tsx
+++ b/src/contexts/WalletContext/WalletContext.tsx
@@ -122,7 +122,6 @@ export default function WalletContext(props: PropsWithChildren<{}>) {
         break;
       case "xdefi-wallet":
       case "station":
-      case "falcon-wallet":
       case "leap-wallet":
       case "walletconnect":
         disconnectTerra();

--- a/src/contexts/WalletContext/constants.ts
+++ b/src/contexts/WalletContext/constants.ts
@@ -1,16 +1,18 @@
-import { ProviderId } from "./types";
+import { WithoutInstallers } from "./types";
 import { Chain } from "types/aws";
 import tokenLogo from "assets/icons/currencies/token.svg";
 // import binanceWalletIcon from "assets/icons/wallets/binance.png";
 import keplrIcon from "assets/icons/wallets/keplr.png";
 import metamaskIcon from "assets/icons/wallets/metamask.png";
-import terraStationIcon from "assets/icons/wallets/terra-extension.jpg";
-import walletConnectIcon from "assets/icons/wallets/wallet-connect.png";
 import xdefiIcon from "assets/icons/wallets/xdefi.jpg";
 import { EXPECTED_NETWORK_TYPE } from "constants/env";
 
 export const WALLET_METADATA: {
-  [key in ProviderId]: { logo: string; installUrl: string; name: string };
+  [key in WithoutInstallers]: {
+    logo: string;
+    installUrl: string;
+    name: string;
+  };
 } = {
   // "binance-wallet": {
   //   logo: binanceWalletIcon,
@@ -31,32 +33,6 @@ export const WALLET_METADATA: {
     logo: xdefiIcon,
     installUrl: "https://www.xdefi.io/",
     name: "XDEFI",
-  },
-  station: {
-    logo: terraStationIcon,
-    installUrl:
-      "https://chrome.google.com/webstore/detail/terra-station-wallet/aiifbnbfobpmeekipheeijimdpnlpgpp",
-    name: "Terra Station",
-  },
-  "leap-wallet": {
-    logo: "https://leapwallet.io/icon.png",
-    installUrl: "https://www.leapwallet.io/",
-    name: "Leap Wallet",
-  },
-  "falcon-wallet": {
-    logo: "https://api.falconwallet.app/assets/images/falcon-logo.png",
-    installUrl: "https://www.falconwallet.app/",
-    name: "Falcon Wallet",
-  },
-  "bitkeep-wallet": {
-    logo: "https://cdn.bitkeep.vip/u_b_6151d430-ae42-11ec-9c39-b7ca284b7fe4.png",
-    installUrl: "https://bitkeep.com/",
-    name: "Bitkeep Wallet",
-  },
-  walletconnect: {
-    logo: walletConnectIcon,
-    installUrl: "",
-    name: "Wallet Connect",
   },
   keplr: {
     logo: keplrIcon,

--- a/src/contexts/WalletContext/types.ts
+++ b/src/contexts/WalletContext/types.ts
@@ -4,11 +4,14 @@ export type ProviderId =
   | "xdefi-wallet" //xdefi terra provider
   | "xdefi-evm" //xdefi evm provider
   | "leap-wallet"
-  | "falcon-wallet"
-  | "bitkeep-wallet"
   | "station"
   | "walletconnect"
   | "keplr";
+
+export type WithoutInstallers = Exclude<
+  ProviderId,
+  "station" | "walletconnect" | "leap-wallet"
+>;
 
 type Base = {
   logo: string;

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -1,4 +1,4 @@
-import { ProviderId } from "contexts/WalletContext/types";
+import { WithoutInstallers } from "contexts/WalletContext/types";
 import { Chain } from "types/aws";
 import { WALLET_METADATA } from "contexts/WalletContext/constants";
 import { EXPECTED_NETWORK_TYPE } from "constants/env";
@@ -115,8 +115,8 @@ export class TxResultFail extends Error {
 }
 
 export class WalletNotInstalledError extends APError {
-  providerId: ProviderId;
-  constructor(providerId: ProviderId) {
+  providerId: WithoutInstallers;
+  constructor(providerId: WithoutInstallers) {
     super(
       "WalletNotInstalledError",
       `Wallet ${WALLET_METADATA[providerId].name} not installed`


### PR DESCRIPTION
ClickUp ticket: [<ticket_link>](https://app.clickup.com/t/3rcffav)

## Explanation of the solution
* whitelist leap-wallet together with station and wallet connect

## Refactors
* remove bitkeep and falcon from `ProviderId`
* remove hardcoded install URLs of terra related wallets
* use `availableInstallations` instead of hardcoded terra wallet URLs

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
if `leap-wallet` is not installed, clicking this option redirects to install url
<img width="343" alt="Screen Shot 2022-11-07 at 8 09 00 PM" src="https://user-images.githubusercontent.com/89639563/200307860-a903d0a0-2b9a-43c5-91dc-42044024e853.png">

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
