### PR TITLE
RC-v1.7.1: use ethers modules instead of umbrella package

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -14,7 +14,6 @@ module.exports = function override(config, env) {
     crypto: require.resolve("crypto-browserify"),
     stream: require.resolve("stream-browserify"),
     buffer: require.resolve("buffer"),
-    util: require.resolve("util"),
     path: require.resolve("path-browserify"),
     https: require.resolve("https-browserify"),
     http: require.resolve("stream-http"),

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
     "@cosmjs/encoding": "^0.29.0",
     "@cosmjs/proto-signing": "^0.29.0",
     "@cosmjs/stargate": "^0.29.0",
+    "@ethersproject/contracts": "^5.7.0",
+    "@ethersproject/logger": "^5.7.0",
+    "@ethersproject/providers": "^5.7.2",
+    "@ethersproject/units": "^5.7.0",
     "@headlessui/react": "^1.7.4",
     "@hookform/error-message": "^2.0.0",
     "@hookform/resolvers": "^2.9.8",
@@ -62,7 +66,6 @@
     "cropperjs": "^1.5.12",
     "decimal.js": "^10.3.1",
     "ethereum-multicall": "^2.15.0",
-    "ethers": "^5.7.1",
     "is-mobile": "^3.1.1",
     "jsonwebtoken": "^8.5.1",
     "jwt-decode": "^3.1.2",
@@ -122,7 +125,6 @@
     "stream-http": "^3.2.0",
     "typescript": "<4.8.0",
     "url": "^0.11.0",
-    "util": "^0.12.4",
     "web-vitals": "^3.0.2"
   }
 }

--- a/src/constants/chainIds.ts
+++ b/src/constants/chainIds.ts
@@ -4,7 +4,7 @@ import { IS_TEST } from "./env";
 export const chainIds: { [key in Chains]: string } = IS_TEST
   ? {
       binance: "97",
-      ethereum: "42",
+      ethereum: "5",
       juno: "uni-5",
       terra: "pisco-1",
     }

--- a/src/contexts/WalletContext/helpers/checkXdefiPriority.ts
+++ b/src/contexts/WalletContext/helpers/checkXdefiPriority.ts
@@ -1,7 +1,7 @@
 import { Dwindow } from "types/ethereum";
 import { WalletError, WalletNotInstalledError } from "errors/errors";
 
-export default function checkXdefiPriority() {
+export function checkXdefiPriority() {
   const dwindow = window as Dwindow;
   if (!dwindow?.xfi) {
     throw new WalletNotInstalledError("xdefi-wallet");

--- a/src/contexts/WalletContext/helpers/index.ts
+++ b/src/contexts/WalletContext/helpers/index.ts
@@ -1,0 +1,3 @@
+export * from "./checkXdefiPriority";
+export * from "./prefActions";
+export * from "./toPrefixedHex";

--- a/src/contexts/WalletContext/helpers/toPrefixedHex.ts
+++ b/src/contexts/WalletContext/helpers/toPrefixedHex.ts
@@ -1,4 +1,4 @@
-export default function toPrefixedHex(value: number | string) {
+export function toPrefixedHex(value: number | string) {
   const num = Number(value);
   if (isNaN(num)) {
     throw new Error(`${value} is not a number`);

--- a/src/contexts/WalletContext/hooks/useAddEthereumChain.ts
+++ b/src/contexts/WalletContext/hooks/useAddEthereumChain.ts
@@ -3,7 +3,7 @@ import { InjectedProvider } from "types/ethereum";
 import { useLazyChainQuery } from "services/apes";
 import { WalletError } from "errors/errors";
 import { EIPMethods } from "constants/ethereum";
-import toPrefixedHex from "../helpers/toPrefixedHex";
+import { toPrefixedHex } from "../helpers";
 
 export function useAddEthereumChain() {
   const [getChain] = useLazyChainQuery();

--- a/src/contexts/WalletContext/useInjectedProvider.ts
+++ b/src/contexts/WalletContext/useInjectedProvider.ts
@@ -1,3 +1,4 @@
+import { formatUnits } from "@ethersproject/units";
 import { useCallback, useEffect, useState } from "react";
 import { Connection, ProviderId, ProviderInfo } from "./types";
 import { BaseChain } from "types/aws";
@@ -18,9 +19,12 @@ import {
 import { chainIDs } from "constants/chains";
 import { EIPMethods } from "constants/ethereum";
 import { WALLET_METADATA } from "./constants";
-import checkXdefiPriority from "./helpers/checkXdefiPriority";
-import { retrieveUserAction, saveUserAction } from "./helpers/prefActions";
-import toPrefixedHex from "./helpers/toPrefixedHex";
+import {
+  checkXdefiPriority,
+  retrieveUserAction,
+  saveUserAction,
+  toPrefixedHex,
+} from "./helpers";
 import { useAddEthereumChain } from "./hooks";
 
 const CHAIN_NOT_ADDED_CODE = 4902;
@@ -59,7 +63,7 @@ export default function useInjectedProvider(
 
   /** event handlers */
   const handleChainChange: ChainChangeHandler = (hexChainId) => {
-    setChainId(`${parseInt(hexChainId, 16)}`);
+    setChainId(formatUnits(hexChainId, 0));
   };
 
   //useful when user changes account internally via metamask
@@ -104,7 +108,7 @@ export default function useInjectedProvider(
           method: EIPMethods.eth_chainId,
         });
 
-        const parsedChainId = `${parseInt(hexChainId, 16)}`;
+        const parsedChainId = formatUnits(hexChainId, 0);
         verifyChainSupported(parsedChainId);
         setAddress(accounts[0]);
         setChainId(parsedChainId);

--- a/src/contexts/WalletContext/useKeplr/useKeplr.ts
+++ b/src/contexts/WalletContext/useKeplr/useKeplr.ts
@@ -10,7 +10,7 @@ import {
 import { chainIDs } from "constants/chains";
 import { IS_TEST } from "constants/env";
 import { WALLET_METADATA } from "../constants";
-import { retrieveUserAction, saveUserAction } from "../helpers/prefActions";
+import { retrieveUserAction, saveUserAction } from "../helpers";
 import { juno_test_chain_info } from "./chains";
 
 const SUPPORTED_CHAINS: BaseChain[] = IS_TEST

--- a/src/services/apes/helpers/fetchBalances.ts
+++ b/src/services/apes/helpers/fetchBalances.ts
@@ -1,6 +1,6 @@
 import { Coin } from "@cosmjs/proto-signing";
-import { ethers } from "ethers";
-import { formatUnits } from "ethers/lib/utils";
+import { JsonRpcProvider } from "@ethersproject/providers";
+import { formatUnits } from "@ethersproject/units";
 import { BalMap } from "./types";
 import { FetchedChain, Token, TokenWithBalance } from "types/aws";
 import { queryContract } from "services/juno/queryContract";
@@ -75,7 +75,7 @@ export async function fetchBalances(
   } else {
     /**fetch balances for ethereum */
     const native = tokens.natives[0]; //evm chains have only one gas token
-    const jsonProvider = new ethers.providers.JsonRpcProvider(chain.rpc_url);
+    const jsonProvider = new JsonRpcProvider(chain.rpc_url);
     const [nativeBal, erc20s] = await Promise.allSettled([
       jsonProvider.getBalance(address),
       getERC20Holdings(chain.rpc_url, address, tokens.alts),

--- a/src/services/apes/helpers/getERC20Holdings.ts
+++ b/src/services/apes/helpers/getERC20Holdings.ts
@@ -1,7 +1,7 @@
+import { formatUnits } from "@ethersproject/units";
 import ERC20Abi from "abi/ERC20.json";
 import { Multicall } from "ethereum-multicall";
 import { CallContext } from "ethereum-multicall/dist/esm/models";
-import { formatUnits } from "ethers/lib/utils";
 import { BalMap } from "./types";
 import { Token } from "types/aws";
 

--- a/src/slices/donation/sendDonation/handleEthError.ts
+++ b/src/slices/donation/sendDonation/handleEthError.ts
@@ -1,4 +1,4 @@
-import { errors } from "ethers";
+import { ErrorCode as errors } from "@ethersproject/logger";
 import { logger } from "helpers";
 
 /** TODO: use this with sendDonation */

--- a/src/slices/donation/sendDonation/index.ts
+++ b/src/slices/donation/sendDonation/index.ts
@@ -1,7 +1,7 @@
-import { TransactionResponse } from "@ethersproject/abstract-provider";
+import { Contract as EVMContract } from "@ethersproject/contracts";
+import { TransactionResponse, Web3Provider } from "@ethersproject/providers";
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import ERC20Abi from "abi/ERC20.json";
-import { ethers } from "ethers";
 import { EstimatedTx, TxStatus } from "../types";
 import { DonateArgs } from "../types";
 import { KYCData } from "types/aws";
@@ -97,15 +97,13 @@ async function sendTransaction(
     }
     //evm donations
     default: {
-      const provider = new ethers.providers.Web3Provider(
-        getProvider(wallet.providerId) as any
-      );
+      const provider = new Web3Provider(getProvider(wallet.providerId) as any);
       const signer = provider.getSigner();
       let response: TransactionResponse;
       if (wallet.chain.native_currency.token_id === token.token_id) {
         response = await signer.sendTransaction(tx.val);
       } else {
-        const ER20Contract: any = new ethers.Contract(
+        const ER20Contract: any = new EVMContract(
           token.token_id,
           ERC20Abi,
           signer

--- a/src/slices/donation/types.ts
+++ b/src/slices/donation/types.ts
@@ -1,4 +1,4 @@
-import { TransactionRequest } from "@ethersproject/abstract-provider";
+import { TransactionRequest } from "@ethersproject/providers";
 import { CreateTxOptions } from "@terra-money/terra.js";
 import { ConnectedWallet } from "@terra-money/wallet-provider";
 import { CountryOption } from "services/types";

--- a/src/types/ethereum.ts
+++ b/src/types/ethereum.ts
@@ -1,4 +1,3 @@
-import { ethers } from "ethers";
 import { Keplr } from "@keplr-wallet/types";
 
 export interface Dwindow extends Window {
@@ -10,8 +9,6 @@ export interface Dwindow extends Window {
   BinanceChain?: any;
   keplr?: Keplr;
 }
-
-export interface Web3Provider extends ethers.providers.Web3Provider {}
 
 /*** EIP1193 spec https://eips.ethereum.org/EIPS/eip-1193*/
 interface RequestArguments {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,7 +2392,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/contracts@npm:5.7.0":
+"@ethersproject/contracts@npm:5.7.0, @ethersproject/contracts@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/contracts@npm:5.7.0"
   dependencies:
@@ -2494,15 +2494,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/networks@npm:5.7.1":
-  version: 5.7.1
-  resolution: "@ethersproject/networks@npm:5.7.1"
-  dependencies:
-    "@ethersproject/logger": ^5.7.0
-  checksum: 0339f312304c17d9a0adce550edb825d4d2c8c9468c1634c44172c67a9ed256f594da62c4cda5c3837a0f28b7fabc03aca9b492f68ff1fdad337ee861b27bd5d
-  languageName: node
-  linkType: hard
-
 "@ethersproject/pbkdf2@npm:5.7.0, @ethersproject/pbkdf2@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/pbkdf2@npm:5.7.0"
@@ -2550,9 +2541,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/providers@npm:5.7.1":
-  version: 5.7.1
-  resolution: "@ethersproject/providers@npm:5.7.1"
+"@ethersproject/providers@npm:^5.7.2":
+  version: 5.7.2
+  resolution: "@ethersproject/providers@npm:5.7.2"
   dependencies:
     "@ethersproject/abstract-provider": ^5.7.0
     "@ethersproject/abstract-signer": ^5.7.0
@@ -2574,7 +2565,7 @@ __metadata:
     "@ethersproject/web": ^5.7.0
     bech32: 1.1.4
     ws: 7.4.6
-  checksum: 673745e967e7215b46b7d3024f5ee02be975d6cf66b605f87a0e5beaa349d6d30c987165f98eceddaf7996f64a1ec414f0715f25fc3458aead6eea4c4820c399
+  checksum: 1754c731a5ca6782ae9677f4a9cd8b6246c4ef21a966c9a01b133750f3c578431ec43ec254e699969c4a0f87e84463ded50f96b415600aabd37d2056aee58c19
   languageName: node
   linkType: hard
 
@@ -2665,7 +2656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/units@npm:5.7.0":
+"@ethersproject/units@npm:5.7.0, @ethersproject/units@npm:^5.7.0":
   version: 5.7.0
   resolution: "@ethersproject/units@npm:5.7.0"
   dependencies:
@@ -2709,19 +2700,6 @@ __metadata:
     "@ethersproject/properties": ^5.7.0
     "@ethersproject/strings": ^5.7.0
   checksum: 9d4ca82f8b1295bbc1c59d58cb351641802d2f70f4b7d523fc726f51b0615296da6d6585dee5749b4d5e4a6a9af6d6650d46fe562d5b04f43a0af5c7f7f4a77e
-  languageName: node
-  linkType: hard
-
-"@ethersproject/web@npm:5.7.1":
-  version: 5.7.1
-  resolution: "@ethersproject/web@npm:5.7.1"
-  dependencies:
-    "@ethersproject/base64": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: 7028c47103f82fd2e2c197ce0eecfacaa9180ffeec7de7845b1f4f9b19d84081b7a48227aaddde05a4aaa526af574a9a0ce01cc0fc75e3e371f84b38b5b16b2b
   languageName: node
   linkType: hard
 
@@ -5618,6 +5596,10 @@ __metadata:
     "@cosmjs/encoding": ^0.29.0
     "@cosmjs/proto-signing": ^0.29.0
     "@cosmjs/stargate": ^0.29.0
+    "@ethersproject/contracts": ^5.7.0
+    "@ethersproject/logger": ^5.7.0
+    "@ethersproject/providers": ^5.7.2
+    "@ethersproject/units": ^5.7.0
     "@headlessui/react": ^1.7.4
     "@hookform/error-message": ^2.0.0
     "@hookform/resolvers": ^2.9.8
@@ -5657,7 +5639,6 @@ __metadata:
     eslint-config-prettier: ^8.6.0
     eslint-plugin-prettier: ^4.2.1
     ethereum-multicall: ^2.15.0
-    ethers: ^5.7.1
     https-browserify: ^1.0.0
     is-mobile: ^3.1.1
     jsonwebtoken: ^8.5.1
@@ -5684,7 +5665,6 @@ __metadata:
     stream-http: ^3.2.0
     typescript: <4.8.0
     url: ^0.11.0
-    util: ^0.12.4
     web-vitals: ^3.0.2
     web3.storage: ^4.3.0
     yup: ^0.32.9
@@ -9489,44 +9469,6 @@ __metadata:
     "@ethersproject/web": 5.7.0
     "@ethersproject/wordlists": 5.7.0
   checksum: 03b16c194e035a25c0c522b81f5bb9d2157f9389db3227066ff3bbf0bd348218a25b576a5293078b61885bd2be6871e1da8232cf5351ce72de1189c89e4d05c7
-  languageName: node
-  linkType: hard
-
-"ethers@npm:^5.7.1":
-  version: 5.7.1
-  resolution: "ethers@npm:5.7.1"
-  dependencies:
-    "@ethersproject/abi": 5.7.0
-    "@ethersproject/abstract-provider": 5.7.0
-    "@ethersproject/abstract-signer": 5.7.0
-    "@ethersproject/address": 5.7.0
-    "@ethersproject/base64": 5.7.0
-    "@ethersproject/basex": 5.7.0
-    "@ethersproject/bignumber": 5.7.0
-    "@ethersproject/bytes": 5.7.0
-    "@ethersproject/constants": 5.7.0
-    "@ethersproject/contracts": 5.7.0
-    "@ethersproject/hash": 5.7.0
-    "@ethersproject/hdnode": 5.7.0
-    "@ethersproject/json-wallets": 5.7.0
-    "@ethersproject/keccak256": 5.7.0
-    "@ethersproject/logger": 5.7.0
-    "@ethersproject/networks": 5.7.1
-    "@ethersproject/pbkdf2": 5.7.0
-    "@ethersproject/properties": 5.7.0
-    "@ethersproject/providers": 5.7.1
-    "@ethersproject/random": 5.7.0
-    "@ethersproject/rlp": 5.7.0
-    "@ethersproject/sha2": 5.7.0
-    "@ethersproject/signing-key": 5.7.0
-    "@ethersproject/solidity": 5.7.0
-    "@ethersproject/strings": 5.7.0
-    "@ethersproject/transactions": 5.7.0
-    "@ethersproject/units": 5.7.0
-    "@ethersproject/wallet": 5.7.0
-    "@ethersproject/web": 5.7.1
-    "@ethersproject/wordlists": 5.7.0
-  checksum: 7a61b7a105c41f9fec327887414f1950dc27bfa2d12fe29a068419eaaa3d415e6a12275685c87f700abd88c3b639ae79c09a2f90edea1e69edc8126cb0dce708
   languageName: node
   linkType: hard
 
@@ -18800,7 +18742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util@npm:^0.12.3, util@npm:^0.12.4":
+"util@npm:^0.12.3":
   version: 0.12.4
   resolution: "util@npm:0.12.4"
   dependencies:


### PR DESCRIPTION
Ticket(s):

* to remove dependence to `util` polyfill from modules we don't use
* hopefully in the future we would just depend on `@ethersproject/abi` (for interacting with contracts ) and use plain `EIP-1193` specs

## Explanation of the solution
* install individual modules
* update ethers consumers

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes