### PR TITLE
Updated IPFS Gateway from 'ipfs.io' to 'dweb.link'

### DIFF
--- a/src/helpers/uploadToIpfs.ts
+++ b/src/helpers/uploadToIpfs.ts
@@ -1,7 +1,7 @@
 import { Web3Storage } from "web3.storage";
 
 //https://docs.ipfs.tech/concepts/ipfs-gateway/#gateway-providers
-export const IPFS_GATEWAY = "https://ipfs.io/ipfs"; //public
+export const IPFS_GATEWAY = "https://dweb.link/ipfs"; //public
 
 export async function uploadToIpfs(file: File): Promise<string> {
   const client = new Web3Storage({


### PR DESCRIPTION
ClickUp ticket: [37t7a4z](https://app.clickup.com/t/37t7a4z)

## Explanation of the solution
Our charity application admins can not open the uploaded files to IPFS via the `ipfs.io` gateway. Based from this [gateway checker](https://ipfs.github.io/public-gateway-checker/), `ipfs.io` has a warning label on their "Origin" column and that might be why it sometimes works and sometimes does not.

The solution is to use `dweb.link` which is also the default gateway used by the Brave browser. Also from the checker above, it's all green.