### PR TITLE
Disable webpack side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angelprotocol-web-app",
+  "sideEffects": false,
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Made on the basis of Justin's analysis of the problem of huge bundles in https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/1665

It would seem that the problem is that we have [webpack side-effects](https://webpack.js.org/configuration/module/#rulesideeffects) turned on - this causes webpack to NOT perform tree-shaking on non-used exports.
When I set this option to `false` in `package.json`, I was able to achieve similar results as the one in https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/1665 with just a single-line change. The `main` bundle was actually even smaller by `200 kB`. 

![image](https://user-images.githubusercontent.com/19427053/214773787-3d31e394-8458-45d1-95e0-abc8847b4d29.png)

See this official webpack tutorial on tree shaking for more info https://webpack.js.org/guides/tree-shaking