### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,5 @@ Ticket(s):
 -
 
 ## UI changes for review
+
+When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes


### PR DESCRIPTION
This is a proposal to just slightly update the PR template

## Explanation of the solution
- removing the `<ticket_link>` part has twofold benefits: it is already redundant and it makes it harder to add multiple tickets to a single PR (rare but happens). Just having `ClickUp tickets:` allows for 1 milisecond faster ticket link addition to the PR and allows for multiple tickets to be appended in a list.
- the description under `UI changes for review` is redundant, at this point we all already know when and which images to add here.