### PR TITLE
RC-v1.7.1: border and divide common utilities

### DIFF
--- a/src/App/WalletSuite/ConnectedWallet/Details/Address.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/Address.tsx
@@ -2,7 +2,7 @@ import Copier from "components/Copier";
 
 export default function Address({ value }: { value: string }) {
   return (
-    <div className="flex items-center justify-between w-full gap-2 p-4 pl-3 bg-gray-l4 dark:bg-bluegray-d1 border border-gray-l2 dark:border-bluegray rounded">
+    <div className="flex items-center justify-between w-full gap-2 p-4 pl-3 bg-gray-l4 dark:bg-bluegray-d1 border border-prim rounded">
       <span className="max-w-[70vw] sm:w-56 font-body font-normal text-sm truncate hover:cursor-default">
         {value}
       </span>

--- a/src/App/WalletSuite/ConnectedWallet/Details/AdminLinks.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/AdminLinks.tsx
@@ -28,7 +28,7 @@ export default function AdminLinks(props: WalletState) {
   if (isLoading || !isApMember || !isReviewMember) return null;
 
   return (
-    <div className="grid p-4 gap-3 border-b border-gray-l2 dark:border-bluegray">
+    <div className="grid p-4 gap-3 border-b border-prim">
       <h3 className="font-heading font-bold text-sm text-gray-d1 dark:text-gray">
         Platform Administration
       </h3>
@@ -44,7 +44,7 @@ export default function AdminLinks(props: WalletState) {
         {isReviewMember && (
           <Link
             to={`${appRoutes.admin}/${REVIEWER_ID}`}
-            className="pl-2 border-l border-gray-l2 dark:border-bluegray text-orange hover:text-orange-l2 decoration-1 hover:decoration-2"
+            className="pl-2 border-l border-prim text-orange hover:text-orange-l2 decoration-1 hover:decoration-2"
           >
             applications
           </Link>

--- a/src/App/WalletSuite/ConnectedWallet/Details/Balances/CoinBalances.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/Balances/CoinBalances.tsx
@@ -47,7 +47,7 @@ export default function CoinBalances({ smallAmountsHidden, tokens }: Props) {
                 type="Giftcard"
                 className="text-green w-4 h-4 inline-block mr-0.5 relative bottom-px"
               />
-              <span className="font-normal text-xs border-r border-gray-l2 dark:border-bluegray pr-1">
+              <span className="font-normal text-xs border-r border-prim pr-1">
                 {humanize(t.gift, 3, true)}
               </span>
             </>
@@ -55,9 +55,7 @@ export default function CoinBalances({ smallAmountsHidden, tokens }: Props) {
           <span className="ml-1">{humanize(t.balance, 3, true)}</span>
         </div>
       ))}
-      {!isEmpty(filtered) && (
-        <div className="border-t border-gray-l2 dark:border-bluegray" />
-      )}
+      {!isEmpty(filtered) && <div className="border-t border-prim" />}
     </>
   );
 }

--- a/src/App/WalletSuite/ConnectedWallet/Details/ChainSelector.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/ChainSelector.tsx
@@ -29,7 +29,7 @@ export default function ChainSelector(props: WalletState) {
       className="relative"
     >
       <Listbox.Button
-        className={`${SELECTOR_STYLE} border border-gray-l2 dark:border-bluegray rounded`}
+        className={`${SELECTOR_STYLE} border border-prim rounded`}
       >
         {({ open }) => (
           <>
@@ -42,7 +42,7 @@ export default function ChainSelector(props: WalletState) {
           </>
         )}
       </Listbox.Button>
-      <Listbox.Options className="absolute mt-1 max-h-60 w-full overflow-y-auto flex flex-col border border-gray-l2 dark:border-bluegray rounded bg-white dark:bg-blue-d6 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+      <Listbox.Options className="absolute mt-1 max-h-60 w-full overflow-y-auto flex flex-col border border-prim rounded bg-white dark:bg-blue-d6 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
         {props.supportedChains.map((suppChain) => (
           <Option key={suppChain.chain_id} {...suppChain} />
         ))}

--- a/src/App/WalletSuite/ConnectedWallet/Details/Favourites/index.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/Favourites/index.tsx
@@ -8,7 +8,7 @@ type Props = { bookmarks: EndowmentBookmark[] | undefined; isError: boolean };
 
 export default function Favourites({ bookmarks, isError }: Props) {
   return (
-    <div className="flex flex-col gap-3 max-h-[244px] flex-1 p-4 border-b border-gray-l2 dark:border-bluegray">
+    <div className="flex flex-col gap-3 max-h-[244px] flex-1 p-4 border-b border-prim">
       <h3 className="flex justify-between gap-2 font-heading">
         <span className="font-bold text-sm text-gray-d1 dark:text-gray">
           Favourites

--- a/src/App/WalletSuite/ConnectedWallet/Details/Logo.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/Logo.tsx
@@ -21,7 +21,7 @@ export default function Logo({ src, className }: Props) {
       {!!src && (
         <img
           src={src}
-          className={`${className} object-contain border border-gray-l2 dark:border-bluegray rounded-full ${
+          className={`${className} object-contain border border-prim rounded-full ${
             isLoading ? "hidden" : ""
           }`}
           alt=""

--- a/src/App/WalletSuite/ConnectedWallet/Details/MobileTitle.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/MobileTitle.tsx
@@ -5,7 +5,7 @@ type Props = { className: string; onClose: () => void };
 export default function MobileTitle({ className, onClose }: Props) {
   return (
     <h3
-      className={`${className} flex justify-between items-center w-full px-4 py-3 bg-orange-l6 border-b border-gray-l2 dark:border-bluegray font-heading font-black text-xl text-orange uppercase dark:bg-blue-d7`}
+      className={`${className} flex justify-between items-center w-full px-4 py-3 bg-orange-l6 border-b border-prim font-heading font-black text-xl text-orange uppercase dark:bg-blue-d7`}
     >
       Wallet
       <button

--- a/src/App/WalletSuite/ConnectedWallet/Details/MyEndowments/Links.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/MyEndowments/Links.tsx
@@ -12,7 +12,7 @@ export default function Links({ endowmentId }: { endowmentId: number }) {
       </Link>
       <Link
         to={`${appRoutes.admin}/${endowmentId}`}
-        className="px-2 border-l border-gray-l2 dark:border-bluegray text-orange hover:text-orange-l2 decoration-1 hover:decoration-2"
+        className="px-2 border-l border-prim text-orange hover:text-orange-l2 decoration-1 hover:decoration-2"
       >
         admin
       </Link>

--- a/src/App/WalletSuite/ConnectedWallet/Details/MyEndowments/MyEndowments.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/MyEndowments/MyEndowments.tsx
@@ -6,7 +6,7 @@ type Props = { endowments: EndowmentBookmark[] };
 
 export default function MyEndowments({ endowments }: Props) {
   return (
-    <div className="grid p-4 gap-3 border-b border-gray-l2 dark:border-bluegray">
+    <div className="grid p-4 gap-3 border-b border-prim">
       <h3 className="font-heading font-bold text-sm text-gray-d1 dark:text-gray">
         My Endowments
       </h3>

--- a/src/App/WalletSuite/ConnectedWallet/Details/index.tsx
+++ b/src/App/WalletSuite/ConnectedWallet/Details/index.tsx
@@ -30,7 +30,7 @@ export default function Details(props: WalletState) {
   }, [isLoading, isFetching, isError, error]);
 
   return (
-    <Popover.Panel className="fixed sm:absolute inset-0 sm:inset-auto sm:origin-top-right sm:mt-2 sm:right-0 flex flex-col w-full sm:w-80 bg-white dark:bg-blue-d6 sm:rounded-lg border border-gray-l2 dark:border-bluegray shadow-[0_0_16px_rgba(15,46,67,0.25)] text-gray-d2 dark:text-white overflow-y-auto">
+    <Popover.Panel className="fixed sm:absolute inset-0 sm:inset-auto sm:origin-top-right sm:mt-2 sm:right-0 flex flex-col w-full sm:w-80 bg-white dark:bg-blue-d6 sm:rounded-lg border border-prim shadow-[0_0_16px_rgba(15,46,67,0.25)] text-gray-d2 dark:text-white overflow-y-auto">
       {({ close }) => {
         if (isLoading || isFetching) {
           return (
@@ -49,7 +49,7 @@ export default function Details(props: WalletState) {
               <MyEndowments endowments={profile.admin} />
             )}
 
-            <div className="grid gap-3 p-4 border-b border-gray-l2 dark:border-bluegray">
+            <div className="grid gap-3 p-4 border-b border-prim">
               <Balances {...props} />
               <Address value={props.address} />
               <ChainSelector {...props} />
@@ -66,7 +66,7 @@ export default function Details(props: WalletState) {
 
 function MyDonations({ address }: { address: string }) {
   return (
-    <div className="flex items-center p-4 border-b border-gray-l2 dark:border-bluegray">
+    <div className="flex items-center p-4 border-b border-prim">
       <Link
         to={`${appRoutes.donations}/${address}`}
         className="font-heading font-bold text-sm uppercase hover:text-orange"

--- a/src/App/WalletSuite/WalletSelectorOpener/WalletModal.tsx
+++ b/src/App/WalletSuite/WalletSelectorOpener/WalletModal.tsx
@@ -9,14 +9,14 @@ export default function WalletModal() {
   const { connections } = useSetWallet();
 
   return (
-    <Dialog.Panel className="fixed inset-0 sm:fixed-center z-20 grid sm:items-center w-full sm:max-w-lg h-full sm:h-fit sm:border border-gray-l2 sm:rounded bg-gray-l5 text-gray-d2 dark:bg-blue-d6 dark:border-bluegray dark:text-white shadow-[0_0_60px_rgba(0,0,0,0.3)]">
+    <Dialog.Panel className="fixed inset-0 sm:fixed-center z-20 grid sm:items-center w-full sm:max-w-lg h-full sm:h-fit sm:border border-prim sm:rounded bg-gray-l5 text-gray-d2 dark:bg-blue-d6  dark:text-white shadow-[0_0_60px_rgba(0,0,0,0.3)]">
       <Dialog.Title
         as="h3"
-        className="relative w-full pl-4 px-4 sm:px-0 py-4 sm:py-6 bg-orange-l6 border-b border-gray-l2 font-heading font-black sm:font-bold sm:text-center text-xl text-orange sm:text-inherit uppercase sm:capitalize dark:bg-blue-d7 dark:border-bluegray"
+        className="relative w-full pl-4 px-4 sm:px-0 py-4 sm:py-6 bg-orange-l6 border-b border-prim font-heading font-black sm:font-bold sm:text-center text-xl text-orange sm:text-inherit uppercase sm:capitalize dark:bg-blue-d7 "
       >
         Connect Wallet
         <button
-          className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-10 h-10 mr-4 sm:border border-gray-l2 hover:border-gray sm:rounded dark:border-bluegray dark:hover:border-bluegray-d1 text-gray-d2 hover:text-black dark:text-white dark:hover:text-gray"
+          className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-10 h-10 mr-4 sm:border border-prim hover:border-gray sm:rounded  dark:hover:border-bluegray-d1 text-gray-d2 hover:text-black dark:text-white dark:hover:text-gray"
           onClick={closeModal}
         >
           <Icon type="Close" className="w-8 sm:w-7 h-8 sm:h-7" />

--- a/src/components/KYC/Form/TextInput.tsx
+++ b/src/components/KYC/Form/TextInput.tsx
@@ -5,7 +5,7 @@ export const errorStyle =
   "absolute -bottom-5 right-0 text-right text-xs text-red dark:text-red-l2";
 
 export const textFieldStyle =
-  "w-full rounded placeholder:text-sm placeholder:text-gray-d1 dark:placeholder:text-gray border px-4 py-3.5 border-gray-l2 focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 dark:border-bluegray bg-gray-l5 dark:bg-blue-d6";
+  "w-full rounded placeholder:text-sm placeholder:text-gray-d1 dark:placeholder:text-gray border px-4 py-3.5 border-prim focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 bg-gray-l5 dark:bg-blue-d6";
 
 export default function TextInput<T extends FieldValues>({
   classes,

--- a/src/components/KYC/Form/index.tsx
+++ b/src/components/KYC/Form/index.tsx
@@ -78,7 +78,7 @@ export default function Form({ classes = "", ...props }: Props) {
           onReset={() => resetField("usState")}
           classes={{
             container:
-              "px-4 border border-gray-l2 rounded focus-within:border-gray-d1 focus-within:dark:border-blue-l2 dark:border-bluegray bg-gray-l5 dark:bg-blue-d6",
+              "px-4 border border-prim rounded focus-within:border-gray-d1 focus-within:dark:border-blue-l2 bg-gray-l5 dark:bg-blue-d6",
             input:
               "py-3.5 w-full placeholder:text-sm placeholder:text-gray-d1 dark:placeholder:text-gray focus:outline-none bg-transparent",
             error: errorStyle,

--- a/src/components/KadoModal.tsx
+++ b/src/components/KadoModal.tsx
@@ -31,14 +31,14 @@ export default function KadoModal() {
     : `&network=${getKadoNetworkValue(wallet.chain.chain_id)}`;
 
   return (
-    <Dialog.Panel className="fixed inset-0 sm:fixed-center z-10 flex flex-col sm:w-[500px] sm:h-[700px] bg-gray-l5 dark:bg-blue-d6 sm:border border-gray-l2 dark:border-bluegray sm:rounded">
+    <Dialog.Panel className="fixed inset-0 sm:fixed-center z-10 flex flex-col sm:w-[500px] sm:h-[700px] bg-gray-l5 dark:bg-blue-d6 sm:border border-prim sm:rounded">
       <Dialog.Title
         as="h3"
-        className="relative w-full pl-4 px-4 sm:px-0 py-4 sm:py-6 bg-orange-l6 border-b border-gray-l2 rounded-t font-heading font-black sm:font-bold sm:text-center text-xl text-orange sm:text-gray-d2 dark:text-white uppercase sm:normal-case dark:bg-blue-d7 dark:border-bluegray"
+        className="relative w-full pl-4 px-4 sm:px-0 py-4 sm:py-6 bg-orange-l6 border-b border-prim rounded-t font-heading font-black sm:font-bold sm:text-center text-xl text-orange sm:text-gray-d2 dark:text-white uppercase sm:normal-case dark:bg-blue-d7 "
       >
         Buy with Kado
         <button
-          className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-10 h-10 mr-4 sm:border border-gray-l2 hover:border-gray sm:rounded dark:border-bluegray dark:hover:border-bluegray-d1 text-gray-d2 hover:text-black dark:text-white dark:hover:text-gray"
+          className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-10 h-10 mr-4 sm:border border-prim hover:border-gray sm:rounded  dark:hover:border-bluegray-d1 text-gray-d2 hover:text-black dark:text-white dark:hover:text-gray"
           onClick={closeModal}
         >
           <Icon type="Close" className="w-8 sm:w-7 h-8 sm:h-7" />

--- a/src/components/LogoPlaceholder.tsx
+++ b/src/components/LogoPlaceholder.tsx
@@ -6,7 +6,7 @@ export default function LogoPlaceholder({ classes }: Props) {
   const { container = "", icon = "" } = classes;
   return (
     <div
-      className={`${container} flex items-center justify-center bg-blue-l3 dark:bg-blue border border-gray-l2 rounded-full dark:border-bluegray`}
+      className={`${container} flex items-center justify-center bg-blue-l3 dark:bg-blue border border-prim rounded-full `}
     >
       <Icon type="Picture" className={`${icon} text-white dark:text-blue-l3`} />
     </div>

--- a/src/components/Prompt/Prompt.tsx
+++ b/src/components/Prompt/Prompt.tsx
@@ -15,13 +15,13 @@ export default function Prompt({
   return (
     <Dialog.Panel className="fixed-center z-10 grid text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden">
       <div className="relative">
-        <p className="empty:h-16 text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l2 dark:border-bluegray p-5 font-work">
+        <p className="empty:h-16 text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-prim p-5 font-work">
           {headline}
         </p>
         {isDismissible && (
           <button
             onClick={closeModal}
-            className="border border-gray-l2 dark:border-bluegray p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l2 dark:disabled:text-bluegray-d1 disabled:dark:border-bluegray-d1"
+            className="border border-prim p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l2 dark:disabled:text-bluegray-d1 disabled:dark:border-bluegray-d1"
           >
             <Icon type="Close" size={24} />
           </button>
@@ -36,7 +36,7 @@ export default function Prompt({
       <div className="px-6 pb-4 text-center text-gray-d1 dark:text-gray">
         {children}
       </div>
-      <div className="p-3 sm:px-8 sm:py-4 empty:h-12 w-full text-end bg-orange-l6 dark:bg-blue-d7 border-t border-gray-l2 dark:border-bluegray">
+      <div className="p-3 sm:px-8 sm:py-4 empty:h-12 w-full text-end bg-orange-l6 dark:bg-blue-d7 border-t border-prim">
         {isDismissible && (
           <button
             type="button"

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -32,7 +32,7 @@ interface Props<
 }
 
 export const selectorButtonStyle =
-  "flex items-center text-sm rounded border border-gray-l2 dark:border-bluegray";
+  "flex items-center text-sm rounded border border-prim";
 
 const labelKey: keyof OptionType<string> = "label";
 
@@ -83,7 +83,7 @@ export function Selector<
             </>
           )}
         </Listbox.Button>
-        <Listbox.Options className="rounded-sm text-sm border border-gray-l2 dark:border-bluegray absolute top-full mt-2 z-20 bg-gray-l5 dark:bg-blue-d6 w-full max-h-[10rem] overflow-y-auto scroller">
+        <Listbox.Options className="rounded-sm text-sm border border-prim absolute top-full mt-2 z-20 bg-gray-l5 dark:bg-blue-d6 w-full max-h-[10rem] overflow-y-auto scroller">
           {options.map((o) => (
             <Listbox.Option
               key={o.value}

--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -58,9 +58,9 @@ export default function TokenSelector<
       <Combobox.Options
         className={`${
           props.classes?.options ?? ""
-        } border border-gray-l2 dark:border-bluegray p-1 mt-10 max-h-60 w-max overflow-y-auto rounded-md bg-gray-l5 dark:bg-blue-d7 shadow-lg focus:outline-none`}
+        } border border-prim p-1 mt-10 max-h-60 w-max overflow-y-auto rounded-md bg-gray-l5 dark:bg-blue-d7 shadow-lg focus:outline-none`}
       >
-        <div className="flex p-2 gap-2 border border-gray-l2 dark:border-bluegray rounded mb-1">
+        <div className="flex p-2 gap-2 border border-prim rounded mb-1">
           <Icon type="Search" size={20} />
           <Combobox.Input
             placeholder="Search..."

--- a/src/components/admin/TemplateContainer.tsx
+++ b/src/components/admin/TemplateContainer.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from "react";
 
 const containerClass =
-  "w-full p-6 rounded-md grid content-start gap-6 rounded bg-white dark:bg-blue-d6 border border-gray-l2 dark:border-bluegray";
+  "w-full p-6 rounded-md grid content-start gap-6 rounded bg-white dark:bg-blue-d6 border border-prim";
 
 export function DivContainer({
   children,
@@ -23,7 +23,7 @@ export function GroupContainer({
 }: PropsWithChildren<{ className?: string }>) {
   return (
     <div
-      className={`p-3 pb-6 grid gap-6 rounded bg-orange-l6 dark:bg-blue-d7 border border-gray-l2 dark:border-bluegray ${className}`}
+      className={`p-3 pb-6 grid gap-6 rounded bg-orange-l6 dark:bg-blue-d7 border border-prim ${className}`}
     >
       {children}
     </div>

--- a/src/components/admin/TextArea.tsx
+++ b/src/components/admin/TextArea.tsx
@@ -12,7 +12,7 @@ export function TextArea<T extends FieldValues>({
       classes={{
         container: `relative ${container}`,
         label: `mb-2 ${label}`,
-        input: `w-full text-sm rounded placeholder:text-gray-d1 dark:placeholder:text-gray border px-4 py-3.5 border-gray-l2 focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 dark:border-bluegray bg-orange-l6 dark:bg-blue-d7 disabled:bg-gray-l4 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-bluegray-d1 ${input}`,
+        input: `w-full text-sm rounded placeholder:text-gray-d1 dark:placeholder:text-gray border px-4 py-3.5 border-prim focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 bg-orange-l6 dark:bg-blue-d7 disabled:bg-gray-l4 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-bluegray-d1 ${input}`,
         error: `absolute -bottom-5 right-0 text-right text-xs text-red dark:text-red-l2 ${error}`,
       }}
     />

--- a/src/components/admin/TextInput.tsx
+++ b/src/components/admin/TextInput.tsx
@@ -4,7 +4,7 @@ import { TextInput as BaseInput, TextInputProps } from "components/form";
 export const errorStyle =
   "absolute -bottom-5 right-0 text-right text-xs text-red dark:text-red-l2";
 export const textPrimStyle =
-  "w-full text-sm rounded placeholder:text-gray-d1 dark:placeholder:text-gray border px-4 py-3.5 border-gray-l2 focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 dark:border-bluegray bg-orange-l6 dark:bg-blue-d7 disabled:bg-gray-l4 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-bluegray-d1";
+  "w-full text-sm rounded placeholder:text-gray-d1 dark:placeholder:text-gray border px-4 py-3.5 border-prim focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 bg-orange-l6 dark:bg-blue-d7 disabled:bg-gray-l4 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-bluegray-d1";
 
 export function TextPrim<T extends FieldValues>({
   classes,
@@ -35,7 +35,7 @@ export function TextSec<T extends FieldValues>({
       classes={{
         container: `relative ${container}`,
         label: `mb-2 ${label}`,
-        input: `w-full text-sm placeholder:text-gray-d1 dark:placeholder:text-gray border-b pb-2 border-gray-l2 focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 dark:border-bluegray bg-transparent disabled:bg-gray-l4 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-bluegray-d1 ${input}`,
+        input: `w-full text-sm placeholder:text-gray-d1 dark:placeholder:text-gray border-b pb-2 border-prim focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2  bg-transparent disabled:bg-gray-l4 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-bluegray-d1 ${input}`,
         error: `${errorStyle} ${error}`,
       }}
     />

--- a/src/components/donation/BtnOutline.tsx
+++ b/src/components/donation/BtnOutline.tsx
@@ -4,7 +4,7 @@ export function BtnOutline({ className = "", ...props }: BtnLinkProps) {
   return (
     <BtnLink
       {...props}
-      className={`${className} text-sm md:text-base p-3 rounded border border-gray-l2 dark:border-bluegray text-center hover:border-gray-l1 hover:dark:border-blue-d2 font-bold font-body`}
+      className={`${className} text-sm md:text-base p-3 rounded border border-prim text-center hover:border-gray-l1 hover:dark:border-blue-d2 font-bold font-body`}
     />
   );
 }

--- a/src/components/donation/BtnSec.tsx
+++ b/src/components/donation/BtnSec.tsx
@@ -4,7 +4,7 @@ export function BtnSec({ className = "", ...props }: BtnLinkProps) {
   return (
     <BtnLink
       {...props}
-      className={`${className}bg-orange-l5 dark:bg-blue-d4 hover:bg-orange-l4 dark:hover:bg-blue-d3 text-sm md:text-base p-3 rounded border border-gray-l2 dark:border-bluegray text-center hover:border-gray-l1 hover:dark:border-blue-d2 font-bold font-body`}
+      className={`${className}bg-orange-l5 dark:bg-blue-d4 hover:bg-orange-l4 dark:hover:bg-blue-d3 text-sm md:text-base p-3 rounded border border-prim text-center hover:border-gray-l1 hover:dark:border-blue-d2 font-bold font-body`}
     />
   );
 }

--- a/src/components/gift/BtnOutline.tsx
+++ b/src/components/gift/BtnOutline.tsx
@@ -4,7 +4,7 @@ export function BtnOutline({ className = "", ...props }: BtnLinkProps) {
   return (
     <BtnLink
       {...props}
-      className={`${className} text-sm uppercase p-3 rounded border border-gray-l2 dark:border-bluegray text-center hover:border-gray-l1 hover:dark:border-blue-d2 font-bold font-body`}
+      className={`${className} text-sm uppercase p-3 rounded border border-prim text-center hover:border-gray-l1 hover:dark:border-blue-d2 font-bold font-body`}
     />
   );
 }

--- a/src/components/gift/BtnSec.tsx
+++ b/src/components/gift/BtnSec.tsx
@@ -4,7 +4,7 @@ export function BtnSec({ className = "", ...props }: BtnLinkProps) {
   return (
     <BtnLink
       {...props}
-      className={`${className} text-sm p-3 uppercase rounded border border-gray-l2 dark:border-bluegray hover:border-gray-l1 hover:dark:border-blue-d2 font-bold font-body bg-orange-l5 dark:bg-blue-d4 disabled:bg-gray-l2 disabled:dark:bg-bluegray disabled:cursor-auto aria-disabled:pointer-events-none aria-disabled:bg-gray-l2 aria-disabled:dark:bg-bluegray-d1 text-center hover:bg-orange-l4 dark:hover:bg-blue-d3`}
+      className={`${className} text-sm p-3 uppercase rounded border border-prim hover:border-gray-l1 hover:dark:border-blue-d2 font-bold font-body bg-orange-l5 dark:bg-blue-d4 disabled:bg-gray-l2 disabled:dark:bg-bluegray disabled:cursor-auto aria-disabled:pointer-events-none aria-disabled:bg-gray-l2 aria-disabled:dark:bg-bluegray-d1 text-center hover:bg-orange-l4 dark:hover:bg-blue-d3`}
     />
   );
 }

--- a/src/components/gift/TextInput.tsx
+++ b/src/components/gift/TextInput.tsx
@@ -2,7 +2,7 @@ import { FieldValues } from "react-hook-form";
 import { TextInput as BaseInput, TextInputProps } from "components/form";
 
 export const textFieldStyle =
-  "w-full text-sm rounded placeholder:text-gray-d1 dark:placeholder:text-gray border px-4 py-3.5 border-gray-l2 focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 dark:border-bluegray bg-white dark:bg-blue-d6 disabled:bg-gray-l4 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-bluegray-d1";
+  "w-full text-sm rounded placeholder:text-gray-d1 dark:placeholder:text-gray border px-4 py-3.5 border-prim focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2  bg-white dark:bg-blue-d6 disabled:bg-gray-l4 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-bluegray-d1";
 
 export const errorStyle =
   "absolute -bottom-5 right-0 text-right text-xs text-red dark:text-red-l2";

--- a/src/components/registration/BtnSec.tsx
+++ b/src/components/registration/BtnSec.tsx
@@ -4,7 +4,7 @@ export function BtnSec({ className = "", ...props }: BtnLinkProps) {
   return (
     <BtnLink
       {...props}
-      className={`${className} text-sm p-3 uppercase rounded border border-gray-l2 dark:border-bluegray hover:border-gray-l1 hover:dark:border-blue-d2 font-bold font-body bg-orange-l5 dark:bg-blue-d4 disabled:bg-gray-l2 disabled:dark:bg-bluegray disabled:cursor-auto aria-disabled:pointer-events-none aria-disabled:bg-gray-l2 aria-disabled:dark:bg-bluegray-d1 text-center hover:bg-orange-l4 dark:hover:bg-blue-d3`}
+      className={`${className} text-sm p-3 uppercase rounded border border-prim hover:border-gray-l1 hover:dark:border-blue-d2 font-bold font-body bg-orange-l5 dark:bg-blue-d4 disabled:bg-gray-l2 disabled:dark:bg-bluegray disabled:cursor-auto aria-disabled:pointer-events-none aria-disabled:bg-gray-l2 aria-disabled:dark:bg-bluegray-d1 text-center hover:bg-orange-l4 dark:hover:bg-blue-d3`}
     />
   );
 }

--- a/src/components/registration/FileDropzone.tsx
+++ b/src/components/registration/FileDropzone.tsx
@@ -53,7 +53,7 @@ export function FileDropzone<T extends FieldValues, K extends Path<T>>(props: {
           className: `relative grid place-items-center rounded border border-dashed w-full h-[11.375rem] focus:outline-none ${
             isDragActive
               ? "border-gray-d1 dark:border-gray"
-              : "border-gray-l2 dark:border-bluegray focus:border-orange-l2 focus:dark:border-blue-d1"
+              : "border-prim focus:border-orange-l2 focus:dark:border-blue-d1"
           } ${
             isSubmitting || props.disabled
               ? "cursor-default bg-gray-l4 dark:bg-bluegray-d1"

--- a/src/components/registration/TextInput.tsx
+++ b/src/components/registration/TextInput.tsx
@@ -13,7 +13,7 @@ export function TextInput<T extends FieldValues>({
       classes={{
         container: `relative ${container}`,
         label: `mb-2 ${label}`,
-        input: `w-full text-sm rounded placeholder:text-gray-d1 dark:placeholder:text-gray border px-4 py-3.5 border-gray-l2 focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 dark:border-bluegray bg-transparent disabled:bg-gray-l4 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-bluegray-d1 ${input}`,
+        input: `w-full text-sm rounded placeholder:text-gray-d1 dark:placeholder:text-gray border px-4 py-3.5 border-prim focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 bg-transparent disabled:bg-gray-l4 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-bluegray-d1 ${input}`,
         error: `${errorStyle} ${error}`,
       }}
     />

--- a/src/index.css
+++ b/src/index.css
@@ -83,6 +83,14 @@
     @apply absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2;
   }
 
+  .border-prim {
+    @apply border-gray-l2 dark:border-bluegray;
+  }
+
+  .divide-prim {
+    @apply divide-gray-l2 dark:divide-bluegray;
+  }
+
   .line-clamp-2 {
     overflow: hidden;
     display: -webkit-box;

--- a/src/pages/Admin/Charity/Dashboard/Balance.tsx
+++ b/src/pages/Admin/Charity/Dashboard/Balance.tsx
@@ -11,7 +11,7 @@ export default function Balance({ type }: Props) {
   const queryState = useBalanceQuery({ id: endowmentId });
 
   return (
-    <div className="rounded p-3 border border-gray-l2 dark:border-bluegray bg-orange-l6 dark:bg-blue-d6">
+    <div className="rounded p-3 border border-prim bg-orange-l6 dark:bg-blue-d6">
       <h4 className="uppercase font-extrabold">
         {accountTypeDisplayValue[type]}
       </h4>

--- a/src/pages/Admin/Charity/Dashboard/Donations/Table.tsx
+++ b/src/pages/Admin/Charity/Dashboard/Donations/Table.tsx
@@ -14,10 +14,7 @@ export default function Table(props: { donations: Donation[] }) {
 
   return (
     <table className="w-full border-collapse self-start">
-      <TableSection
-        type="thead"
-        rowClass="border-b-2 border-gray-l2 dark:border-bluegray"
-      >
+      <TableSection type="thead" rowClass="border-b-2 border-prim">
         <Cells
           type="th"
           cellClass="text-left uppercase font-heading font-semibold text-sm p-2 first:pl-0 last:pr-0"
@@ -61,7 +58,7 @@ export default function Table(props: { donations: Donation[] }) {
       </TableSection>
       <TableSection
         type="tbody"
-        rowClass="border-b border-gray-l2 dark:border-bluegray hover:bg-blue-l4 hover:dark:bg-blue-d4"
+        rowClass="border-b border-prim hover:bg-blue-l4 hover:dark:bg-blue-d4"
       >
         {sorted.map(({ hash, amount, symbol, chainId, date, kycData }) => (
           <Cells key={hash} type="td" cellClass="p-2 first:pl-0 last:pr-0">

--- a/src/pages/Admin/Charity/Dashboard/Table.tsx
+++ b/src/pages/Admin/Charity/Dashboard/Table.tsx
@@ -8,10 +8,7 @@ type Props = { proposals: Proposal[] };
 export default function Table({ proposals }: Props) {
   return (
     <table>
-      <TableSection
-        rowClass="border-b border-gray-l2 dark:border-bluegray"
-        type="thead"
-      >
+      <TableSection rowClass="border-b border-prim" type="thead">
         <Cells type="th" cellClass="p-1.5 uppercase text-left font-heading">
           <>title</>
           <>status</>
@@ -19,7 +16,7 @@ export default function Table({ proposals }: Props) {
         </Cells>
       </TableSection>
       <TableSection
-        rowClass="last:border-none border-b border-gray-l2 dark:border-bluegray hover:bg-blue-l4 hover:dark:bg-blue-d4"
+        rowClass="last:border-none border-b border-prim hover:bg-blue-l4 hover:dark:bg-blue-d4"
         type="tbody"
       >
         {proposals.map(({ title, status, expires, id }) => (

--- a/src/pages/Admin/Charity/EditProfile/Form.tsx
+++ b/src/pages/Admin/Charity/EditProfile/Form.tsx
@@ -39,7 +39,7 @@ export default function Form() {
         name="image"
         accept={VALID_MIME_TYPES}
         aspect={[4, 1]}
-        classes="w-full aspect-[4/1] mb-4 rounded border border-gray-l2 dark:border-bluegray"
+        classes="w-full aspect-[4/1] mb-4 rounded border border-prim"
       />
       <Label className="-mb-4" required>
         Logo
@@ -48,7 +48,7 @@ export default function Form() {
         name="logo"
         accept={VALID_MIME_TYPES}
         aspect={[1, 1]}
-        classes="w-28 sm:w-48 aspect-square mb-4 rounded border border-gray-l2 dark:border-bluegray"
+        classes="w-28 sm:w-48 aspect-square mb-4 rounded border border-prim"
       />
       <Label className="-mb-4">SDG#</Label>
       <SDGSelector />
@@ -63,7 +63,7 @@ export default function Form() {
         fieldName="hq_country"
         classes={{
           container:
-            "px-4 border border-gray-l2 rounded focus-within:border-gray-d1 focus-within:dark:border-blue-l2 dark:border-bluegray bg-orange-l6 dark:bg-blue-d7",
+            "px-4 border border-prim rounded focus-within:border-gray-d1 focus-within:dark:border-blue-l2 bg-orange-l6 dark:bg-blue-d7",
           input:
             "text-sm py-3.5 w-full placeholder:text-sm placeholder:text-gray-d1 dark:placeholder:text-gray focus:outline-none bg-transparent",
           error: errorStyle,
@@ -75,7 +75,7 @@ export default function Form() {
         placeHolder="A short overview of your charity"
         classes={{
           container:
-            "rich-text-toolbar border border-gray-l2 dark:border-bluegray text-sm grid grid-rows-[auto_1fr] rounded bg-orange-l6 dark:bg-blue-d7 p-3",
+            "rich-text-toolbar border border-prim text-sm grid grid-rows-[auto_1fr] rounded bg-orange-l6 dark:bg-blue-d7 p-3",
           error: "text-right text-red dark:text-red-l1 text-xs -mt-4",
           charCounter: "text-gray-d1 dark:text-gray",
         }}

--- a/src/pages/Admin/Charity/EditProfile/SDGSelector.tsx
+++ b/src/pages/Admin/Charity/EditProfile/SDGSelector.tsx
@@ -20,7 +20,7 @@ export default function SDGSelector() {
       value={value}
       onChange={onChange}
       as="div"
-      className="w-full focus:outline-none rounded text-sm uppercase relative bg-orange-l6 dark:bg-blue-d7 border border-gray-l2 dark:border-bluegray"
+      className="w-full focus:outline-none rounded text-sm uppercase relative bg-orange-l6 dark:bg-blue-d7 border border-prim"
     >
       <Listbox.Button className="w-full p-3 text-left uppercase flex justify-between items-center">
         {({ open }) => (

--- a/src/pages/Admin/Charity/Templates/Nav.tsx
+++ b/src/pages/Admin/Charity/Templates/Nav.tsx
@@ -9,7 +9,7 @@ const styler = createNavLinkStyler(
 
 export default function Nav() {
   return (
-    <div className="bg-white dark:bg-blue-d6 border border-gray-l2 dark:border-bluegray flex flex-col py-4 rounded">
+    <div className="bg-white dark:bg-blue-d6 border border-prim flex flex-col py-4 rounded">
       <Category title="Admin" classes="mb-2" />
       <NavLink end to={routes.cw4_members} className={styler}>
         Update group members

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Amounts.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Amounts.tsx
@@ -29,7 +29,7 @@ export default function Amounts() {
 
         return (
           <div
-            className="flex relative mb-6 border-b border-gray-l2 dark:border-bluegray pr-2 pb-1 pt-6 items-center"
+            className="flex relative mb-6 border-b border-prim pr-2 pb-1 pt-6 items-center"
             key={field.id}
           >
             <button

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Beneficiary.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Beneficiary.tsx
@@ -10,9 +10,7 @@ export default function Beneficiary({ classes = "" }: { classes?: string }) {
   } = useFormContext<WithdrawValues>();
 
   return (
-    <div
-      className={`${classes} relative grid border-b border-gray-l2 dark:border-bluegray`}
-    >
+    <div className={`${classes} relative grid border-b border-prim`}>
       <label
         htmlFor={id}
         className="font-bold font-heading text-sm uppercase mb-2"

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/index.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/index.tsx
@@ -14,7 +14,7 @@ export default function WithdrawTabs({ tokens_on_hand }: EndowmentBalance) {
       className="mt-6 justify-self-center"
       defaultIndex={type === "locked" ? 1 : 0}
     >
-      <Tab.List className="grid grid-cols-2 rounded mb-1 overflow-hidden border border-gray-l2 dark:border-bluegray p-0.5">
+      <Tab.List className="grid grid-cols-2 rounded mb-1 overflow-hidden border border-prim p-0.5">
         {tabs.map((t) => (
           <Tab
             key={t}
@@ -30,7 +30,7 @@ export default function WithdrawTabs({ tokens_on_hand }: EndowmentBalance) {
           </Tab>
         ))}
       </Tab.List>
-      <Tab.Panels className="w-full max-w-md border rounded border-gray-l2 dark:border-bluegray">
+      <Tab.Panels className="w-full max-w-md border rounded border-prim">
         {tabs.map((t) => (
           <Tab.Panel key={t}>
             <Withdrawer balance={tokens_on_hand[t]} type={t} />

--- a/src/pages/Admin/Charity/Withdraws/index.tsx
+++ b/src/pages/Admin/Charity/Withdraws/index.tsx
@@ -20,7 +20,7 @@ export default function Withdraws() {
         {(balance) => <WithdrawTabs {...balance} />}
       </QueryLoader>
 
-      <h3 className="uppercase font-extrabold text-2xl mt-6 border-t border-gray-l2 dark:border-bluegray pt-2">
+      <h3 className="uppercase font-extrabold text-2xl mt-6 border-t border-prim pt-2">
         Transactions
       </h3>
       <Transactions />

--- a/src/pages/Admin/Core/Templates/Nav.tsx
+++ b/src/pages/Admin/Core/Templates/Nav.tsx
@@ -9,7 +9,7 @@ const styler = createNavLinkStyler(
 
 export default function Nav() {
   return (
-    <div className="bg-white dark:bg-blue-d6 border border-gray-l2 dark:border-bluegray flex flex-col py-4 rounded">
+    <div className="bg-white dark:bg-blue-d6 border border-prim flex flex-col py-4 rounded">
       <Category title="Admin" />
       <NavLink end to={routes.cw4_members} className={styler}>
         Update group members

--- a/src/pages/Admin/Core/Templates/index-fund/Alliance/AllianceSelection/Toolbar.tsx
+++ b/src/pages/Admin/Core/Templates/index-fund/Alliance/AllianceSelection/Toolbar.tsx
@@ -6,7 +6,7 @@ export default function Toolbar(props: {
 }) {
   return (
     <div className="flex justify-end bg-orange-l5 dark:bg-blue-d5 p-3 sticky top-0">
-      <div className="flex px-3 py-1.5 rounded bg-orange-l6 dark:bg-blue-d7 border border-gray-l2 dark:border-bluegray">
+      <div className="flex px-3 py-1.5 rounded bg-orange-l6 dark:bg-blue-d7 border border-prim">
         <input
           id="__allianceSearch"
           placeholder="name or address"

--- a/src/pages/Admin/Core/Templates/index-fund/Alliance/AllianceSelection/index.tsx
+++ b/src/pages/Admin/Core/Templates/index-fund/Alliance/AllianceSelection/index.tsx
@@ -9,7 +9,7 @@ export default function AllianceSelection() {
     useAllianceSelection();
 
   return (
-    <div className="h-96 overflow-auto rounded bg-orange-l6 dark:bg-blue-d7 border border-gray-l2 dark:border-bluegray relative">
+    <div className="h-96 overflow-auto rounded bg-orange-l6 dark:bg-blue-d7 border border-prim relative">
       <Toolbar
         searchText={searchText}
         handleSearchTextChange={handleSearchTextChange}
@@ -41,7 +41,7 @@ function MemberTable(props: { members: AllianceMemberWithFlags[] }) {
       </TableSection>
       <TableSection
         type="tbody"
-        rowClass="border-b border-gray-l2 dark:border-bluegray hover:bg-blue hover:bg-blue/10"
+        rowClass="border-b border-prim hover:bg-blue hover:bg-blue/10"
       >
         {props.members.map((member) => (
           <Member key={member.wallet} {...member} />

--- a/src/pages/Admin/Core/Templates/index-fund/CreateFund/Form.tsx
+++ b/src/pages/Admin/Core/Templates/index-fund/CreateFund/Form.tsx
@@ -30,7 +30,7 @@ export default function Form() {
         name="isFundRotating"
         classes={{
           container:
-            "p-3 text-sm rounded bg-orange-l6 dark:bg-blue-d7 grid items-center border border-gray-l2 dark:border-bluegray",
+            "p-3 text-sm rounded bg-orange-l6 dark:bg-blue-d7 grid items-center border border-prim",
         }}
       >
         Included on fund rotation
@@ -64,7 +64,7 @@ function Slider() {
           reset
         </button>
       </Label>
-      <div className="rounded bg-orange-l6 dark:bg-blue-d7 grid items-center px-4 py-6 border border-gray-l2 dark:border-bluegray">
+      <div className="rounded bg-orange-l6 dark:bg-blue-d7 grid items-center px-4 py-6 border border-prim">
         <input
           {...register("splitToLiquid")}
           className="w-full slider"

--- a/src/pages/Admin/Core/Templates/index-fund/FundSelection.tsx
+++ b/src/pages/Admin/Core/Templates/index-fund/FundSelection.tsx
@@ -11,10 +11,7 @@ export default function FundSelection<T extends FundIdContext>(props: {
   );
   return (
     <table className="table-auto rounded text-left bg-orange-l6 dark:bg-blue-d7">
-      <TableSection
-        type="thead"
-        rowClass="border-b border-gray-l2 dark:border-bluegray"
-      >
+      <TableSection type="thead" rowClass="border-b border-prim">
         <Cells type="th" cellClass="px-4 py-2 uppercase">
           <>fund id</>
           <>fund name</>

--- a/src/pages/Admin/Guard.tsx
+++ b/src/pages/Admin/Guard.tsx
@@ -47,7 +47,7 @@ export const useAdminResources = (): AdminResources => {
 
 function GuardPrompt(props: { message: string; showLoader?: true }) {
   return (
-    <div className="place-self-center grid content-center justify-items-center min-h-[15rem] w-full bg-white dark:bg-blue-d6 border border-gray-l2 dark:border-bluegray max-w-sm p-4 rounded">
+    <div className="place-self-center grid content-center justify-items-center min-h-[15rem] w-full bg-white dark:bg-blue-d6 border border-prim max-w-sm p-4 rounded">
       {props.showLoader ? (
         <Loader
           gapClass="gap-2"

--- a/src/pages/Admin/Proposal/Content/Preview/DiffTable.tsx
+++ b/src/pages/Admin/Proposal/Content/Preview/DiffTable.tsx
@@ -13,7 +13,7 @@ export default function DiffTable<T extends object>(props: {
         <TableSection type="thead" rowClass="">
           <Cells
             type="th"
-            cellClass="text-right p-2 uppercase text-xs font-heading border-r border-gray-l2 dark:border-bluegray"
+            cellClass="text-right p-2 uppercase text-xs font-heading border-r border-prim"
             dual
           >
             <></>
@@ -21,17 +21,14 @@ export default function DiffTable<T extends object>(props: {
             <>to</>
           </Cells>
         </TableSection>
-        <TableSection
-          type="tbody"
-          rowClass="border-b border-gray-l2 dark:border-bluegray"
-        >
+        <TableSection type="tbody" rowClass="border-b border-prim">
           {props.diffSet.map(([key, prev, next]) => (
             <Cells
               type="td"
-              cellClass="text-right p-2 border-r border-gray-l2 dark:border-bluegray truncate max-w-2xl"
+              cellClass="text-right p-2 border-r border-prim truncate max-w-2xl"
               dual
               key={key as string} //T is a normal object with string keys
-              verticalHeaderClass="uppercase text-xs text-left p-2 pl-0 font-heading border-r border-gray-l2 dark:border-bluegray"
+              verticalHeaderClass="uppercase text-xs text-left p-2 pl-0 font-heading border-r border-prim"
             >
               <>{(key as string).replace(/_/g, " ")}</>
               {createColumn(prev)}

--- a/src/pages/Admin/Proposal/Content/Preview/FundTransfer.tsx
+++ b/src/pages/Admin/Proposal/Content/Preview/FundTransfer.tsx
@@ -12,10 +12,7 @@ export default function FundTransfer(props: FundSendMeta["data"]) {
           admin group contract
         </span>
       </KeyValue>
-      <KeyValue
-        _key="total amount"
-        _classes="border-t border-gray-l2 dark:border-bluegray mt-2"
-      >
+      <KeyValue _key="total amount" _classes="border-t border-prim mt-2">
         <span>
           {humanize(props.amount, 3)} {symbols[props.denom]}
         </span>

--- a/src/pages/Admin/Proposal/Content/Preview/common/PreviewContainer.tsx
+++ b/src/pages/Admin/Proposal/Content/Preview/common/PreviewContainer.tsx
@@ -6,7 +6,7 @@ export default function PreviewContainer({
 }: PropsWithChildren<{ classes?: string }>) {
   return (
     <div
-      className={`border border-gray-l2 dark:border-bluegray dark:bg-blue-d7 bg-orange-l6 p-3 rounded mb-2 mt-1 ${classes} font-work`}
+      className={`border border-prim dark:bg-blue-d7 bg-orange-l6 p-3 rounded mb-2 mt-1 ${classes} font-work`}
     >
       {children}
     </div>

--- a/src/pages/Admin/Proposal/Content/index.tsx
+++ b/src/pages/Admin/Proposal/Content/index.tsx
@@ -46,7 +46,7 @@ function RawBlock(props: EmbeddedWasmMsg | EmbeddedBankMsg) {
     : JSON.stringify(props, null, 2);
 
   return (
-    <div className="grid rounded text-gray-d1 dark:text-gray border border-gray-l2 dark:border-bluegray bg-orange-l6 dark:bg-blue-d7 p-3 mb-6 text-sm">
+    <div className="grid rounded text-gray-d1 dark:text-gray border border-prim bg-orange-l6 dark:bg-blue-d7 p-3 mb-6 text-sm">
       <code className="font-mono whitespace-pre overflow-x-auto">
         {isWASM && <span>to contract: {props.wasm.execute.contract_addr}</span>}
         <br />

--- a/src/pages/Admin/Proposal/Stats.tsx
+++ b/src/pages/Admin/Proposal/Stats.tsx
@@ -79,7 +79,7 @@ function Stat(props: {
 }) {
   return (
     <p
-      className={`uppercase ${props.textColor} grid min-w-[10rem] rounded-md border border-gray-l2 dark:border-bluegray bg-orange-l6 dark:bg-blue-d7 p-4`}
+      className={`uppercase ${props.textColor} grid min-w-[10rem] rounded-md border border-prim bg-orange-l6 dark:bg-blue-d7 p-4`}
     >
       <span className="">{props.title}</span>
       <span className="my-2 text-2xl">{props.value}</span>

--- a/src/pages/Admin/Proposal/Voter/Form.tsx
+++ b/src/pages/Admin/Proposal/Voter/Form.tsx
@@ -10,7 +10,7 @@ export default function Form() {
     <Dialog.Panel
       as="form"
       onSubmit={vote}
-      className="w-full max-w-md fixed-center z-20 font-work text-gray-d2 dark:text-white bg-white dark:bg-blue-d6 border border-gray-l2 dark:border-bluegray -mt-4 grid p-4 pt-4 rounded"
+      className="w-full max-w-md fixed-center z-20 font-work text-gray-d2 dark:text-white bg-white dark:bg-blue-d6 border border-prim -mt-4 grid p-4 pt-4 rounded"
       autoComplete="off"
     >
       <div className="grid grid-cols-2 gap-4 mb-6 mt-2">

--- a/src/pages/Admin/Proposal/Voter/VoteOption.tsx
+++ b/src/pages/Admin/Proposal/Voter/VoteOption.tsx
@@ -22,7 +22,7 @@ export default function VoteOption<T extends VoteOptionContextType>(
     );
 
   return (
-    <div className="grid place-items-center border border-gray-l2 dark:border-bluegray rounded bg-orange-l6 dark:bg-blue-d7">
+    <div className="grid place-items-center border border-prim rounded bg-orange-l6 dark:bg-blue-d7">
       <label
         className={`cursor-pointer grid place-items-center rounded-md p-4 w-full ${
           is_active ? "pointer-events-none" : ""

--- a/src/pages/Admin/Proposal/Votes/index.tsx
+++ b/src/pages/Admin/Proposal/Votes/index.tsx
@@ -26,7 +26,7 @@ export default function Votes(props: { proposalId: number; classes?: string }) {
         </TableSection>
         <TableSection
           type="tbody"
-          rowClass="border border-gray-l2 dark:border-bluegray divide-x divide-gray-l2 dark:divide-bluegray hover:bg-blue hover:bg-blue/10 mb-6 sm:mb-0 flex flex-row flex-wrap sm:flex-no-wrap"
+          rowClass="border border-prim divide-x divide-prim hover:bg-blue hover:bg-blue/10 mb-6 sm:mb-0 flex flex-row flex-wrap sm:flex-no-wrap"
         >
           {votes.map((vote, i) => (
             <Cells

--- a/src/pages/Admin/Proposal/index.tsx
+++ b/src/pages/Admin/Proposal/index.tsx
@@ -35,12 +35,12 @@ export default function Proposal() {
         }}
       >
         {(proposal) => (
-          <div className="rounded p-4 border border-gray-l2 dark:border-bluegray dark:bg-blue-d6 bg-white">
+          <div className="rounded p-4 border border-prim dark:bg-blue-d6 bg-white">
             <div className="flex justify-between flex-wrap">
               <p>ID : {proposal.id}</p>
               <Status status={proposal.status} />
             </div>
-            <div className="mt-8 mb-6 flex justify-between items-center border-b-2 border-gray-l2 dark:border-bluegray pb-2">
+            <div className="mt-8 mb-6 flex justify-between items-center border-b-2 border-prim pb-2">
               <h4 className="font-bold text-lg">{proposal.title}</h4>
               <PollAction {...proposal} />
             </div>
@@ -55,7 +55,7 @@ export default function Proposal() {
               {proposal.description}
             </p>
             <Content {...proposal} />
-            <h4 className="mt-6 uppercase font-bold text-lg py-2 border-b-2 border-gray-l2 dark:border-bluegray">
+            <h4 className="mt-6 uppercase font-bold text-lg py-2 border-b-2 border-prim">
               Votes
             </h4>
             <Stats {...proposal} />

--- a/src/pages/Admin/Proposals/ProposalCard.tsx
+++ b/src/pages/Admin/Proposals/ProposalCard.tsx
@@ -8,13 +8,13 @@ export default function ProposalCard(props: Proposal) {
   return (
     <Link
       to={`../${adminRoutes.proposal}/${props.id}`}
-      className="p-4 rounded grid border border-gray-l2 dark:border-bluegray bg-orange-l6 dark:bg-blue-d6 hover:bg-orange-l5 hover:dark:bg-blue-d7"
+      className="p-4 rounded grid border border-prim bg-orange-l6 dark:bg-blue-d6 hover:bg-orange-l5 hover:dark:bg-blue-d7"
     >
       <div className="flex justify-between items-center mb-4">
         <p className="text-sm">ID: {props.id}</p>
         <Status status={props.status} />
       </div>
-      <span className="pb-2 font-semibold mt-2 border-b-2 border-gray-l2 dark:border-bluegray line-clamp-2">
+      <span className="pb-2 font-semibold mt-2 border-b-2 border-prim line-clamp-2">
         {props.title}
       </span>
 

--- a/src/pages/Admin/Proposals/Toolbar/GroupSelector.tsx
+++ b/src/pages/Admin/Proposals/Toolbar/GroupSelector.tsx
@@ -11,7 +11,7 @@ export default function GroupSelector() {
   }
 
   return (
-    <div className="flex gap-2 items-center border p-2 border-gray-l2 dark:border-bluegray rounded dark:bg-blue-d4">
+    <div className="flex gap-2 items-center border p-2 border-prim rounded dark:bg-blue-d4">
       <label htmlFor="group_selector" className="uppercase text-sm font-bold">
         group :
       </label>

--- a/src/pages/Admin/Proposals/Toolbar/StatusSelector.tsx
+++ b/src/pages/Admin/Proposals/Toolbar/StatusSelector.tsx
@@ -11,7 +11,7 @@ export default function StatusSelector() {
   }
 
   return (
-    <div className="flex gap-2 items-center border p-2 border-gray-l2 dark:border-bluegray rounded dark:bg-blue-d4">
+    <div className="flex gap-2 items-center border p-2 border-prim rounded dark:bg-blue-d4">
       <label htmlFor="status_selector" className="uppercase text-sm font-bold">
         status :
       </label>

--- a/src/pages/Admin/Proposals/Toolbar/index.tsx
+++ b/src/pages/Admin/Proposals/Toolbar/index.tsx
@@ -13,7 +13,7 @@ export default function Toolbar({ classes = "" }: { classes?: string }) {
   });
   return (
     <div
-      className={`flex items-center gap-3 ${classes} border-b-2 pb-3 border-gray-l2 dark:border-bluegray`}
+      className={`flex items-center gap-3 ${classes} border-b-2 pb-3 border-prim`}
     >
       <StatusSelector />
       <GroupSelector />

--- a/src/pages/Admin/Review/Applications/Table/StatusSelector.tsx
+++ b/src/pages/Admin/Review/Applications/Table/StatusSelector.tsx
@@ -34,7 +34,7 @@ export default function StatusSelector() {
           <span>{activeStatus === "all" ? "status" : texts[activeStatus]}</span>
           <Icon type="FilterLeft" size={20} />
         </Listbox.Button>
-        <Listbox.Options className="absolute w-max rounded bg-white dark:bg-blue-d7 p-3 border border-gray-l2 dark:border-blue-gray">
+        <Listbox.Options className="absolute w-max rounded bg-white dark:bg-blue-d7 p-3 border border-prim">
           {options.map((status) => (
             <Listbox.Option key={status} value={status} as={Fragment}>
               {({ selected }) =>

--- a/src/pages/Admin/Review/Applications/Table/index.tsx
+++ b/src/pages/Admin/Review/Applications/Table/index.tsx
@@ -11,10 +11,7 @@ export default function Table(props: { applications: EndowmentProposal[] }) {
 
   return (
     <table className="w-full self-start font-work">
-      <TableSection
-        type="thead"
-        rowClass="border-b-2 border-gray-l2 dark:border-bluegray"
-      >
+      <TableSection type="thead" rowClass="border-b-2 border-prim">
         <Cells type="th" cellClass="p-2">
           <Header
             sortDirection={sortDirection}
@@ -44,10 +41,7 @@ export default function Table(props: { applications: EndowmentProposal[] }) {
           <></>
         </Cells>
       </TableSection>
-      <TableSection
-        type="tbody"
-        rowClass="border-b border-gray-l2 dark:border-bluegray"
-      >
+      <TableSection type="tbody" rowClass="border-b border-prim">
         {sortedApplications.map((app) => (
           <AppRow key={app.PK} {...app} />
         ))}

--- a/src/pages/Admin/Review/Templates/Nav.tsx
+++ b/src/pages/Admin/Review/Templates/Nav.tsx
@@ -9,7 +9,7 @@ const styler = createNavLinkStyler(
 
 export default function Nav() {
   return (
-    <div className="bg-white dark:bg-blue-d6 border border-gray-l2 dark:border-bluegray flex flex-col py-4 rounded">
+    <div className="bg-white dark:bg-blue-d6 border border-prim flex flex-col py-4 rounded">
       <Category title="Admin" />
       <NavLink end to={routes.cw4_members} className={styler}>
         Update group members

--- a/src/pages/Admin/Review/Templates/ReviewCW3Configurer/Form.tsx
+++ b/src/pages/Admin/Review/Templates/ReviewCW3Configurer/Form.tsx
@@ -21,7 +21,7 @@ export default function Form() {
         name="require_execution"
         classes={{
           container:
-            "p-3 text-sm rounded bg-orange-l6 dark:bg-blue-d7 grid items-center border border-gray-l2 dark:border-bluegray",
+            "p-3 text-sm rounded bg-orange-l6 dark:bg-blue-d7 grid items-center border border-prim",
         }}
       >
         Execution required

--- a/src/pages/Admin/templates/cw3/Config/Form.tsx
+++ b/src/pages/Admin/templates/cw3/Config/Form.tsx
@@ -21,7 +21,7 @@ export default function Form() {
         name="require_execution"
         classes={{
           container:
-            "p-3 text-sm rounded bg-orange-l6 dark:bg-blue-d7 grid items-center border border-gray-l2 dark:border-bluegray",
+            "p-3 text-sm rounded bg-orange-l6 dark:bg-blue-d7 grid items-center border border-prim",
         }}
       >
         Execution required

--- a/src/pages/Admin/templates/cw4/Members/Form.tsx
+++ b/src/pages/Admin/templates/cw4/Members/Form.tsx
@@ -13,7 +13,7 @@ export default function Form() {
       <TextArea<T> label="Proposal description" name="description" required />
 
       <Label className="text-red dark:text-red-l2 -mb-3">Remove member</Label>
-      <div className="p-3 rounded border border-gray-l2 dark:border-bluegray bg-orange-l6 dark:bg-blue-d7">
+      <div className="p-3 rounded border border-prim bg-orange-l6 dark:bg-blue-d7">
         <div className="flex flex-col gap-2 mb-2">
           {apCW4Members.map((member) => (
             <Member key={member.addr} {...member} />

--- a/src/pages/Donate/Steps/Donater/Form/AdvancedOptions/Split/Portion.tsx
+++ b/src/pages/Donate/Steps/Donater/Form/AdvancedOptions/Split/Portion.tsx
@@ -9,7 +9,7 @@ type Props = PropsWithChildren<{
 export default function Portion({ type, title, action, children }: Props) {
   const { disp_amount, disp_split } = usePortion(type);
   return (
-    <div className="flex flex-col items-center dark:bg-blue-d6 border border-gray-l2 dark:border-bluegray p-6 rounded">
+    <div className="flex flex-col items-center dark:bg-blue-d6 border border-prim p-6 rounded">
       <p className="uppercase font-bold text-sm md:text-lg">{title}</p>
       <p className="text-sm md:text-lg mb-2 font-bold">{disp_split}%</p>
       <p className="uppercase text-xs text-center w-24 font-body">{action}</p>

--- a/src/pages/Donate/Steps/Donater/Form/AdvancedOptions/Split/index.tsx
+++ b/src/pages/Donate/Steps/Donater/Form/AdvancedOptions/Split/index.tsx
@@ -4,7 +4,7 @@ import Slider from "./Slider";
 
 export default function Split() {
   return (
-    <div className="grid p-6 pt-4 font-heading border-t border-gray-l2 dark:border-bluegray">
+    <div className="grid p-6 pt-4 font-heading border-t border-prim">
       <p className="text-xs uppercase font-bold mb-2">Split</p>
       <div className="grid grid-cols-2 gap-2 mb-6">
         <Portion type="locked" title="Endowment" action="Compounded forever" />
@@ -12,7 +12,7 @@ export default function Split() {
           <Slider classes="my-2.5" />
         </Portion>
       </div>
-      <div className="flex items-center gap-4 px-4 py-3 text-center dark:bg-blue-d6 border border-gray-l2 dark:border-bluegray rounded">
+      <div className="flex items-center gap-4 px-4 py-3 text-center dark:bg-blue-d6 border border-prim rounded">
         <Icon type="Info" size={44} />
         <p className="text-sm leading-normal text-left">
           Donations into the Endowment provide sustainable financial runaway and

--- a/src/pages/Donate/Steps/Donater/Form/AdvancedOptions/index.tsx
+++ b/src/pages/Donate/Steps/Donater/Form/AdvancedOptions/index.tsx
@@ -15,7 +15,7 @@ export default function AdvancedOptions({ classes = "" }: Props) {
 
   return (
     <div
-      className={`grid ${classes} border border-gray-l2 dark:border-bluegray  rounded overflow-clip`}
+      className={`grid ${classes} border border-prim  rounded overflow-clip`}
     >
       <div className="flex items-center justify-between px-4 py-2 bg-orange-l6 dark:bg-blue-d7">
         <span className="font-bold py-2">
@@ -24,7 +24,7 @@ export default function AdvancedOptions({ classes = "" }: Props) {
         <button
           type="button"
           onClick={toggle}
-          className="border border-gray-l2 dark:border-bluegray h-full aspect-square rounded grid place-items-center"
+          className="border border-prim h-full aspect-square rounded grid place-items-center"
         >
           <Icon type={isOpen ? "Dash" : "Plus"} size={15} />
         </button>

--- a/src/pages/Donate/Steps/Donater/Form/Amount/index.tsx
+++ b/src/pages/Donate/Steps/Donater/Form/Amount/index.tsx
@@ -26,7 +26,7 @@ export default function Amount() {
         <Balance />
       </div>
 
-      <div className="relative grid grid-cols-[1fr_auto] items-center gap-2 py-3 px-4 dark:bg-blue-d6 border border-gray-l2 dark:border-bluegray rounded">
+      <div className="relative grid grid-cols-[1fr_auto] items-center gap-2 py-3 px-4 dark:bg-blue-d6 border border-prim rounded">
         <input
           {...register("token.amount")}
           autoComplete="off"

--- a/src/pages/Donate/Steps/Donater/Form/AmountOptions/index.tsx
+++ b/src/pages/Donate/Steps/Donater/Form/AmountOptions/index.tsx
@@ -27,7 +27,7 @@ export default function AmountOptions({ classes = "" }: { classes?: string }) {
             className={`${
               stepAmount === Number(amount)
                 ? "bg-blue-l3 border-blue-l3 dark:bg-blue-d2 dark:border-blue-d2"
-                : "bg-blue-l4 dark:bg-blue-d4 border-gray-l2 dark:border-bluegray"
+                : "bg-blue-l4 dark:bg-blue-d4 border-prim"
             }  rounded-full py-1.5 border`}
           >
             {s * 100}%

--- a/src/pages/Donate/Steps/Result/Success/Share.tsx
+++ b/src/pages/Donate/Steps/Result/Success/Share.tsx
@@ -44,19 +44,19 @@ function Prompt({ type, iconSize, recipient: { name } }: Props) {
   }, []);
 
   return (
-    <Dialog.Panel className="grid content-start fixed-center z-20 border border-gray-l2 dark:border-bluegray bg-gray-l5 dark:bg-blue-d5 font-work text-gray-d2 dark:text-white w-[91%] sm:w-full max-w-[39rem] rounded overflow-hidden">
-      <div className="grid place-items-center relative h-16 font-heading font-bold bg-orange-l5 dark:bg-blue-d7 border-b border-gray-l2 dark:border-bluegray">
+    <Dialog.Panel className="grid content-start fixed-center z-20 border border-prim bg-gray-l5 dark:bg-blue-d5 font-work text-gray-d2 dark:text-white w-[91%] sm:w-full max-w-[39rem] rounded overflow-hidden">
+      <div className="grid place-items-center relative h-16 font-heading font-bold bg-orange-l5 dark:bg-blue-d7 border-b border-prim">
         Share on {type}
         <button
           onClick={closeModal}
-          className="absolute top-1/2 transform -translate-y-1/2 right-4 w-10 h-10 border border-gray-l2 rounded dark:border-bluegray"
+          className="absolute top-1/2 transform -translate-y-1/2 right-4 w-10 h-10 border border-prim rounded "
         >
           <Icon type="Close" className="absolute-center" size={28} />
         </button>
       </div>
       <p
         ref={msgRef}
-        className="my-6 sm:my-10 mx-4 sm:mx-12 text-sm leading-normal p-3 border dark:bg-blue-d6 border-gray-l2 dark:border-bluegray rounded"
+        className="my-6 sm:my-10 mx-4 sm:mx-12 text-sm leading-normal p-3 border dark:bg-blue-d6 border-prim rounded"
       >
         I just donated to <span className="font-bold">{name}</span> on{" "}
         <span className="font-bold">@AngelProtocol</span>! Every gift is

--- a/src/pages/Donate/Steps/Result/Success/index.tsx
+++ b/src/pages/Donate/Steps/Result/Success/index.tsx
@@ -39,7 +39,7 @@ export default function Success({
         <span>View transaction</span>
       </BtnSec>
 
-      <div className="p-5 flex flex-col sm:flex-row items-center my-12 dark:bg-blue-d7 rounded border border-gray-l2 dark:border-bluegray w-full gap-2">
+      <div className="p-5 flex flex-col sm:flex-row items-center my-12 dark:bg-blue-d7 rounded border border-prim w-full gap-2">
         <span className="uppercase font-bold mb-6 mt-1 sm:my-0 sm:mr-auto">
           Share on social media
         </span>

--- a/src/pages/Donate/Steps/Submit/index.tsx
+++ b/src/pages/Donate/Steps/Submit/index.tsx
@@ -168,7 +168,7 @@ function Row({
 }: PropsWithChildren<{ classes?: string; title: string }>) {
   return (
     <div
-      className={`${classes} py-3 text-gray-d1 dark:text-gray flex items-center justify-between w-full border-b border-gray-l2 dark:border-bluegray last:border-none`}
+      className={`${classes} py-3 text-gray-d1 dark:text-gray flex items-center justify-between w-full border-b border-prim last:border-none`}
     >
       <p className="text-gray-d2 dark:text-white">{title}</p>
       {children}

--- a/src/pages/Donations/Filter/DateInput.tsx
+++ b/src/pages/Donations/Filter/DateInput.tsx
@@ -16,7 +16,7 @@ export default function DateInput<T extends FieldValues>({
       <input
         {...register(name as any)}
         type="date"
-        className="date-input uppercase text-sm relative w-full px-4 py-3 border border-gray-l2 dark:border-bluegray rounded-md border-collapse dark:bg-blue-d6"
+        className="date-input uppercase text-sm relative w-full px-4 py-3 border border-prim rounded-md border-collapse dark:bg-blue-d6"
       />
       <ErrorMessage
         errors={errors}

--- a/src/pages/Donations/Filter/Form.tsx
+++ b/src/pages/Donations/Filter/Form.tsx
@@ -18,7 +18,7 @@ const Form: FC<Props> = ({ onReset, submit, classes = "" }) => {
       as="form"
       onSubmit={submit}
       onReset={onReset}
-      className={`${classes} grid content-start gap-4 w-full rounded border border-gray-l2 dark:border-bluegray bg-white dark:bg-blue-d5`}
+      className={`${classes} grid content-start gap-4 w-full rounded border border-prim bg-white dark:bg-blue-d5`}
     >
       <div className="lg:hidden relative text-[1.25rem] px-4 py-3 -mb-4  font-bold uppercase">
         <span className="text-orange">Filters</span>
@@ -36,7 +36,7 @@ const Form: FC<Props> = ({ onReset, submit, classes = "" }) => {
       <NetworkDropdown classes="px-4 lg:px-6" />
       <CurrencyDropdown classes="px-4 lg:px-6 max-lg:mb-4" />
 
-      <div className="max-lg:row-start-2 flex gap-x-4 items-center justify-between max-lg:px-4 max-lg:py-3 p-6 lg:mt-2 bg-orange-l6 dark:bg-blue-d7 border-y lg:border-t border-gray-l2 dark:border-bluegray">
+      <div className="max-lg:row-start-2 flex gap-x-4 items-center justify-between max-lg:px-4 max-lg:py-3 p-6 lg:mt-2 bg-orange-l6 dark:bg-blue-d7 border-y lg:border-t border-prim">
         <h3 className="font-bold uppercase lg:hidden">Filter by</h3>
         <button
           type="reset"

--- a/src/pages/Donations/Filter/index.tsx
+++ b/src/pages/Donations/Filter/index.tsx
@@ -63,7 +63,7 @@ export default function Filter({
       <Popover.Button
         ref={buttonRef}
         disabled={isDisabled}
-        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l2 lg:dark:disabled:bg-bluegray-d1 lg:border lg:border-gray-l2 lg:dark:border-bluegray"
+        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l2 lg:dark:disabled:bg-bluegray-d1 lg:border lg:border-prim"
       >
         {({ open }) => (
           <>

--- a/src/pages/Donations/MobileTable.tsx
+++ b/src/pages/Donations/MobileTable.tsx
@@ -11,10 +11,8 @@ export default function MobileTable({ donations, classes = "" }: TableProps) {
   const showKYCForm = useKYC();
 
   return (
-    <div
-      className={`${classes} border border-gray-l2 dark:border-bluegray rounded`}
-    >
-      <div className="grid items-center grid-cols-8 uppercase text-xs font-bold bg-orange-l6 dark:bg-blue-d7 border-b border-gray-l2 dark:border-bluegray divide-x divide-gray-l2 dark:divide-bluegray rounded">
+    <div className={`${classes} border border-prim rounded`}>
+      <div className="grid items-center grid-cols-8 uppercase text-xs font-bold bg-orange-l6 dark:bg-blue-d7 border-b border-prim divide-x divide-prim rounded">
         <div />
         <div className="col-start-2 col-span-4 p-4">Recipient</div>
         <div className="col-span-3 p-4">Date</div>
@@ -25,9 +23,9 @@ export default function MobileTable({ donations, classes = "" }: TableProps) {
           <Disclosure
             key={index}
             as="div"
-            className="even:bg-orange-l6 dark:even:bg-blue-d7 w-full border-b border-gray-l2 dark:border-bluegray"
+            className="even:bg-orange-l6 dark:even:bg-blue-d7 w-full border-b border-prim"
           >
-            <Disclosure.Button className="w-full grid grid-cols-8 border-b last:border-0 border-gray-l2 dark:border-bluegray divide-x divide-gray-l2 dark:divide-bluegray ">
+            <Disclosure.Button className="w-full grid grid-cols-8 border-b last:border-0 border-prim divide-x divide-prim">
               {({ open }) => (
                 <>
                   <DrawerIcon

--- a/src/pages/Donations/Table.tsx
+++ b/src/pages/Donations/Table.tsx
@@ -21,7 +21,7 @@ export default function Table({ donations, classes = "" }: TableProps) {
     >
       <TableSection
         type="thead"
-        rowClass="bg-orange-l6 dark:bg-blue-d7 rounded divide-x border-b divide-gray-l2 dark:divide-bluegray border-gray-l2 dark:border-bluegray"
+        rowClass="bg-orange-l6 dark:bg-blue-d7 rounded divide-x border-b divide-prim border-prim"
       >
         <Cells
           type="th"
@@ -74,7 +74,7 @@ export default function Table({ donations, classes = "" }: TableProps) {
       </TableSection>
       <TableSection
         type="tbody"
-        rowClass="even:bg-orange-l6 dark:even:bg-blue-d7 divide-x divide-gray-l2 dark:divide-bluegray border-b last:border-b-0 border-gray-l2 dark:border-bluegray"
+        rowClass="even:bg-orange-l6 dark:even:bg-blue-d7 divide-x divide-prim border-b last:border-b-0 border-prim"
       >
         {sorted.map((row) => (
           <Cells key={row.hash} type="td" cellClass="p-3">

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -52,7 +52,7 @@ export default function Donations() {
       >
         Export to CSV
       </CsvExporter>
-      <div className="relative flex gap-x-3 items-center border border-gray-l2 dark:border-bluegray w-full bg-white dark:bg-blue-d6 rounded">
+      <div className="relative flex gap-x-3 items-center border border-prim w-full bg-white dark:bg-blue-d6 rounded">
         <Icon
           type="Search"
           size={24}

--- a/src/pages/Gift/Claim/Form.tsx
+++ b/src/pages/Gift/Claim/Form.tsx
@@ -62,8 +62,8 @@ export default function Form({ classes = "" }) {
       <h3 className="text-center text-3xl font-bold leading-snug">
         Redeem Angel Protocol Giftcard
       </h3>
-      <div className="relative grid w-full border border-gray-l2 dark:border-bluegray rounded-lg overflow-clip">
-        <p className="text-xs text-center uppercase text-gray-d1 dark:text-gray p-4 border-b border-gray-l2 dark:border-bluegray">
+      <div className="relative grid w-full border border-prim rounded-lg overflow-clip">
+        <p className="text-xs text-center uppercase text-gray-d1 dark:text-gray p-4 border-b border-prim">
           Type your giftcard code here:
         </p>
         <textarea

--- a/src/pages/Gift/Mailer/Form.tsx
+++ b/src/pages/Gift/Mailer/Form.tsx
@@ -57,7 +57,7 @@ export default function Form({ classes = "" }) {
         fieldName="message"
         classes={{
           container:
-            "rich-text-toolbar border border-gray-l2 dark:border-bluegray text-sm grid grid-rows-[auto_10rem] rounded bg-white dark:bg-blue-d6 aria-disabled:bg-gray-l4 aria-disabled:dark:bg-bluegray-d1 p-3 break-words",
+            "rich-text-toolbar border border-prim text-sm grid grid-rows-[auto_10rem] rounded bg-white dark:bg-blue-d6 aria-disabled:bg-gray-l4 aria-disabled:dark:bg-bluegray-d1 p-3 break-words",
           error: "text-right text-red dark:text-red-l1 text-xs -mt-4",
           charCounter: "text-gray-d1 dark:text-gray",
         }}

--- a/src/pages/Gift/Purchase/Purchaser/Form/Amount/index.tsx
+++ b/src/pages/Gift/Purchase/Purchaser/Form/Amount/index.tsx
@@ -24,7 +24,7 @@ export default function Amount() {
         <Balance />
       </div>
 
-      <div className="relative grid grid-cols-[1fr_auto] items-center gap-2 py-3 px-4 bg-white dark:bg-blue-d6 border border-gray-l2 dark:border-bluegray rounded">
+      <div className="relative grid grid-cols-[1fr_auto] items-center gap-2 py-3 px-4 bg-white dark:bg-blue-d6 border border-prim rounded">
         <input
           {...register("token.amount")}
           autoComplete="off"

--- a/src/pages/Gift/Purchase/Purchaser/Form/AmountOptions/index.tsx
+++ b/src/pages/Gift/Purchase/Purchaser/Form/AmountOptions/index.tsx
@@ -29,7 +29,7 @@ export default function AmountOptions({ classes = "" }: { classes?: string }) {
             className={`${
               m === Number(amount)
                 ? "bg-blue-l3 border-blue-l3 dark:bg-blue-d2 dark:border-blue-d2"
-                : "bg-blue-l4 dark:bg-blue-d4 border-gray-l2 dark:border-bluegray"
+                : "bg-blue-l4 dark:bg-blue-d4 border-prim"
             }  rounded-full py-1.5 border`}
           >
             {humanize(m, precision)}

--- a/src/pages/Gift/Purchase/Result/Success.tsx
+++ b/src/pages/Gift/Purchase/Result/Success.tsx
@@ -59,8 +59,8 @@ function EmailCode({ secret }: { secret: string }) {
       <p className="text-center font-heading mt-4 mb-8">
         Send the code below to your chosen recipient.
       </p>
-      <div className="grid border border-gray-l2 dark:border-bluegray rounded-lg overflow-clip">
-        <p className="text-xs text-center uppercase text-gray-d1 dark:text-gray p-4 border-b border-gray-l2 dark:border-bluegray">
+      <div className="grid border border-prim rounded-lg overflow-clip">
+        <p className="text-xs text-center uppercase text-gray-d1 dark:text-gray p-4 border-b border-prim">
           Your giftcard code:
         </p>
         <p className="bg-orange-l6 dark:bg-blue-d7 p-4 font-bold text-center text-3xl leading-relaxed break-all">

--- a/src/pages/Gift/Purchase/Submit/index.tsx
+++ b/src/pages/Gift/Purchase/Submit/index.tsx
@@ -155,7 +155,7 @@ function Row({
 }: PropsWithChildren<{ classes?: string; title: string }>) {
   return (
     <div
-      className={`${classes} py-3 text-gray-d1 dark:text-gray flex items-center justify-between w-full border-b border-gray-l2 dark:border-bluegray last:border-none`}
+      className={`${classes} py-3 text-gray-d1 dark:text-gray flex items-center justify-between w-full border-b border-prim last:border-none`}
     >
       <p className="text-gray-d2 dark:text-white">{title}</p>
       {children}

--- a/src/pages/Leaderboard/Table/Row/Amount/Summary.tsx
+++ b/src/pages/Leaderboard/Table/Row/Amount/Summary.tsx
@@ -6,7 +6,7 @@ import { AmountProps } from ".";
 export default function Summary({ locked, liquid, type }: AmountProps) {
   const { closeModal } = useModalContext();
   return (
-    <Dialog.Panel className="grid content-start bg-gray-l5 dark:bg-blue-d5 text-gray-d2 border border-gray-l2 dark:border-bluegray dark:text-white font-work fixed-center z-20 p-8 rounded-2xl shadow-lg max-w-md">
+    <Dialog.Panel className="grid content-start bg-gray-l5 dark:bg-blue-d5 text-gray-d2 border border-prim dark:text-white font-work fixed-center z-20 p-8 rounded-2xl shadow-lg max-w-md">
       <Amount title="principal" value={locked} />
       <Amount title="impact" value={liquid} />
       <button

--- a/src/pages/Leaderboard/Table/index.tsx
+++ b/src/pages/Leaderboard/Table/index.tsx
@@ -10,12 +10,12 @@ type Props = {
 export default function Table({ classes = "", endowments }: Props) {
   return (
     <div
-      className={`${classes} h-[50rem] overflow-y-scroll scroller border border-gray-l2 dark:border-bluegray rounded`}
+      className={`${classes} h-[50rem] overflow-y-scroll scroller border border-prim rounded`}
     >
       <table className="border-collapse table-auto w-full">
         <TableSection
           type="thead"
-          rowClass="border-b border-gray-l2 dark:border-bluegray bg-orange-l6 dark:bg-blue-d6"
+          rowClass="border-b border-prim bg-orange-l6 dark:bg-blue-d6"
         >
           <Cells
             type="th"

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -24,7 +24,7 @@ export default function Card({
   kyc_donors_only,
 }: EndowmentCard) {
   return (
-    <div className="relative overflow-clip dark:bg-blue-d6 rounded-lg border border-gray-l2 dark:border-bluegray hover:border-blue dark:hover:border-blue">
+    <div className="relative overflow-clip dark:bg-blue-d6 rounded-lg border border-prim hover:border-blue dark:hover:border-blue">
       <div className="absolute top-[14px] left-[14px] right-[14px] flex justify-between gap-3">
         <p className="bg-orange-l1 text-white font-semibold text-2xs rounded-sm uppercase px-2 py-0.5 font-heading">
           {endow_type === "Charity" ? "Non-profit" : "For-profit"}
@@ -88,7 +88,7 @@ function SDG({ num }: { num: UNSDG_NUMS }) {
       <Tooltip anchorRef={ref} content={unsdgs[num].title} />
       <div
         ref={ref}
-        className="flex items-center bg-blue-l4 hover:bg-blue-l3 dark:bg-blue-d4 hover:dark:bg-blue-d3 h-4 px-1 py-1 border border-gray-l2 dark:border-bluegray rounded-lg"
+        className="flex items-center bg-blue-l4 hover:bg-blue-l3 dark:bg-blue-d4 hover:dark:bg-blue-d3 h-4 px-1 py-1 border border-prim rounded-lg"
       >
         SDG #{num}
       </div>

--- a/src/pages/Marketplace/Sidebar/common/FlatFilter.tsx
+++ b/src/pages/Marketplace/Sidebar/common/FlatFilter.tsx
@@ -14,7 +14,7 @@ export function FlatFilter<T>(props: GroupProps<T>) {
   return (
     <Listbox
       as="div"
-      className="grid gap-6 px-2 py-4 border-b border-gray-l2 dark:border-bluegray"
+      className="grid gap-6 px-2 py-4 border-b border-prim"
       multiple
       value={props.selectedValues}
       onChange={props.onChange}

--- a/src/pages/Marketplace/Sidebar/common/MultilevelFilter/MultilevelFilter.tsx
+++ b/src/pages/Marketplace/Sidebar/common/MultilevelFilter/MultilevelFilter.tsx
@@ -19,9 +19,7 @@ export function MultilevelFilter<T>(props: MultiLevelFilterProps<T>) {
   return (
     <div
       className={`grid gap-6 px-2 py-4 ${
-        props.hideBottomBorder
-          ? ""
-          : "border-b border-gray-l2 dark:border-bluegray"
+        props.hideBottomBorder ? "" : "border-b border-prim"
       }`}
     >
       <Drawer isOpen={isOpen} toggle={toggle}>

--- a/src/pages/Marketplace/Sidebar/index.tsx
+++ b/src/pages/Marketplace/Sidebar/index.tsx
@@ -15,15 +15,15 @@ export default function Sidebar({ classes = "" }: { classes?: string }) {
 
   return (
     <div
-      className={`border border-gray-l2 dark:border-bluegray dark:bg-blue-d5 dark:text-white overflow-y-auto md:overflow-hidden md:rounded-md content-start md:h-fit md:w-80 bg-gray-l5 ${classes}`}
+      className={`border border-prim dark:bg-blue-d5 dark:text-white overflow-y-auto md:overflow-hidden md:rounded-md content-start md:h-fit md:w-80 bg-gray-l5 ${classes}`}
     >
-      <div className="flex justify-between p-3 items-center md:hidden bg-orange-l6 dark:bg-blue-d7 border-b border-gray-l2 dark:border-bluegray">
+      <div className="flex justify-between p-3 items-center md:hidden bg-orange-l6 dark:bg-blue-d7 border-b border-prim">
         <h3 className="text-orange text-xl font-black uppercase">Filters</h3>
         <button onClick={toggleFilter} className="active:text-orange">
           <Icon type="Close" size={25} />
         </button>
       </div>
-      <div className="bg-orange-l6 dark:bg-blue-d7 flex items-center justify-between p-4 border-b border-gray-l2 dark:border-bluegray">
+      <div className="bg-orange-l6 dark:bg-blue-d7 flex items-center justify-between p-4 border-b border-prim">
         <h3 className="uppercase font-bold">Filter by</h3>
         <button
           type="button"

--- a/src/pages/Marketplace/Toolbar/Search.tsx
+++ b/src/pages/Marketplace/Toolbar/Search.tsx
@@ -23,7 +23,7 @@ export default function Search({ classes = "" }: { classes?: string }) {
 
   return (
     <div
-      className={`${classes} flex gap-2 items-center  dark:text-gray-l2 border border-gray-l2 dark:border-bluegray rounded-lg overflow-clip`}
+      className={`${classes} flex gap-2 items-center  dark:text-gray-l2 border border-prim rounded-lg overflow-clip`}
     >
       <Icon
         type={isLoading ? "Loading" : "Search"}

--- a/src/pages/Marketplace/Toolbar/Sorter.tsx
+++ b/src/pages/Marketplace/Toolbar/Sorter.tsx
@@ -45,7 +45,7 @@ export default function Sorter() {
       as="div"
       className="relative min-w-[10rem]"
     >
-      <div className="w-full h-full flex items-center justify-between text-[0.9375rem] py-2 pl-3 dark:text-gray-l2 border border-gray-l2 dark:border-bluegray rounded-lg font-bold">
+      <div className="w-full h-full flex items-center justify-between text-[0.9375rem] py-2 pl-3 dark:text-gray-l2 border border-prim rounded-lg font-bold">
         <Listbox.Button className="upppercase flex items-center justify-between w-full">
           {({ open }) => (
             <>

--- a/src/pages/Profile/Body/GeneralInfo/Content/Container.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/Content/Container.tsx
@@ -9,7 +9,7 @@ export default function Container(props: Props) {
   const [isOpen, setOpen] = useState(true);
 
   return (
-    <div className="flex flex-col gap-px w-full border border-gray-l2 rounded dark:bg-blue-d6 dark:border-bluegray">
+    <div className="flex flex-col gap-px w-full border border-prim rounded dark:bg-blue-d6 ">
       <Header
         isOpen={isOpen}
         title={props.title}
@@ -28,14 +28,14 @@ function Header(props: {
 }) {
   return (
     <div
-      className={`flex items-center justify-between px-8 py-5 w-full bg-orange-l5 border-gray-l2 rounded dark:bg-blue-d7 dark:border-bluegray ${
+      className={`flex items-center justify-between px-8 py-5 w-full bg-orange-l5 border-prim rounded dark:bg-blue-d7 ${
         props.isOpen ? "border-b" : ""
       }`}
     >
       <span className="font-heading font-bold text-xl">{props.title}</span>
       <button
         onClick={props.onClick}
-        className="flex items-center justify-center p-px w-10 h-10 border border-gray-l2 rounded dark:border-bluegray"
+        className="flex items-center justify-center p-px w-10 h-10 border border-prim rounded "
       >
         <Icon type={props.isOpen ? "Dash" : "Plus"} />
       </button>

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
@@ -15,7 +15,7 @@ export default function Balances() {
 
 function Balance(props: { title: string; amount: number }) {
   return (
-    <div className="flex flex-col justify-center items-center gap-2 h-20 w-full py-4 rounded border border-gray-l2 dark:bg-blue-d6 dark:border-bluegray md:items-start md:h-28 md:px-6 md:py-04">
+    <div className="flex flex-col justify-center items-center gap-2 h-20 w-full py-4 rounded border border-prim dark:bg-blue-d6 md:items-start md:h-28 md:px-6 md:py-04">
       <h6 className="font-heading font-bold text-xs tracking-wider uppercase">
         {props.title}
       </h6>

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/DetailsColumn.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/DetailsColumn.tsx
@@ -10,7 +10,7 @@ export default function DetailsColumn({ className }: { className: string }) {
       <Balances />
 
       <div
-        className={`${className} flex flex-col gap-8 w-full lg:w-96 p-8 border border-gray-l2 rounded text-gray-d2 dark:bg-blue-d6 dark:border-bluegray dark:text-white`}
+        className={`${className} flex flex-col gap-8 w-full lg:w-96 p-8 border border-prim rounded text-gray-d2 dark:bg-blue-d6  dark:text-white`}
       >
         <Details />
         <Tags />

--- a/src/pages/Profile/Logo.tsx
+++ b/src/pages/Profile/Logo.tsx
@@ -3,7 +3,7 @@ import { useProfileContext } from "./ProfileContext";
 
 const container = "h-48 w-48";
 
-const logoStyle = `${container} border border-gray-l2 rounded-full object-cover dark:border-bluegray bg-white`;
+const logoStyle = `${container} border border-prim rounded-full object-cover bg-white`;
 
 export default function Logo() {
   return (

--- a/src/pages/Registration/Steps/Dashboard/Step.tsx
+++ b/src/pages/Registration/Steps/Dashboard/Step.tsx
@@ -22,7 +22,7 @@ export default function Step({
     <div
       className={`py-6 pl-2 pr-4 grid grid-cols-[1fr_auto_auto] items-center border-b ${
         num === 1 ? "border-t" : ""
-      } border-gray-l2 dark:border-bluegray `}
+      } border-prim `}
     >
       <p className="mr-auto text-left">{title[num]}</p>
 

--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -82,14 +82,14 @@ function Step({
       {/** line */}
       <div
         className={`h-[22px] border-l ${
-          isDone ? "border-orange" : "border-gray-l2 dark:border-bluegray"
+          isDone ? "border-orange" : "border-prim"
         } my-2 group-first:hidden`}
       />
       <div className="flex items-center">
         {/** circle */}
         <div
           className={`w-4 aspect-square ${
-            isDone ? "bg-orange" : "bg-gray-l2 dark:bg-bluegray"
+            isDone ? "bg-orange" : "border-prim"
           } rounded-full transform -translate-x-1/2`}
         />
         <span

--- a/src/pages/Registration/Steps/Reference.tsx
+++ b/src/pages/Registration/Steps/Reference.tsx
@@ -11,7 +11,7 @@ export default function Reference({ id, classes = "" }: Props) {
 
   return (
     <div
-      className={`${classes} w-full py-4 px-6 text-sm text-left md:text-center bg-gray-l5 dark:bg-blue-d5 text-gray-d2 dark:text-white md:text-gray-d1 md:dark:text-gray md:border-t border-gray-l2 dark:border-bluegray rounded-b-lg`}
+      className={`${classes} w-full py-4 px-6 text-sm text-left md:text-center bg-gray-l5 dark:bg-blue-d5 text-gray-d2 dark:text-white md:text-gray-d1 md:dark:text-gray md:border-t border-prim rounded-b-lg`}
     >
       <div className="relative">
         <span className="font-semibold mr-2">Your registration number:</span>
@@ -53,6 +53,6 @@ function WithTooltip(props: {
       ` ${
         props.classes ?? "" /** control position */
       } relative before:w-48 before:z-10 before:content-[attr(data-before-content)] hover:before:block before:hidden before:absolute  
-      before:text-xs before:bg-gray-l5 before:dark:bg-blue-d6 before:text-gray-d1 before:dark:text-gray before:border before:border-gray-l2 before:dark:border-bluegray before:p-2 before:rounded`,
+      before:text-xs before:bg-gray-l5 before:dark:bg-blue-d6 before:text-gray-d1 before:dark:text-gray before:border before:border-prim before:p-2 before:rounded`,
   });
 }

--- a/src/pages/Registration/Steps/WalletRegistration/ChooseWallet/KeplrConnector.tsx
+++ b/src/pages/Registration/Steps/WalletRegistration/ChooseWallet/KeplrConnector.tsx
@@ -20,7 +20,7 @@ export default function KeplrConnector() {
   return (
     <button
       onClick={handleConnect}
-      className="flex items-center border border-gray-l2 dark:border-bluegray w-full p-4 rounded"
+      className="flex items-center border border-prim w-full p-4 rounded"
     >
       <img
         src={keplrWalletLogo}

--- a/src/pages/Registration/Steps/WalletRegistration/RegisteredWallet.tsx
+++ b/src/pages/Registration/Steps/WalletRegistration/RegisteredWallet.tsx
@@ -17,12 +17,12 @@ export default function RegisteredWallet(props: {
         time.
       </p>
 
-      <div className="grid mt-8 border border-gray-l2 dark:border-bluegray p-8 rounded">
+      <div className="grid mt-8 border border-prim p-8 rounded">
         {/** TODO: only address:string is saved in DB, can't determine what wallet corresponds to that address
          *  should also save: { name, logo }
          */}
         <p className="text-sm mb-2">Your Wallet address:</p>
-        <p className="relative px-4 py-3 border border-gray-l2 dark:border-bluegray rounded flex items-center text-sm truncate">
+        <p className="relative px-4 py-3 border border-prim rounded flex items-center text-sm truncate">
           <span className="truncate pr-6">{props.address}</span>
           <Copier
             text={props.address}

--- a/src/pages/Registration/Steps/WalletRegistration/WalletSubmission.tsx
+++ b/src/pages/Registration/Steps/WalletRegistration/WalletSubmission.tsx
@@ -41,7 +41,7 @@ export default function WalletSubmission({
       <h3 className="text-center md:text-left text-lg font-bold">
         You are already connected to a Wallet:
       </h3>
-      <div className="grid grid-cols-[auto_1fr] items-center border border-gray-l2 dark:border-bluegray p-4 rounded mt-8">
+      <div className="grid grid-cols-[auto_1fr] items-center border border-prim p-4 rounded mt-8">
         <img
           src={walletIcon}
           alt=""

--- a/src/pages/Registration/Steps/index.tsx
+++ b/src/pages/Registration/Steps/index.tsx
@@ -55,7 +55,7 @@ export default function Steps({ classes = "" }: { classes?: string }) {
 
   return (
     <div
-      className={`w-full md:w-[90%] max-w-[62.5rem] md:pt-8 grid md:grid-cols-[auto_1fr] md:border border-gray-l2 dark:border-bluegray rounded-none md:rounded-lg bg-white dark:bg-blue-d6 ${classes}`}
+      className={`w-full md:w-[90%] max-w-[62.5rem] md:pt-8 grid md:grid-cols-[auto_1fr] md:border border-prim rounded-none md:rounded-lg bg-white dark:bg-blue-d6 ${classes}`}
     >
       <ProgressIndicator
         step={regState.step}


### PR DESCRIPTION
Ticket(s):
N/A Abstract this widespread utility combination for easier future UI styling

## Explanation of the solution
* `border-gray-l2 dark:border-bluegray` --> `border-prim` - just `prim` to encapsulate both `gray` and `bluegray`
* `divide-gray-l2 dark:divide-bluegray` --> `divide-prim`

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes