### PR TITLE
Deleting registration number doesn't register as `change`

### DIFF
--- a/src/pages/Admin/Charity/EditProfile/schema.ts
+++ b/src/pages/Admin/Charity/EditProfile/schema.ts
@@ -32,7 +32,7 @@ const shape: SchemaShape<ProfileFormValues> = {
   image: fileObj,
   logo: fileObj,
   url: url.required("required"),
-  // registration_number: no need to validate
+  registration_number: requiredString,
   // country_city_origin: no need to validate
   country: Yup.object().shape<SchemaShape<CountryOption>>({
     name: requiredString,

--- a/src/pages/Admin/Charity/EditProfile/useEditProfile.ts
+++ b/src/pages/Admin/Charity/EditProfile/useEditProfile.ts
@@ -31,7 +31,7 @@ export default function useEditProfile() {
   const { endowmentId, cw3, propMeta } = useAdminResources();
   const {
     handleSubmit,
-    formState: { isSubmitting, isDirty, isValid },
+    formState: { isSubmitting, isDirty },
   } = useFormContext<ProfileFormValues>();
   const { wallet } = useGetWallet();
   const dispatch = useSetter();
@@ -121,7 +121,7 @@ export default function useEditProfile() {
 
   return {
     editProfile: handleSubmit(editProfile),
-    isSubmitDisabled: isSubmitting || !isDirty || !isValid,
+    isSubmitDisabled: isSubmitting || !isDirty,
     id: endowmentId,
   };
 }


### PR DESCRIPTION
Ticket(s):
https://app.clickup.com/t/865bdarra

`getPayloadDiff` views field changes from `something` to `nothing ("", undefined, null )` as no change - this intentional to exclude these fields as execute contract payloads. 

## Explanation of the solution
* prevent unsetting of existing fields e.g. if have `registration` or `website` on registration, shoudn't be set to `""` on editing profile but be replaced with something else (would register as diff in the context of validation)

* remove `isValid` restriction on `submit` so user could just click it and be directed to invalid field - rather than it being disabled and user finding in the long form which field is currently invalid.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes