### PR TITLE
FIX: ascii restriction problems

### DIFF
--- a/src/components/KYC/schema.ts
+++ b/src/components/KYC/schema.ts
@@ -1,15 +1,14 @@
 import * as Yup from "yup";
 import { FormValues } from "./types";
 import { SchemaShape } from "schemas/types";
-import { asciiSchema } from "schemas/string";
 
 const shape: SchemaShape<FormValues> = {
-  email: asciiSchema.email("email is invalid").required("email is required"),
-  fullName: asciiSchema.required("full name is required."),
-  streetAddress: asciiSchema.required("street address is required"),
-  city: asciiSchema.required("city is required"),
-  zipCode: asciiSchema.required("zipCode is required"),
-  country: asciiSchema.required("country is required"),
+  email: Yup.string().email("email is invalid").required("email is required"),
+  fullName: Yup.string().required("full name is required."),
+  streetAddress: Yup.string().required("street address is required"),
+  city: Yup.string().required("city is required"),
+  zipCode: Yup.string().required("zipCode is required"),
+  country: Yup.string().required("country is required"),
   consent_marketing: Yup.boolean().oneOf([true]),
   consent_tax: Yup.boolean().oneOf([true]),
 };

--- a/src/helpers/toBase64.ts
+++ b/src/helpers/toBase64.ts
@@ -1,3 +1,14 @@
+/**
+ *
+ * @param value object that may contain strings with some [charaters occupying more than one byte](https://developer.mozilla.org/en-US/docs/Web/API/btoa#unicode_strings)
+ * @returns base64 encoded string
+ */
 export function toBase64<T extends object>(value: T): string {
-  return window.btoa(JSON.stringify(value));
+  const encoder = new TextEncoder();
+  /**
+   * convert the string such that each character occupies only one byte
+   * https://developer.mozilla.org/en-US/docs/Web/API/btoa#unicode_strings
+   */
+  const u8a = encoder.encode(JSON.stringify(value));
+  return window.btoa(String.fromCharCode(...Array.from(u8a)));
 }

--- a/src/pages/Admin/Charity/Templates/account/EndowmentStatus/schema.ts
+++ b/src/pages/Admin/Charity/Templates/account/EndowmentStatus/schema.ts
@@ -2,7 +2,7 @@ import * as Yup from "yup";
 import { EndowmentUpdateValues as EPV } from "pages/Admin/types";
 import { SchemaShape } from "schemas/types";
 import { requiredPositiveNumber } from "schemas/number";
-import { asciiSchema, requiredWalletAddr } from "schemas/string";
+import { requiredWalletAddr } from "schemas/string";
 import { proposalShape } from "../../../../constants";
 
 type BeneficiaryType = EPV["beneficiaryType"];
@@ -26,11 +26,11 @@ const genTypeTest =
 const shape: SchemaShape<EPV> = {
   ...proposalShape,
   id: requiredPositiveNumber,
-  beneficiaryType: asciiSchema.required("beneficiary must be selected"),
+  beneficiaryType: Yup.string().required("beneficiary must be selected"),
 
   //beneficiaries
-  wallet: asciiSchema.when(beneficiaryTypeKey, genTypeTest("wallet")),
-  endowmentId: asciiSchema.when(beneficiaryTypeKey, genTypeTest("endowment")),
-  indexFund: asciiSchema.when(beneficiaryTypeKey, genTypeTest("index fund")),
+  wallet: Yup.string().when(beneficiaryTypeKey, genTypeTest("wallet")),
+  endowmentId: Yup.string().when(beneficiaryTypeKey, genTypeTest("endowment")),
+  indexFund: Yup.string().when(beneficiaryTypeKey, genTypeTest("index fund")),
 };
 export const schema = Yup.object(shape);

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/schema.ts
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/schema.ts
@@ -2,7 +2,7 @@ import * as Yup from "yup";
 import { Amount, WithdrawValues as WV } from "./types";
 import { SchemaShape } from "schemas/types";
 import { tokenConstraint } from "schemas/number";
-import { asciiSchema, requiredWalletAddr } from "schemas/string";
+import { requiredWalletAddr } from "schemas/string";
 
 type TVal = Amount["value"];
 type TBal = Amount["balance"];
