### PR TITLE
Set `Donate` page min height to min-h-[900px] on Desktop

### DIFF
--- a/src/pages/Donate/Steps/index.tsx
+++ b/src/pages/Donate/Steps/index.tsx
@@ -31,7 +31,7 @@ export default function Steps(props: DonationRecipient) {
   );
 
   return (
-    <div className="justify-self-center grid padded-container max-w-[35rem] min-h-[600px]">
+    <div className="justify-self-center grid padded-container max-w-[35rem]">
       {isHeadingShown(state) && (
         <>
           <h3 className="text-center text-3xl font-bold mt-20 leading-snug">

--- a/src/pages/Donate/index.tsx
+++ b/src/pages/Donate/index.tsx
@@ -11,7 +11,7 @@ export default function Donate() {
   const queryState = useEndowInfoQuery(numId, { skip: numId === 0 });
 
   return (
-    <section className="grid content-start w-full font-work pb-20">
+    <section className="grid content-start w-full font-work min-h-screen sm:min-h-[900px] pb-20">
       <div
         style={{
           backgroundImage: `url('${queryState.data?.image || banner}')`,


### PR DESCRIPTION

## Explanation of the solution

Having `min-h-screen` leaves a lot of empty spaces in the bottom part of the page

**Desktop:**
expected:
![image](https://user-images.githubusercontent.com/19427053/205684910-7793794d-d07e-4ff2-ad9d-c515b8f5bbdd.png)

actual:
![image](https://user-images.githubusercontent.com/19427053/205684951-10250794-cef8-4ff0-bd47-46bd47a5a747.png)

**Mobile:**
expected:
![image](https://user-images.githubusercontent.com/19427053/205684715-ddb1e4d1-6e66-4326-942e-bc15018c720f.png)

actual:
![image](https://user-images.githubusercontent.com/19427053/205684686-d3933b8d-484a-47f7-a6ab-53eab91dbfdb.png)

The reason for this is the `Donate/index.tsx > min-h-screen` style, which causes this extra space. Reason for this min height is so that the user would not see both header and footer at the same time, but this isn't really a big deal in most cases, see this Figma example:
![image](https://user-images.githubusercontent.com/19427053/205687047-8fd6929c-09ee-4385-ac58-65ff7a616e13.png)

Since the height of the page content is less than 600px, most users would see both header and footer at the same time, but the UI still looks nice.

To address this, we can leave the `min-h-screen` on mobile, but set it to `min-h-[800px]`

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to http://localhost:4200/donate/3
- verify no extra spaces appear around the page contents
- verify loading screen doesn't have too small a height


## UI changes for review

Desktop:
![image](https://user-images.githubusercontent.com/19427053/205689942-43d4052b-4ead-492e-bce8-fb22fd91c1b4.png)

Smaller screen (larger than mobile):
![image](https://user-images.githubusercontent.com/19427053/205691434-f508cee8-2414-41c7-9cbf-d2bef15e9ba2.png)

Mobile is the same as before.
