### PR TITLE
Fix: donate page is scrolled when visiting for the first time

### DIFF
--- a/src/pages/Donate/Steps/Progress.tsx
+++ b/src/pages/Donate/Steps/Progress.tsx
@@ -1,20 +1,11 @@
-import { useEffect } from "react";
 import { useGetter } from "store/accessors";
-
-const CONTAINER_ID = "steps";
 
 export default function Progress({ classes = "" }: { classes?: string }) {
   const step = useGetter((state) => state.donation.step);
 
-  useEffect(() => {
-    const element = document.getElementById(CONTAINER_ID);
-    element?.scrollIntoView({ behavior: "smooth" });
-  }, [step]);
-
   return (
     <div
       className={`${classes} text-sm mb-10 grid grid-cols-3 justify-items-center gap-2`}
-      id={CONTAINER_ID}
     >
       <p className="text-center">Donation method</p>
       <p className="text-center">Donor details</p>

--- a/src/pages/Donate/Steps/index.tsx
+++ b/src/pages/Donate/Steps/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useModalContext } from "contexts/ModalContext";
 import { useGetWallet } from "contexts/WalletContext";
 import Breadcrumbs from "components/Breadcrumbs";
@@ -32,8 +32,23 @@ export default function Steps(props: DonationRecipient) {
     [showModal]
   );
 
+  const CONTAINER_ID = "__container_id";
+  const prevStep = useRef(state.step);
+  useEffect(() => {
+    /** at first visit, equal so no scrolling happens
+     * on next or back, would be different
+     */
+    if (state.step === prevStep.current) return;
+    const element = document.getElementById(CONTAINER_ID);
+    element?.scrollIntoView();
+    prevStep.current = state.step;
+  }, [state.step]);
+
   return (
-    <div className="justify-self-center grid padded-container max-w-[35rem] py-8 sm:py-20">
+    <div
+      className="justify-self-center grid padded-container max-w-[35rem] py-8 sm:py-20 scroll-mt-6"
+      id={CONTAINER_ID}
+    >
       <Breadcrumbs
         className="font-body font-normal text-sm justify-self-start sm:justify-self-auto mb-10 sm:mb-12"
         items={[


### PR DESCRIPTION
Ticket(s):
* #1599
* scrolled on first visit
* donation info not shown
<img width="844" alt="Screenshot 2023-01-12 at 8 34 36 PM" src="https://user-images.githubusercontent.com/89639563/212071947-cc5682ae-b039-4403-800c-abd704bb45fc.png">


## Explanation of the solution
* track page using `ref` to ensure only scrolled on page changes (not on first visit)
* make top level container the element to scroll to instead of `<ProgressIndicator/>` which umounts on `Result` step. 


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes