### PR TITLE
RC-v1.7.1 : hq and acitivity countries filter wiring

### DIFF
--- a/src/pages/Marketplace/Cards/index.tsx
+++ b/src/pages/Marketplace/Cards/index.tsx
@@ -10,12 +10,29 @@ import Card from "./Card";
 
 export default function Cards({ classes = "" }: { classes?: string }) {
   const dispatch = useSetter();
-  const { sdgGroups, endow_types, sort, searchText, kyc_only, tiers } =
+  const { sdgGroups, endow_types, sort, searchText, kyc_only, tiers, region } =
     useGetter((state) => state.component.marketFilter);
 
   const selectedSDGs = useMemo(
     () => Object.entries(sdgGroups).flatMap(([, members]) => members),
     [sdgGroups]
+  );
+
+  const { activities, headquarters } = region;
+  const hqCountries = useMemo(
+    () =>
+      Object.entries(headquarters)
+        .flatMap(([, countries]) => (countries ? countries : []))
+        .join(","),
+    [headquarters]
+  );
+
+  const activityCountries = useMemo(
+    () =>
+      Object.entries(activities)
+        .flatMap(([, countries]) => (countries ? countries : []))
+        .join(","),
+    [activities]
   );
 
   const { isLoading, data, isError, originalArgs } = useEndowmentsQuery({
@@ -25,6 +42,8 @@ export default function Cards({ classes = "" }: { classes?: string }) {
     tiers: tiers.join(",") || null,
     sdgs: selectedSDGs.join(",") || 0,
     kyc_only: kyc_only.join(",") || null,
+    ...(hqCountries ? { hq_country: hqCountries } : {}),
+    ...(activityCountries ? { active_in_countries: activityCountries } : {}),
     start: 0,
   });
 

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -75,6 +75,8 @@ export type EndowmentsQueryParams = {
   sdgs: string | 0; // comma separated sdg values. The backend recognizes "0" as "no SDG was selected"
   tiers: string | null; // comma separated Exclude<EndowmentTier, "Level1"> values ("Level1" excluded for now)
   kyc_only: string | null; // comma separated boolean values
+  hq_country?: string; //comma separated values
+  active_in_countries?: string; //comma separated values
 };
 
 export interface LeaderboardEntry {


### PR DESCRIPTION
Ticket(s):
https://app.clickup.com/t/865bhavhp - active countries
https://app.clickup.com/t/865bhavhq - hq 



## Explanation of the solution
* append this to db profile works since it uses `v3/endowments endpoint` where some fields are depracated
* add fields to query params

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes