### PR TITLE
Kado widget should offer only networks we support (ETH, JUNO, TERRA)

### DIFF
--- a/src/pages/Donate/Steps/KadoModal.tsx
+++ b/src/pages/Donate/Steps/KadoModal.tsx
@@ -54,11 +54,15 @@ function getKadoNetworkValue(chainId: string): KADO_NETWORK_VALUES {
   switch (chainId) {
     // if Binance, just default to ethereum
     case chainIDs.binanceMain:
+    case chainIDs.binanceTest:
     case chainIDs.ethMain:
+    case chainIDs.ethTest:
       return "ethereum";
     case chainIDs.junoMain:
+    case chainIDs.junoTest:
       return "juno";
     case chainIDs.terraMain:
+    case chainIDs.terraTest:
       return "terra";
     default:
       logger.error(`${chainId} is not supported`);


### PR DESCRIPTION
ClickUp ticket: <[ticket_link](https://app.clickup.com/t/3xjeqfy)>

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to profile page, e.g. http://localhost:4200/profile/3
- click "DONATE NOW" btn
- on donate page click `Buy some to make your donation`
- verify only allowed networks are ethereum, terra & juno

## UI changes for review

![image](https://user-images.githubusercontent.com/19427053/205615904-b9359c9b-ef2e-48a7-8365-30fa4227b635.png)
