### PR TITLE
RC-v1.7.1: remove unused css

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -92,21 +92,6 @@
   .box-delay-2 {
     animation-delay: 600ms;
   }
-
-  .img-no-drag {
-    -webkit-user-drag: none;
-    -khtml-user-drag: none;
-    -moz-user-drag: none;
-    -o-user-drag: none;
-  }
-
-  .scroll-hidden {
-    -ms-overflow-style: none; /* for Internet Explorer, Edge */
-    scrollbar-width: none;
-  }
-  .scroll-hidden::-webkit-scrollbar {
-    display: none; /* for Chrome, Safari, and Opera */
-  }
 }
 
 @layer base {


### PR DESCRIPTION
Ticket(s): N/A: refactor


## Explanation of the solution
* classes from old admin forms design
* classes related to `react-select` (removed)
* classes from very old LP swap (also removed)
* btn-outline used in old registration pages
* classes from old marketplace scroller cards

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes