### PR TITLE
Gray out checkbox label on disabled

### DIFF
--- a/src/components/CheckboxFormField.tsx
+++ b/src/components/CheckboxFormField.tsx
@@ -18,7 +18,7 @@ export default function CheckboxFormField<T extends FieldValues>({
 }: PropsWithChildren<{
   name: Path<T>;
   classes?: Classes;
-  disabled?: true;
+  disabled?: boolean;
   required?: boolean;
 }>) {
   const {

--- a/src/pages/AIF/WidgetConfigurer/WidgetUrlGenerator/WidgetUrlGenerator.tsx
+++ b/src/pages/AIF/WidgetConfigurer/WidgetUrlGenerator/WidgetUrlGenerator.tsx
@@ -31,11 +31,13 @@ export default function WidgetUrlGenerator({ endowId, onChange }: Props) {
           Hide "advanced options"
         </CheckboxFormField>
 
-        {!hideAdvancedOptions && (
-          <CheckboxFormField<FormValues> name="unfoldAdvancedOptions">
-            Unfold "advanced options" by default
-          </CheckboxFormField>
-        )}
+        <CheckboxFormField<FormValues>
+          name="unfoldAdvancedOptions"
+          disabled={hideAdvancedOptions}
+          classes={{ label: "peer-disabled:text-gray" }}
+        >
+          Unfold "advanced options" by default
+        </CheckboxFormField>
 
         <span>Define split value by default:</span>
         <Split />


### PR DESCRIPTION

## Explanation of the solution
Grayed out checkbox when disabled is better UX than suddenly hiding the field.
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- connect Charity 1 wallet
- go to http://localhost:4200/aif/11/widget
- check the `hide "advanced options"` checkbox
- verify `unfold "advanced options" by default` gets grayed out and disabled (as opposed to getting hidden as was previously).

## UI changes for review

![image](https://user-images.githubusercontent.com/19427053/212691932-aaacf6be-012b-4567-a47f-048d3e32c739.png)

If it was previously checked:
![image](https://user-images.githubusercontent.com/19427053/212692005-45cc9374-9bf1-435e-afb2-dfe37cb09c08.png)
But the generated URL still excludes the "unfold..." param:
![image](https://user-images.githubusercontent.com/19427053/212692079-85bdec00-d622-4715-819a-853fa9852b9b.png)
