### PR TITLE
giftcard linked added to footer

### DIFF
--- a/src/App/Footer/constants.ts
+++ b/src/App/Footer/constants.ts
@@ -76,6 +76,10 @@ export const SECTIONS_DATA: Section[] = [
         text: "For CSR Partners",
         href: "https://angelprotocol.io/csr-partners/",
       },
+      {
+        text: "For Giftcards",
+        href: "https://app.angelprotocol.io/gift/purchase",
+      },
     ],
   },
   {


### PR DESCRIPTION
Ticket(s):
- N/A

## Explanation of the solution
Add link to giftcards in footer (marketing Wordpress site will mirror this in their footer). 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
