### PR TITLE
footer grid spacing

### DIFF
--- a/src/App/Footer/Links.tsx
+++ b/src/App/Footer/Links.tsx
@@ -5,7 +5,7 @@ const linkStyles = "font-body font-semibold text-sm";
 
 export default function Links() {
   return (
-    <div className="grid grid-rows-2 grid-cols-2 gap-6 w-4/5 max-w-[38rem] md:grid-rows-1 md:grid-cols-4 lg:w-full">
+    <div className="grid grid-rows-2 grid-cols-2 gap-4 w-4/5 max-w-[38rem] md:grid-rows-1 md:grid-cols-4 lg:w-full">
       {SECTIONS_DATA.map(({ title, links }) => (
         <div key={title} className="flex flex-col items-start gap-4">
           <h6 className="font-heading font-black text-base uppercase">


### PR DESCRIPTION
ClickUp ticket: https://app.clickup.com/t/3xjeqk6

Footer items in grid need to fit on single line (w/in reason). 

## Explanation of the solution
Grid spacing changed from 6 -> 4. 

## UI changes for review
None