### PR TITLE
FIX: erc20 gas calc is wrong

### DIFF
--- a/src/pages/Donate/Steps/Submit/estimateDonation.ts
+++ b/src/pages/Donate/Steps/Submit/estimateDonation.ts
@@ -129,7 +129,7 @@ export async function estimateDonation({
         );
         const minFee = gasLimit.mul(gasPrice);
         feeAmount = parseFloat(
-          ethers.utils.formatUnits(minFee, token.decimals)
+          ethers.utils.formatUnits(minFee, native_currency.decimals)
         );
       }
 


### PR DESCRIPTION
Ticket(s): N/A

incorrect fee figure
<img width="407" alt="image" src="https://user-images.githubusercontent.com/89639563/216609614-085b68bd-8b87-444b-a5a0-5181c92f9c7a.png">

NOTE:  fee estimates for erc20  are just for presentation, wallet is ultiamately responsible for setting fees

## Explanation of the solution
* fix: use gas token decimal for condensing fee 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes