### PR TITLE
Remove unused StdFee import

### DIFF
--- a/src/slices/transaction/types.ts
+++ b/src/slices/transaction/types.ts
@@ -1,5 +1,5 @@
 import { EncodeObject } from "@cosmjs/proto-signing";
-import { DeliverTxResponse, StdFee } from "@cosmjs/stargate";
+import { DeliverTxResponse } from "@cosmjs/stargate";
 import { TransactionRequest } from "@ethersproject/abstract-provider";
 import { AsyncThunkAction, PayloadAction } from "@reduxjs/toolkit";
 import { TagDescription } from "@reduxjs/toolkit/dist/query/endpointDefinitions";


### PR DESCRIPTION

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes