### PR TITLE
Update constants/chainIds > ethereum on testnet from 42 to 5

### DIFF
--- a/src/constants/chainIds.ts
+++ b/src/constants/chainIds.ts
@@ -4,7 +4,7 @@ import { IS_TEST } from "./env";
 export const chainIds: { [key in Chains]: string } = IS_TEST
   ? {
       binance: "97",
-      ethereum: "42",
+      ethereum: "5",
       juno: "uni-5",
       terra: "pisco-1",
     }


### PR DESCRIPTION
## Explanation of the solution
Fixed from no longer used `chainId: 42` to `chainId: 5` (Goerli)
 
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes