### PR TITLE
[Bug Fix] Added loader logic when charity application submit is initiated

### DIFF
--- a/src/pages/Registration/Dashboard/useSubmit/useSubmit.ts
+++ b/src/pages/Registration/Dashboard/useSubmit/useSubmit.ts
@@ -7,7 +7,7 @@ import { useModalContext } from "contexts/ModalContext";
 import { useGetWallet } from "contexts/WalletContext/WalletContext";
 import TransactionPrompt from "components/Transactor/TransactionPrompt";
 import { useGetter, useSetter } from "store/accessors";
-import { setStage } from "slices/transaction/transactionSlice";
+import { setFormLoading, setStage } from "slices/transaction/transactionSlice";
 import { logger } from "helpers";
 
 export default function useSubmit() {
@@ -23,6 +23,7 @@ export default function useSubmit() {
         dispatch(
           setStage({ step: "submit", message: "Saving endowment proposal" })
         );
+        dispatch(setFormLoading(true));
 
         const postData: SubmitData = {
           PK: charity.ContactPerson.PK!,
@@ -30,6 +31,8 @@ export default function useSubmit() {
         };
 
         const response = await submitApplication(postData);
+
+        dispatch(setFormLoading(false));
 
         if ("error" in response) {
           throw new Error("Request failed");


### PR DESCRIPTION
ClickUp ticket: [3vdvp2f](https://app.clickup.com/t/3vdvp2f)

## Explanation of the solution
There were some application submissions that have duplicate proposals (as well as Discord pings) created. In AWS, it will only create a proposal and Discord ping once per every trigger event. Having multiple trigger means that in the web app there might be a recursive function but this is not the case. The reason users can pass multiple requests is due to the lack of a "loading" event when they click the `Submit` button.

## Instructions on making this work
Create a test application and verify that when the `Submit` button is clicked at the end of the application process, it will change into a `Loader` component and can't be clicked again until the request is finished.

## UI changes for review
No major UI changes.