@@ -16,7 +16,7 @@ const heightKey: keyof WV = "height";
 const amount: SchemaShape<Amount> = {
   value: Yup.lazy((val: TVal) =>
     val === ""
-      ? asciiSchema //required collected on _amount
+      ? Yup.string() //required collected on _amount
       : tokenConstraint.when(balKey, (balance: TBal, schema) =>
           schema.test("balance test", "not enough balance", () => {
             return +balance >= +val; //if false test fails
@@ -28,15 +28,15 @@ const amount: SchemaShape<Amount> = {
 const shape: SchemaShape<WV> = {
   amounts: Yup.array(Yup.object().shape(amount)),
   //test if at least one amount is filled
-  _amounts: asciiSchema.when(amountsKey, (amounts: Amount[], schema) =>
+  _amounts: Yup.string().when(amountsKey, (amounts: Amount[], schema) =>
     schema.test("at least one is filled", "", () =>
       amounts.some((amount) => amount.value !== "")
     )
   ),
-  beneficiary: asciiSchema.when(netKey, (network: TNetwork) =>
+  beneficiary: Yup.string().when(netKey, (network: TNetwork) =>
     requiredWalletAddr(network)
   ),
-  reason: asciiSchema.when(heightKey, (height, schema) =>
+  reason: Yup.string().when(heightKey, (height, schema) =>
     height > 0 ? schema.required("reason required") : schema.optional()
   ),
 };

--- a/src/pages/Admin/Core/Templates/index-fund/Alliance/schema.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/Alliance/schema.ts
@@ -1,18 +1,18 @@
 import * as Yup from "yup";
 import { AllianceEditValues } from "pages/Admin/types";
 import { SchemaShape } from "schemas/types";
-import { asciiSchema, requiredWalletAddr } from "schemas/string";
+import { requiredWalletAddr } from "schemas/string";
 import { proposalShape } from "../../../../constants";
 
 const shape: SchemaShape<AllianceEditValues> = {
   ...proposalShape,
   wallet: requiredWalletAddr(),
-  name: asciiSchema.required("name is required"),
-  logo: asciiSchema
+  name: Yup.string().required("name is required"),
+  logo: Yup.string()
     .nullable()
     .required("logo is required")
     .url("url is invalid"),
-  website: asciiSchema
+  website: Yup.string()
     .nullable()
     .required("website is required")
     .url("url is invalid"),

--- a/src/pages/Admin/Proposal/Voter/schema.ts
+++ b/src/pages/Admin/Proposal/Voter/schema.ts
@@ -1,14 +1,13 @@
 import * as Yup from "yup";
 import { VoteValues as VV } from "./types";
 import { SchemaShape } from "schemas/types";
-import { asciiSchema } from "schemas/string";
 
 type Keys = keyof VV;
 const type: Keys = "type";
 const vote: Keys = "vote";
 
 const shape: SchemaShape<VV> = {
-  reason: asciiSchema.when([vote, type], (...args: any[]) => {
+  reason: Yup.string().when([vote, type], (...args: any[]) => {
     const [vote, type, schema] = args as [VV["vote"], VV["type"], any];
     return type === "application" && vote === "no"
       ? schema.required("reason is required")

--- a/src/pages/Registration/ContactDetails/ContactDetailsForm/contactDetailsSchema.ts
+++ b/src/pages/Registration/ContactDetails/ContactDetailsForm/contactDetailsSchema.ts
@@ -1,33 +1,32 @@
 import * as Yup from "yup";
 import { ContactDetails } from "pages/Registration/types";
 import { SchemaShape } from "schemas/types";
-import { asciiSchema } from "schemas/string";
 
 export const contactInfoShape: SchemaShape<ContactDetails> = {
-  charityName: asciiSchema.required(
+  charityName: Yup.string().required(
     "Please enter the name of your organization."
   ),
-  firstName: asciiSchema.required("Please enter your first name."),
-  lastName: asciiSchema.required("Please enter your last name"),
-  email: asciiSchema
+  firstName: Yup.string().required("Please enter your first name."),
+  lastName: Yup.string().required("Please enter your last name"),
+  email: Yup.string()
     .email("Invalid email format")
     .required("Please enter your email."),
-  goals: asciiSchema.required(
+  goals: Yup.string().required(
     "Please state your goal in working with Angel Protocol."
   ),
   // since selector logic has a default value selected, this error message should never appear
-  role: asciiSchema.required(
+  role: Yup.string().required(
     "Please select your role within your organization."
   ),
-  otherRole: asciiSchema.when("role", {
+  otherRole: Yup.string().when("role", {
     is: "other",
-    then: asciiSchema.required(
+    then: Yup.string().required(
       "Please enter your role within your organization."
     ),
   }),
-  otherReferralMethod: asciiSchema.when("referralMethod", {
+  otherReferralMethod: Yup.string().when("referralMethod", {
     is: "other",
-    then: asciiSchema.required("Please enter your referral method."),
+    then: Yup.string().required("Please enter your referral method."),
   }),
   checkedPolicy: Yup.bool().isTrue("Checkbox must be checked"),
 };

--- a/src/pages/Registration/Documentation/documentationSchema.ts
+++ b/src/pages/Registration/Documentation/documentationSchema.ts
@@ -2,7 +2,6 @@ import * as Yup from "yup";
 import { DocumentationValues } from "pages/Registration/types";
 import { SchemaShape } from "schemas/types";
 import { FileWrapper } from "components/FileDropzone";
-import { asciiSchema } from "schemas/string";
 
 const VALID_MIME_TYPES = [
   "image/jpeg",
@@ -31,7 +30,7 @@ const documentationShape: SchemaShape<DocumentationValues> = {
   proofOfRegistration: FILE_SCHEMA.required("Proof of registration required"),
   financialStatements: Yup.array<FileWrapper>().of(FILE_SCHEMA),
   auditedFinancialReports: Yup.array<FileWrapper>().of(FILE_SCHEMA),
-  website: asciiSchema
+  website: Yup.string()
     .required("Organization website required")
     .url("Must be a valid URL"),
   un_sdg: Yup.number().min(1, "UNSDG must be selected").max(17),

--- a/src/pages/Registration/LandingPage/ResumeForm.tsx
+++ b/src/pages/Registration/LandingPage/ResumeForm.tsx
@@ -8,13 +8,12 @@ import {
   getSavedRegistrationReference,
   storeRegistrationReference,
 } from "helpers";
-import { asciiSchema } from "schemas/string";
 import { Button } from "../common";
 import routes from "../routes";
 
 type ResumeValues = { refer: string };
 const FormInfoSchema = Yup.object().shape({
-  refer: asciiSchema.required("Please enter your registration reference."),
+  refer: Yup.string().required("Please enter your registration reference."),
 });
 
 export default function ResumeForm() {

--- a/src/schemas/string.ts
+++ b/src/schemas/string.ts
@@ -22,18 +22,12 @@ export const requiredWalletAddr = (network: string = chainIds.juno) => {
 
 export const url = Yup.string().url("invalid url").nullable();
 
-export const asciiSchema = Yup.string().matches(
-  /^[\x20-\x7E]+$/,
-  "Only ASCII characters are allowed"
-);
-
 export const stringByteSchema = (
   title: string,
   minBytes: number,
   maxBytes: number
 ) =>
-  asciiSchema
-    .required(`${title} is required`)
+  Yup.string()
     .test(
       "min_length",
       `${title} is too short`,


### PR DESCRIPTION
restricting most fields to allow only ASCII encounters these problems
https://app.clickup.com/t/2y8u6hc
https://app.clickup.com/t/32ddp82
https://app.clickup.com/t/3rxn5n1

## Explanation of the solution
* remove ascii-only restrictions in general 
* keep restrictions on values that futher operations are intended for
  * email - AWS sending email verifications. this is already handled by `Yup.email()` in web-app and `Joi` schema on server
 
![image](https://user-images.githubusercontent.com/89639563/202613882-5448dc1f-3fef-4434-9457-db32c771ba7a.png)

  * contract address - already handled by contract address pattern
  * urls (meant to be clicked on client) - already handled by `Yup.url()`
![image](https://user-images.githubusercontent.com/89639563/202614281-317f79ce-ada9-491b-83d0-ce4e9b232e98.png)


(future) phone number - if would be used to send notif


on-chain texts with no intended operations upon e.g `name`, `street address`, `proposal title` etc. still pose problems when being encoded to `base64` format with `window.btoa`. The solution for this is to simply extend `helpers/toBase64` to be able to encode [multibyte characters](https://developer.mozilla.org/en-US/docs/Web/API/btoa#unicode_strings)


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
