### PR TITLE
Fixes for MyEndowment in Wallet dropdown menu

### DIFF
--- a/src/App/WalletSuite/ConnectedWallet/Details/MyEndowment.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/MyEndowment.tsx
@@ -26,18 +26,19 @@ export default function MyEndowment() {
           </span>
           <div className="flex items-center uppercase font-heading font-semibold text-xs underline underline-offset-2 decoration-1 text-orange">
             {/* Will be added once possible to fetch endowment profile by wallet address */}
-            <Link
-              to={""}
-              className="pr-2 border-r border-gray-l2 dark:border-bluegray"
-            >
+            <Link to={""} className="pr-2">
               profile
             </Link>
             <AdminLink
               label="admin"
-              className="px-2 border-r border-gray-l2 dark:border-bluegray"
+              className="px-2 border-l border-gray-l2 dark:border-bluegray"
               id={AP_ID}
             />
-            <AdminLink label="applications" className="pl-2" id={REVIEWER_ID} />
+            <AdminLink
+              label="applications"
+              className="pl-2 border-l border-gray-l2 dark:border-bluegray"
+              id={REVIEWER_ID}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
- show `MyEndowment` section of wallet dropdown only when it exists
- make the borders next to `MyEndowment` links appear on the left side of admin links (as opposed to previous where it was on the right side of `Profile` and `Admin` links, making it trailing if any of the right hand side links does not appear)

This is now fixed (the right border no longer appears):
![image](https://user-images.githubusercontent.com/19427053/205232033-2fdd3bc4-c9f1-4e58-9a54-5e4207214e5f.png)

The border appears between links as before:
![image](https://user-images.githubusercontent.com/19427053/205231754-71300c35-4dc2-4f6c-b48f-a942e7869569.png)
