### PR TITLE
Mobile filters: Group heads (like SDG Groups) should be aligned left

### DIFF
--- a/src/pages/Marketplace/Sidebar/common/Drawer.tsx
+++ b/src/pages/Marketplace/Sidebar/common/Drawer.tsx
@@ -10,7 +10,7 @@ export function Drawer({ toggle, isOpen, classes = "", title }: Props) {
   return (
     <button
       onClick={toggle}
-      className={`${classes} focus:outline-none w-full font-heading uppercase text-sm flex items-center justify-between gap-2`}
+      className={`${classes} text-left focus:outline-none w-full font-heading uppercase text-sm flex items-center justify-between gap-2`}
     >
       <span className="text-xs font-semibold">{title}</span>
       <DrawerIcon isOpen={isOpen} size={20} />


### PR DESCRIPTION
ClickUp ticket: [<ticket_link>](https://app.clickup.com/t/3rcffbd)

## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
group heads now left-aligned
<img width="376" alt="Screen Shot 2022-11-08 at 6 24 24 PM" src="https://user-images.githubusercontent.com/89639563/200540803-8547fc0f-4bb9-4e8e-912e-4a17e8f163b4.png">



When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
