### PR TITLE
RC-v1.7: incorrect split

### DIFF
--- a/src/slices/donation/sendDonation/index.ts
+++ b/src/slices/donation/sendDonation/index.ts
@@ -59,7 +59,7 @@ export const sendDonation = createAsyncThunk<void, DonateArgs>(
           chainName: wallet.chain.chain_name,
           charityName: recipient.name,
           denomination: token.symbol,
-          splitLiq: `${+pctLiquidSplit / 100}`,
+          splitLiq: pctLiquidSplit,
           transactionId: hash,
           transactionDate: new Date().toISOString(),
           walletAddress: wallet.address,


### PR DESCRIPTION
Ticket(s):
https://app.clickup.com/t/865banxmr

aws expects string `"0"-"100"`  but web-app sends `"0.xx" - "1"`

## Explanation of the solution
remove division by 100 before posting to AWS
verified correct now
![image](https://user-images.githubusercontent.com/89639563/208051586-d10ab92e-4af8-42e8-b0d5-ceb49812938b.png)


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes