### PR TITLE
Fix KYC badge appearance for non-KYC endows

### DIFF
--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -24,7 +24,7 @@ export default function Card({
         <p className="bg-orange-l1 text-white font-semibold text-2xs rounded-sm uppercase px-2 py-0.5 font-heading">
           {endow_type === "Charity" ? "Non-profit" : "For-profit"}
         </p>
-        {!kyc_donors_only && <KYCIcon className="ml-auto" />}
+        {kyc_donors_only && <KYCIcon className="ml-auto" />}
         <BookmarkBtn name={name} id={id} logo={logo} />
       </div>
       <Link


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/865banmp2

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify KYC-enabled endowments have the badge, while non-KYC endows do not.
