### PR TITLE
RC-v1.7.1: remove intermediary filter type

### DIFF
--- a/src/pages/Marketplace/Cards/index.tsx
+++ b/src/pages/Marketplace/Cards/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   updateAWSQueryData,
   useEndowmentsQuery,
@@ -12,13 +13,18 @@ export default function Cards({ classes = "" }: { classes?: string }) {
   const { sdgGroups, endow_types, sort, searchText, kyc_only, tiers } =
     useGetter((state) => state.component.marketFilter);
 
+  const selectedSDGs = useMemo(
+    () => Object.entries(sdgGroups).flatMap(([, members]) => members),
+    [sdgGroups]
+  );
+
   const { isLoading, data, isError, originalArgs } = useEndowmentsQuery({
-    query: searchText,
-    sort,
-    endow_types,
-    tiers,
-    sdgGroups,
-    kyc_only,
+    query: searchText || "matchall",
+    sort: sort ? `${sort.key}+${sort.direction}` : "default",
+    endow_types: endow_types.join(",") || null,
+    tiers: tiers.join(",") || null,
+    sdgs: selectedSDGs.join(",") || 0,
+    kyc_only: kyc_only.join(",") || null,
     start: 0,
   });
 

--- a/src/pages/Marketplace/Toolbar/Sorter.tsx
+++ b/src/pages/Marketplace/Toolbar/Sorter.tsx
@@ -1,7 +1,8 @@
 import { Listbox } from "@headlessui/react";
-import { EndowmentsSortKey, Sort } from "types/aws";
+import { EndowmentsSortKey } from "types/aws";
 import Icon, { DrawerIcon } from "components/Icon";
 import { useGetter, useSetter } from "store/accessors";
+import { Sort } from "slices/components/marketFilter";
 import { setSort } from "slices/components/marketFilter";
 
 type Option = { name: string; key: EndowmentsSortKey };

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -3,7 +3,6 @@ import {
   Endowment,
   EndowmentBookmark,
   EndowmentsQueryParams,
-  EndowmentsQueryRequest,
   PaginatedAWSQueryRes,
   WalletProfile,
 } from "types/aws";
@@ -35,11 +34,10 @@ export const aws = createApi({
   endpoints: (builder) => ({
     endowments: builder.query<
       PaginatedAWSQueryRes<Endowment[]>,
-      EndowmentsQueryRequest
+      EndowmentsQueryParams
     >({
       providesTags: [{ type: awsTags.endowments }],
-      query: (request) => {
-        const params: EndowmentsQueryParams = getParams(request);
+      query: (params) => {
         return { url: `/v2/endowments/${network}`, params };
       },
     }),
@@ -77,23 +75,3 @@ export const {
     updateQueryData: updateAWSQueryData,
   },
 } = aws;
-
-function getParams(paramsObj: EndowmentsQueryRequest): EndowmentsQueryParams {
-  const selectedSDGs = Object.entries(paramsObj.sdgGroups).flatMap(
-    ([, members]) => members
-  );
-
-  const params: EndowmentsQueryParams = {
-    query: paramsObj.query || "matchall",
-    sort: paramsObj.sort
-      ? `${paramsObj.sort.key}+${paramsObj.sort.direction}`
-      : "default",
-    endow_types: paramsObj.endow_types.join(",") || null,
-    tiers: paramsObj.tiers.join(",") || null,
-    sdgs: selectedSDGs.join(",") || 0,
-    kyc_only: paramsObj.kyc_only.join(",") || null,
-    start: paramsObj.start || undefined,
-  };
-
-  return params;
-}

--- a/src/slices/components/marketFilter/constants.ts
+++ b/src/slices/components/marketFilter/constants.ts
@@ -1,5 +1,4 @@
-import { SdgGroups, Sort } from "types/aws";
-import { CapitalizedEndowmentType, EndowmentTier } from "types/contracts";
+import { FilterState, SdgGroups } from "./types";
 import { UNSDG_NUMS } from "types/lists";
 
 export const SDG_GROUPS: {
@@ -39,18 +38,7 @@ export const SDG_GROUPS: {
   },
 ];
 
-type State = {
-  isOpen: boolean;
-  searchText: string;
-  endow_types: CapitalizedEndowmentType[];
-  sort?: Sort;
-  //geography
-  sdgGroups: SdgGroups;
-  kyc_only: boolean[];
-  tiers: Exclude<EndowmentTier, "Level1">[];
-};
-
-export const initialState: State = {
+export const initialState: FilterState = {
   sdgGroups: SDG_GROUPS.reduce(
     (prev, curr) => ({ ...prev, [curr.key]: [...curr.options] }),
     {} as SdgGroups

--- a/src/slices/components/marketFilter/index.ts
+++ b/src/slices/components/marketFilter/index.ts
@@ -1,3 +1,4 @@
 export { default } from "./marketFilter";
 export * from "./marketFilter";
 export { SDG_GROUPS } from "./constants";
+export * from "./types";

--- a/src/slices/components/marketFilter/marketFilter.ts
+++ b/src/slices/components/marketFilter/marketFilter.ts
@@ -1,5 +1,5 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
-import { Sort } from "types/aws";
+import { Sort } from "./types";
 import { CapitalizedEndowmentType } from "types/contracts";
 import { UNSDG_NUMS } from "types/lists";
 import { initialState } from "./constants";

--- a/src/slices/components/marketFilter/types.ts
+++ b/src/slices/components/marketFilter/types.ts
@@ -1,0 +1,17 @@
+import { EndowmentsSortKey, SortDirection } from "types/aws";
+import { CapitalizedEndowmentType, EndowmentTier } from "types/contracts";
+import { UNSDG_NUMS } from "types/lists";
+
+export type Sort = { key: EndowmentsSortKey; direction: SortDirection };
+export type SdgGroups = { [idx: number]: UNSDG_NUMS[] };
+
+export type FilterState = {
+  isOpen: boolean;
+  searchText: string;
+  endow_types: CapitalizedEndowmentType[];
+  sort?: Sort;
+  //geography
+  sdgGroups: SdgGroups;
+  kyc_only: boolean[];
+  tiers: Exclude<EndowmentTier, "Level1">[];
+};

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -5,7 +5,7 @@ import {
   EndowmentTier,
   SocialMedialUrls,
 } from "../../contracts";
-import { NetworkType, UNSDG_NUMS } from "../../lists";
+import { NetworkType } from "../../lists";
 
 /**
  * put all aws/ap definitions here, if big category exist, separate in a file
@@ -40,18 +40,6 @@ export type Endowment = {
 
 export type SortDirection = "asc" | "desc";
 export type EndowmentsSortKey = "name_internal" | "overall";
-export type Sort = { key: EndowmentsSortKey; direction: SortDirection };
-export type SdgGroups = { [idx: number]: UNSDG_NUMS[] };
-
-export type EndowmentsQueryRequest = {
-  query: string; //set to "matchAll" if no search query
-  sort?: Sort;
-  start?: number; //to load next page, set start to ItemCutOff + 1
-  endow_types: CapitalizedEndowmentType[];
-  sdgGroups: SdgGroups;
-  tiers: Exclude<EndowmentTier, "Level1">[]; // "Level1" excluded for now
-  kyc_only: boolean[]; // comma separated boolean values
-};
 
 export type EndowmentsQueryParams = {
   query: string; //set to "matchAll" if no search query


### PR DESCRIPTION
Ticket(s):
related to https://app.clickup.com/t/865bdartf upcoming filter changes

## Explanation of the solution
* instead of `FilterState` > `EndowmentRequest` > `EndowmentParams`, go straight to `FilterState > EndowmentParams`
* remove `getParams` helper and just assign straight to object literal
* remove filter related types from `types/aws`

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes