### PR TITLE
HOT FIX: mobile nav `x` button not working

### DIFF
--- a/src/App/Header/MobileNav/Menu/index.tsx
+++ b/src/App/Header/MobileNav/Menu/index.tsx
@@ -1,10 +1,12 @@
 import { Dialog } from "@headlessui/react";
+import { useModalContext } from "contexts/ModalContext";
 import Icon from "components/Icon";
 import Logo from "../../Logo";
 import { adminMobileNavId } from "../constants";
 import Links from "./Links";
 
-export default function Menu({ onClose }: { onClose: () => void }) {
+export default function Menu() {
+  const { closeModal } = useModalContext();
   return (
     <Dialog.Panel
       as="div"
@@ -13,7 +15,7 @@ export default function Menu({ onClose }: { onClose: () => void }) {
       <div className="flex justify-between items-center w-full py-4 padded-container border-b border-gray-l2">
         <Logo />
         <button
-          onClick={onClose}
+          onClick={closeModal}
           className="flex items-center text-white justify-center"
         >
           <Icon type="Close" size={32} />

--- a/src/App/Header/MobileNav/Opener.tsx
+++ b/src/App/Header/MobileNav/Opener.tsx
@@ -6,14 +6,6 @@ import Menu from "./Menu";
 export function Opener({ classes = "" }: { classes?: string }) {
   const { showModal, closeModal, isModalOpen } = useModalContext();
 
-  const handleCloseModal = () => {
-    closeModal();
-  };
-
-  const openMenu = () => {
-    showModal(Menu, { onClose: handleCloseModal });
-  };
-
   useHandleScreenResize(
     (screenSize) => {
       if (screenSize >= SCREEN_LG) {
@@ -27,7 +19,7 @@ export function Opener({ classes = "" }: { classes?: string }) {
 
   return (
     <button
-      onClick={openMenu}
+      onClick={() => showModal(Menu, {})}
       className={`${classes} items-center text-white justify-center`}
     >
       <Icon type="Menu" size={24} />


### PR DESCRIPTION
Ticket(s):
<img width="607" alt="image" src="https://user-images.githubusercontent.com/89639563/210341786-73a45290-48b4-4b7f-8688-ff7cb90e24a2.png">

instead throws error "no open modal to close"
passed `closeModal` have state in context as `undefined` - that is when `Opener` is rendered
and `handleClose` is created, modal is not yet opened thus `undefined` 

## Explanation of the solution
instead of passing `closeModal` let `Menu` access it directly to get latest modal state.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes