### PR TITLE
Add small screen support to generic profile view-holder component

### DIFF
--- a/src/pages/Profile/Body/Body.tsx
+++ b/src/pages/Profile/Body/Body.tsx
@@ -6,12 +6,12 @@ import UrlDonateSection from "./UrlDonateSection";
 export default function Body() {
   return (
     <div className="flex justify-center items-center w-full h-full bg-gray-l5 text-gray-d2 dark:bg-blue-d4 dark:text-white">
-      <div className="padded-container grid gap-8 justify-items-center w-full h-full pt-32 pb-8 lg:grid-rows-[auto_auto_1fr] lg:grid-cols-[auto_auto] lg:justify-items-start lg:items-end lg:gap-16 lg:pt-6 lg:pb-20">
-        <UrlDonateSection className="order-2 lg:order-1 lg:col-span-2" />
+      <div className="padded-container grid gap-8 justify-items-center w-full h-full pt-32 pb-8 xl:grid-rows-[auto_auto_1fr] xl:grid-cols-[auto_auto] xl:justify-items-start xl:items-end xl:gap-16 xl:pt-6 xl:pb-20">
+        <UrlDonateSection className="order-2 xl:order-1 xl:col-span-2" />
 
-        <NameAddressSection className="order-1 lg:order-2 lg:pl-2" />
+        <NameAddressSection className="order-1 xl:order-2 xl:pl-2" />
 
-        <Balances className="order-3 lg:col-span-1 lg:justify-self-end" />
+        <Balances className="order-3 xl:col-span-1 xl:justify-self-end" />
 
         <GeneralInfo className="order-4 xl:col-span-2 w-full h-full" />
       </div>

--- a/src/pages/Profile/Body/GeneralInfo/GeneralInfo.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/GeneralInfo.tsx
@@ -6,7 +6,7 @@ type Props = { className: string };
 export default function GeneralInfo({ className }: Props) {
   return (
     <div
-      className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full xl:grid-rows-1 xl:grid-cols-[1fr_auto]`}
+      className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
     >
       <Content />
       <InfoColumn />

--- a/src/pages/Profile/Body/GeneralInfo/InfoColumn.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/InfoColumn.tsx
@@ -1,6 +1,6 @@
 export default function InfoColumn() {
   return (
-    <div className="w-full xl:w-96 h-[928px] box-border border border-gray-l2 rounded">
+    <div className="w-full lg:w-96 h-[928px] box-border border border-gray-l2 rounded">
       InfoColumn
     </div>
   );

--- a/src/pages/Profile/Body/NameAddressSection.tsx
+++ b/src/pages/Profile/Body/NameAddressSection.tsx
@@ -6,7 +6,7 @@ export default function NameAddressSection(props: { className: string }) {
 
   return (
     <div
-      className={`flex flex-col gap-8 items-center w-full max-w-sm lg:items-start lg:h-full lg:gap-6 ${props.className}`}
+      className={`flex flex-col gap-8 items-center w-full max-w-sm xl:items-start xl:h-full xl:gap-6 ${props.className}`}
     >
       <p className="font-header font-bold text-2xl max-w-[320px] truncate sm:text-3xl">
         {profile.name}

--- a/src/pages/Profile/Body/UrlDonateSection.tsx
+++ b/src/pages/Profile/Body/UrlDonateSection.tsx
@@ -8,7 +8,7 @@ export default function UrlDonateSection({ className }: { className: string }) {
 
   return (
     <div
-      className={`flex flex-col items-center justify-end gap-8 w-full lg:flex-row lg:gap-6 ${className}`}
+      className={`flex flex-col items-center justify-end gap-8 w-full xl:flex-row xl:gap-6 ${className}`}
     >
       {profile.url && (
         <span className="flex items-center justify-center gap-2 w-full font-sans font-medium text-sm sm:w-auto sm:text-base">

--- a/src/pages/Profile/Logo.tsx
+++ b/src/pages/Profile/Logo.tsx
@@ -6,7 +6,7 @@ const logoStyle =
 
 export default function Logo() {
   return (
-    <div className="padded-container flex justify-center items-center w-full overflow-visible h-0 isolate lg:justify-start">
+    <div className="padded-container flex justify-center items-center w-full overflow-visible h-0 isolate xl:justify-start">
       <Image />
     </div>
   );


### PR DESCRIPTION
ClickUp ticket: <[ticket_link](https://app.clickup.com/t/3rcffa5)>

## Explanation of the solution
Updated the UI of profile info section (just below banner and logo) as it looked unpleasant to the eye on `lg`:
![image](https://user-images.githubusercontent.com/19427053/201048107-bf4ab356-a2e3-4c08-bed6-7cc9453330c2.png)
to have similar layout to mobile screen:
![image](https://user-images.githubusercontent.com/19427053/201048238-20fe0ebd-d02a-4cbe-b4a6-6224ae7834d3.png)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to profile page, e.g. http://localhost:4200/profile/4
- verify smaller screens page appearance is as in images below

## UI changes for review

- `>= xl`:
![image](https://user-images.githubusercontent.com/19427053/201046776-2cadc00a-14b7-41cd-90a5-2cb7a0eebd8e.png)

- `< xl`:
![image](https://user-images.githubusercontent.com/19427053/201047097-27bb6583-81fd-4615-a7dd-a5f587c044d9.png)

- `< lg`:
![image](https://user-images.githubusercontent.com/19427053/201047347-4f90356b-d582-430a-87a9-23e651b2336f.png)

- `< md`:
![image](https://user-images.githubusercontent.com/19427053/201047305-4af3231b-037c-4772-8a82-df92bcf753c7.png)

- `< sm`:
![image](https://user-images.githubusercontent.com/19427053/201047426-44ce4f87-93d1-40c7-aa7d-35a27898c097.png)
