### PR TITLE
Add "Clear Filters" btn to sidebar

### DIFF
--- a/src/pages/Marketplace/Sidebar/index.tsx
+++ b/src/pages/Marketplace/Sidebar/index.tsx
@@ -1,6 +1,6 @@
 import Icon from "components/Icon";
 import { useSetter } from "store/accessors";
-import { reset, toggle } from "slices/components/marketFilter";
+import { clear, reset, toggle } from "slices/components/marketFilter";
 import Designations from "./Designations";
 import KYCFilter from "./KYCFilter";
 import Regions from "./Regions";
@@ -28,6 +28,15 @@ export default function Sidebar({ classes = "" }: { classes?: string }) {
         <h3 className="uppercase font-bold">Filter by</h3>
         <button
           type="button"
+          title="Remove all filter selections."
+          onClick={() => dispatch(clear())}
+          className="text-gray-d1 dark:text-gray-l2 text-sm"
+        >
+          Clear Filters
+        </button>
+        <button
+          type="button"
+          title="Reset all filters to their default values."
           onClick={() => dispatch(reset())}
           className="text-gray-d1 dark:text-gray-l2 text-sm"
         >

--- a/src/slices/components/marketFilter/constants.ts
+++ b/src/slices/components/marketFilter/constants.ts
@@ -51,3 +51,17 @@ export const initialState: FilterState = {
   kyc_only: [true, false],
   tiers: ["Level2", "Level3"],
 };
+
+export const clearedState: FilterState = {
+  sdgGroups: SDG_GROUPS.reduce(
+    (prev, curr) => ({ ...prev, [curr.key]: [] }),
+    {} as SdgGroups
+  ),
+  region: { activities: {}, headquarters: {} },
+  isOpen: false,
+  searchText: "",
+  endow_types: ["Charity"],
+  endow_designation: [],
+  kyc_only: [],
+  tiers: ["Level2", "Level3"],
+};

--- a/src/slices/components/marketFilter/marketFilter.ts
+++ b/src/slices/components/marketFilter/marketFilter.ts
@@ -3,12 +3,16 @@ import { RegionType, Sort } from "./types";
 import { EndowDesignation } from "types/aws";
 import { CapitalizedEndowmentType } from "types/contracts";
 import { UNSDG_NUMS } from "types/lists";
-import { initialState } from "./constants";
+import { clearedState, initialState } from "./constants";
 
 const marketFilter = createSlice({
   name: "marketFilter",
   initialState,
   reducers: {
+    clear: (state) => {
+      // clears everything except isOpen && sortKey
+      return { ...clearedState, isOpen: state.isOpen, sortKey: state.sort };
+    },
     reset: (state) => {
       //reset everything except isOpen && sortKey
       return { ...initialState, isOpen: state.isOpen, sortKey: state.sort };
@@ -62,6 +66,7 @@ const marketFilter = createSlice({
 export const {
   setSdgs,
   setRegions,
+  clear,
   reset,
   toggle,
   setTypes,


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/863fzg29f

## Explanation of the solution
- Adds a "Clear Filters" button to the filters SideBar in Marketplace. Clicking said button results in filters being cleared out (well nearly, as we don't clear ones that user cannot directly affect like Tiers). User is then free to select the items they want to see (1 sdg group or such). 
- Adds "title" to both filter buttons along with brief descriptions on what they do. Good for accessibility/screen readers and overall to help clarify buttons function/intent.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp