### PR TITLE
Show all available fiat currencies in Kado iframe

### DIFF
--- a/src/pages/Donate/Steps/KadoModal.tsx
+++ b/src/pages/Donate/Steps/KadoModal.tsx
@@ -52,7 +52,7 @@ export default function KadoModal() {
         />
       )}
       <iframe
-        src={`https://app.kado.money?apiKey=${process.env.REACT_APP_KADO_API_KEY}&onPayCurrency=USD&onRevCurrency=USDC&onPayAmount=100${onToAddress}&cryptoList=USDC&fiatList=USD${network}&product=BUY&networkList=ethereum,juno,terra`}
+        src={`https://app.kado.money?apiKey=${process.env.REACT_APP_KADO_API_KEY}&onPayCurrency=USD&onRevCurrency=USDC&onPayAmount=100${onToAddress}&cryptoList=USDC${network}&product=BUY&networkList=ethereum,juno,terra`}
         className={`${
           isLoading ? "hidden" : ""
         } w-full h-full border-none rounded-b`}


### PR DESCRIPTION
ClickUp ticket: <[ticket_link](https://app.clickup.com/t/3xjeqg0)>

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to profile page, e.g. http://localhost:4200/profile/3
- click "DONATE NOW" btn
- on donate page click `Buy some to make your donation`
- click on currency dropdown
- verify all currencies available on Kado appear (see `fiatList` in [official Kado docs](https://docs.kado.money/kado-ramp-widget/reference/customizing-your-widget/parameters))

## UI changes for review

![image](https://user-images.githubusercontent.com/19427053/205617323-2ff0c622-6d4d-44ec-9685-1b7fc1f1ad13.png)
