### PR TITLE
Fix for potential bug: apply `token.decimal` instead of default decimal value

### DIFF
--- a/src/contracts/CW20.ts
+++ b/src/contracts/CW20.ts
@@ -10,21 +10,19 @@ export default class CW20 extends Contract {
     this.address = address;
   }
 
-  createEmbeddedTransferMsg(amount: number, recipient: string) {
+  createEmbeddedTransferMsg(scaledAmount: string, recipient: string) {
     return this.createEmbeddedWasmMsg(this.address, {
       transfer: {
-        //convert to uamount
-        amount: scaleToStr(amount),
+        amount: scaledAmount,
         recipient,
       },
     });
   }
 
-  createTransferMsg(amount: number | string, recipient: string) {
+  createTransferMsg(scaledAmount: string, recipient: string) {
     return this.createExecuteContractMsg(this.address, {
       transfer: {
-        //convert to uamount
-        amount: scaleToStr(amount),
+        amount: scaledAmount,
         recipient,
       },
     });

--- a/src/contracts/Contract.ts
+++ b/src/contracts/Contract.ts
@@ -18,7 +18,7 @@ import { EmbeddedBankMsg, EmbeddedWasmMsg } from "types/contracts";
 import { Dwindow } from "types/ethereum";
 import { TxOptions } from "types/slices";
 import { WalletState } from "contexts/WalletContext";
-import { logger, scaleToStr, toBase64 } from "helpers";
+import { logger, toBase64 } from "helpers";
 import {
   CosmosTxSimulationFail,
   TxResultFail,
@@ -101,7 +101,7 @@ export default class Contract {
   }
 
   createTransferNativeMsg(
-    amount: number | string,
+    scaledAmount: string,
     recipient: string,
     denom = this.wallet!.chain.native_currency.token_id
   ): MsgSendEncodeObject {
@@ -113,7 +113,7 @@ export default class Contract {
         amount: [
           {
             denom,
-            amount: scaleToStr(amount),
+            amount: scaledAmount,
           },
         ],
       },

--- a/src/pages/Admin/templates/cw3/FundSender/Form/useTransferFunds.ts
+++ b/src/pages/Admin/templates/cw3/FundSender/Form/useTransferFunds.ts
@@ -42,7 +42,7 @@ export default function useTransferFunds() {
     const cw20Contract = new CW20(wallet, contracts.halo_token);
     if (data.denom === denoms.halo) {
       embeddedMsg = cw20Contract.createEmbeddedTransferMsg(
-        data.amount,
+        scaleToStr(data.amount), //halo decimals:6
         data.recipient
       );
     } else {


### PR DESCRIPTION
Ticket(s):

erc20 amount is converted to by `parseEther` which assumes decimal is `18`
for cw20, `scaleToStr` with default `6` 

this may not be the case all the time, so it's safe to use `token.decimals` from aws
however, conversions with known tokens like `juno` or `halo` is just okay to default to `6`

## Explanation of the solution
* use `parseUnits(amount, decimals)` instead of `parseEther`
* send/transfer methods for Contract should already receive scaled amount (or just pass the whole token object ? - future  ), except for `Gov` methods which plays around `juno` and `halo` 
* verify correct amounts is computed on transactions
- [x] juno 
- [x] luna 
- [x] astro (cw20)
- [x] eth
- [x] dai (erc20)
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes