### PR TITLE
upgrade loader-utils version (v1.7 prod)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,9 @@
     "yup": "^0.32.9"
   },
   "resolutions": {
-    "tailwindcss": "3.2.4"
+    "tailwindcss": "3.2.4",
+    "loader-utils@^2.0.0": "^2.0.4",
+    "loader-utils@^3.2.0": "^3.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13100,21 +13100,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loader-utils@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "loader-utils@npm:2.0.2"
+"loader-utils@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "loader-utils@npm:2.0.4"
   dependencies:
     big.js: ^5.2.2
     emojis-list: ^3.0.0
     json5: ^2.1.2
-  checksum: 9078d1ed47cadc57f4c6ddbdb2add324ee7da544cea41de3b7f1128e8108fcd41cd3443a85b7ee8d7d8ac439148aa221922774efe4cf87506d4fb054d5889303
+  checksum: a5281f5fff1eaa310ad5e1164095689443630f3411e927f95031ab4fb83b4a98f388185bb1fe949e8ab8d4247004336a625e9255c22122b815bb9a4c5d8fc3b7
   languageName: node
   linkType: hard
 
-"loader-utils@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "loader-utils@npm:3.2.0"
-  checksum: c7b9a8dc4b3bc19e9ef563c48e3a18ea9f8bb2da1ad38a12e4b88358cfba5f148a7baf12d78fe78ffcb718ce1e062ab31fcf5c148459f1247a672a4213471e80
+"loader-utils@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "loader-utils@npm:3.2.1"
+  checksum: 4e3ea054cdc8be1ab1f1238f49f42fdf0483039eff920fb1d442039f3f0ad4ebd11fb8e584ccdf2cb7e3c56b3d40c1832416e6408a55651b843da288960cc792
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ticket(s):
- N/A

## Explanation of the solution
- Bump `loader-utils` to `^3.2.1` to patch critical vuln with package.json "resolutions", accounting for 2.0.0 > 2.0.4. 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## UI changes for review
None