### PR TITLE
Scroll To Top in the Steps

### DIFF
--- a/src/pages/Donate/Steps/Progress.tsx
+++ b/src/pages/Donate/Steps/Progress.tsx
@@ -1,11 +1,20 @@
+import { useEffect } from "react";
 import { useGetter } from "store/accessors";
+
+const CONTAINER_ID = "steps";
 
 export default function Progress({ classes = "" }: { classes?: string }) {
   const step = useGetter((state) => state.donation.step);
 
+  useEffect(() => {
+    const element = document.getElementById(CONTAINER_ID);
+    element?.scrollIntoView({ behavior: "smooth" });
+  }, [step]);
+
   return (
     <div
       className={`${classes} text-sm mb-10 grid grid-cols-3 justify-items-center gap-2`}
+      id={CONTAINER_ID}
     >
       <p className="text-center">Donation method</p>
       <p className="text-center">Donor details</p>

--- a/src/pages/Donate/Steps/index.tsx
+++ b/src/pages/Donate/Steps/index.tsx
@@ -18,8 +18,6 @@ import Progress from "./Progress";
 import Result from "./Result";
 import Submit from "./Submit";
 
-const CONTAINER_ID = "steps";
-
 export default function Steps(props: DonationRecipient) {
   const { showModal } = useModalContext();
   const state = useGetter((state) => state.donation);
@@ -28,11 +26,6 @@ export default function Steps(props: DonationRecipient) {
   useEffect(() => {
     dispatch(setRecipient(props));
   }, [dispatch, props]);
-
-  useEffect(() => {
-    const element = document.getElementById(CONTAINER_ID);
-    element?.scrollIntoView({ behavior: "smooth" });
-  }, [state.step]);
 
   const handleOpenKado = useCallback(
     () => showModal(KadoModal, {}),
@@ -73,9 +66,7 @@ export default function Steps(props: DonationRecipient) {
         </>
       )}
 
-      <div id={CONTAINER_ID}>
-        <CurrStep {...state} />
-      </div>
+      <CurrStep {...state} />
     </div>
   );
 }


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/865bdarn8

## Video
https://www.loom.com/share/62f022af249a4a2aa9bcbb43178a2bc7

## Explanation of the solution
Added a custom hook "useScrollTo". This hook can receive an HTML element's id as a string and scroll to this id.

## Instructions on making this work
On the make donation page when the first form is submitted the scroll will work from the second page.

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes