### PR TITLE
Move closeModal to ImgCropper

### DIFF
--- a/src/components/ImgEditor/ImgCropper.tsx
+++ b/src/components/ImgEditor/ImgCropper.tsx
@@ -2,6 +2,7 @@ import { Dialog } from "@headlessui/react";
 import Cropper from "cropperjs";
 import "cropperjs/dist/cropper.min.css";
 import { useCallback, useRef } from "react";
+import { useModalContext } from "contexts/ModalContext";
 import Icon from "components/Icon";
 
 type Props = {
@@ -11,6 +12,8 @@ type Props = {
 };
 
 export default function ImgCropper({ preview, aspect: [x, y], onSave }: Props) {
+  const { closeModal } = useModalContext();
+
   const cropperRef = useRef<Cropper>();
 
   const imgRef = useCallback(
@@ -31,6 +34,7 @@ export default function ImgCropper({ preview, aspect: [x, y], onSave }: Props) {
     if (cropperRef.current) {
       cropperRef.current.getCroppedCanvas().toBlob((blob) => {
         onSave(blob);
+        closeModal();
       });
     }
   }

--- a/src/components/ImgEditor/useImgEditor.ts
+++ b/src/components/ImgEditor/useImgEditor.ts
@@ -18,7 +18,7 @@ export default function useImgEditor<T extends FieldValues, K extends keyof T>({
   const previewPath: any = `${String(name)}.${previewKey}`;
 
   const { setValue, watch } = useFormContext<T>();
-  const { showModal, closeModal } = useModalContext();
+  const { showModal } = useModalContext();
   const {
     field: { value: currFile, onChange: onFileChange },
   } = useController<T>({ name: filePath });
@@ -66,7 +66,6 @@ export default function useImgEditor<T extends FieldValues, K extends keyof T>({
         type: originalFile.type,
       })
     );
-    closeModal();
   }
 
   function handleReset() {


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/865bm3814

## Explanation of the solution
The issue was caused by the way [JS closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures) work, specifically related to `closeModal` func. The func checks if there's any open modal before closing it by [checking for existence of `state`](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/RC-v1.7.1/src/contexts/ModalContext.tsx#L52) and if it does not exist, it throws an error from the CU task.
When we pass this func as part of `handleCropResult` in [handleOpenCropper](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/RC-v1.7.1/src/components/ImgEditor/useImgEditor.ts#L52), it creates a closure in which `closeModal` always checks an undefined `state`, thus assuming no modal was open. The `ImgCropper`, which is responsible for closing the modal on save, receives this version of `closeModal` and even when `state` changes (and by extension `closeModal` changes), the func version passed to `ImgCropper` **remains the same**, which is to say it remains the version from when `state` was `undefined`.
So due to the `ImgCropper.onSave` closure, which only includes this old version of `closeModal`, we get the error that no modal was open.

Moving `closeModal` to `ImgCropper` directly fixes the issue, as it allows for auto-updating of `closeModal` once `state` changes. This is also a safe place to put this, as `ImgCropper` is a dialog that should be closed on saving.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify issue no longer appears
