### PR TITLE
RC-v1.7: custom success message for edit profile

### DIFF
--- a/src/pages/Admin/Charity/EditProfile/useEditProfile.ts
+++ b/src/pages/Admin/Charity/EditProfile/useEditProfile.ts
@@ -103,10 +103,11 @@ export default function useEditProfile() {
         JSON.stringify(profileUpdateMeta)
       );
 
+      const { successMeta: defaultMeta, willExecute, ...meta } = propMeta;
       await sendTx({
         msgs: [proposalMsg],
-        ...propMeta,
-        successMeta: propMeta.willExecute
+        ...meta,
+        successMeta: willExecute
           ? {
               message: "Profile has been updated!",
               link: {
@@ -114,8 +115,8 @@ export default function useEditProfile() {
                 description: "checkout new changes",
               },
             }
-          : propMeta.successMeta,
-        tagPayloads: getTagPayloads(propMeta.willExecute && "acc_profile"),
+          : defaultMeta,
+        tagPayloads: getTagPayloads(willExecute && "acc_profile"),
       });
     } catch (err) {
       handleError(err);


### PR DESCRIPTION
Ticket(s):
https://app.clickup.com/t/865bdarr2

## Explanation of the solution
apply custom message only when proposal will execute right away
<img width="615" alt="Screenshot 2023-01-05 at 6 27 29 PM" src="https://user-images.githubusercontent.com/89639563/210759676-20f91eee-da4c-43ba-aec6-f0bdf164425a.png">


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes