### PR TITLE
Add full iframe for widget url

### DIFF
--- a/src/pages/AIF/WidgetConfigurer/WidgetConfigurer.tsx
+++ b/src/pages/AIF/WidgetConfigurer/WidgetConfigurer.tsx
@@ -8,9 +8,15 @@ const TITLE_STYLE = "text-lg sm:text-2xl font-heading font-bold";
 
 export default function WidgetConfigurer() {
   const { id } = useParams<{ id: string }>();
-  const [widgetUrl, setWidgetUrl] = useState("");
+  const [widgetSnippet, setWidgetSnippet] = useState("");
 
-  const handleOnUrlChange = useCallback((url: string) => setWidgetUrl(url), []);
+  const handleOnUrlChange = useCallback(
+    (url: string) =>
+      setWidgetSnippet(
+        `<iframe src="${url}" width="700" height="900" style="border: 0px;"></iframe>`
+      ),
+    []
+  );
 
   return (
     <div className="padded-container grid grid-rows-[auto_1fr] gap-10 w-full h-full">
@@ -49,9 +55,12 @@ export default function WidgetConfigurer() {
           <h2 className={`${TITLE_STYLE} mt-10`}>Copy / paste this URL:</h2>
           <div className="flex items-center justify-center gap-4 h-32 px-10 rounded bg-gray-l3 dark:bg-blue-d4">
             <span className="w-full text-sm sm:text-base font-mono break-all">
-              {widgetUrl}
+              {widgetSnippet}
             </span>
-            <Copier classes="w-10 h-10 hover:text-orange" text={widgetUrl} />
+            <Copier
+              classes="w-10 h-10 hover:text-orange"
+              text={widgetSnippet}
+            />
           </div>
         </section>
       </div>


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/8669b9cj3

## Explanation of the solution
Waiting on https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/1639

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- open http://localhost:4200/aif/11/widget
- configure widget URL (check random checkboxes)
- verify whole iframe snippet with url changes
- verify Copier copies the whole snippet