### PR TITLE
Update charity withdraw warning wording

### DIFF
--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Form.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Form.tsx
@@ -20,8 +20,10 @@ export default function Form() {
       <Beneficiary classes="mt-6 mb-2" />
       <Warning classes="mt-4 mb-2">
         All withdraws to Ethereum & Binance are processed on a hourly basis by
-        our cross-chain pipelines. The minimum withdrawal for Ethereum & Binance
-        is $20 USDC.
+        our cross-chain pipelines.
+      </Warning>
+      <Warning classes="mb-2">
+        The minimum withdrawal for Ethereum & Binance is $20 USDC.
       </Warning>
       <Warning classes="mb-2">
         We recommend not using crypto exchange addresses for withdrawals. We are


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/33nju06

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- connect Charity 1 wallet
- go to admin page for the charity http://localhost:4200/admin/11
- click on "Withdraw" link on any of the balances
- verify new "$20 USDC limit" sentence appears in the warning section

## UI changes for review

Current:
![image](https://user-images.githubusercontent.com/19427053/206150900-663b8047-62a4-4cd7-9ef1-bfecf07b40c5.png)
Endowment:
![image](https://user-images.githubusercontent.com/19427053/206150776-8a3e0968-1677-4293-a3a6-2088e950be03.png)
