### PR TITLE
Add a cross icon to close the Kado modal

### DIFF
--- a/src/pages/Donate/Steps/KadoModal.tsx
+++ b/src/pages/Donate/Steps/KadoModal.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from "react";
 import { apesTags, invalidateApesTags } from "services/apes";
 import { useModalContext } from "contexts/ModalContext";
 import { useGetWallet } from "contexts/WalletContext";
+import Icon from "components/Icon";
 import Loader from "components/Loader";
 import { useSetter } from "store/accessors";
 import { logger } from "helpers";
@@ -13,7 +14,7 @@ type KADO_NETWORK_VALUES = "ethereum" | "juno" | "terra";
 export default function KadoModal() {
   const [isLoading, setLoading] = useState(true);
   const dispatch = useSetter();
-  const { onModalClose } = useModalContext();
+  const { onModalClose, closeModal } = useModalContext();
 
   const { wallet } = useGetWallet();
 
@@ -30,7 +31,19 @@ export default function KadoModal() {
     : `&network=${getKadoNetworkValue(wallet.chain.chain_id)}`;
 
   return (
-    <Dialog.Panel className="fixed inset-0 sm:fixed-center z-10 sm:w-[500px] sm:h-[700px] bg-gray-l5 dark:bg-blue-d6 sm:border border-gray-l2 dark:border-bluegray sm:rounded">
+    <Dialog.Panel className="fixed inset-0 sm:fixed-center z-10 flex flex-col sm:w-[500px] sm:h-[700px] bg-gray-l5 dark:bg-blue-d6 sm:border border-gray-l2 dark:border-bluegray sm:rounded">
+      <Dialog.Title
+        as="h3"
+        className="relative w-full pl-4 px-4 sm:px-0 py-4 sm:py-6 bg-orange-l6 border-b border-gray-l2 rounded-t font-heading font-black sm:font-bold sm:text-center text-xl text-orange sm:text-gray-d2 dark:text-white uppercase sm:normal-case dark:bg-blue-d7 dark:border-bluegray"
+      >
+        Buy with Kado
+        <button
+          className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-10 h-10 mr-4 sm:border border-gray-l2 hover:border-gray sm:rounded dark:border-bluegray dark:hover:border-bluegray-d1 text-gray-d2 hover:text-black dark:text-white dark:hover:text-gray"
+          onClick={closeModal}
+        >
+          <Icon type="Close" className="w-8 sm:w-7 h-8 sm:h-7" />
+        </button>
+      </Dialog.Title>
       {isLoading && (
         <Loader
           bgColorClass="bg-blue dark:bg-white"
@@ -42,7 +55,7 @@ export default function KadoModal() {
         src={`https://app.kado.money?apiKey=${process.env.REACT_APP_KADO_API_KEY}&onPayCurrency=USD&onRevCurrency=USDC&onPayAmount=100${onToAddress}&cryptoList=USDC&fiatList=USD${network}&product=BUY`}
         className={`${
           isLoading ? "hidden" : ""
-        } w-full h-full border-none rounded`}
+        } w-full h-full border-none rounded-b`}
         title="Buy with Kado"
         onLoad={handleOnLoad}
       ></iframe>


### PR DESCRIPTION
ClickUp tickets:
https://app.clickup.com/t/3xjeqg2
https://app.clickup.com/t/3xjeqfv

## Explanation of the solution
- added title section + header + close icon

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to profile page, e.g. http://localhost:4200/profile/3
- click "DONATE NOW" btn
- on donate page click `Buy some to make your donation`
- verify title section appears with a working close icon

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
