### PR TITLE
FIX: proxy testnet endpoints

### DIFF
--- a/src/contexts/WalletContext/useKeplr/chains.ts
+++ b/src/contexts/WalletContext/useKeplr/chains.ts
@@ -1,6 +1,5 @@
 import { ChainInfo } from "@keplr-wallet/types";
 import { JUNO_LCD_OVERRIDE, JUNO_RPC_OVERRIDE } from "constants/env";
-import { APIs } from "constants/urls";
 
 // is used only when running on Juno Testnet
 export const juno_test_chain_info: ChainInfo = {
@@ -8,8 +7,12 @@ export const juno_test_chain_info: ChainInfo = {
   // modified denoms
   chainId: "uni-6",
   chainName: "Juno Testnet",
-  rpc: JUNO_RPC_OVERRIDE || `${APIs.aws}/juno/uni-6/rpc`,
-  rest: JUNO_LCD_OVERRIDE || `${APIs.aws}/juno/uni-6/lcd`,
+  rpc:
+    JUNO_RPC_OVERRIDE ||
+    "https://59vigz9r91.execute-api.us-east-1.amazonaws.com/juno/uni-6/rpc",
+  rest:
+    JUNO_LCD_OVERRIDE ||
+    "https://59vigz9r91.execute-api.us-east-1.amazonaws.com/juno/uni-6/lcd",
   stakeCurrency: {
     coinDenom: "JUNOX",
     coinMinimalDenom: "ujunox",


### PR DESCRIPTION
Ticket(s): N/A
other lcd enpoints are still in `uni-5`
except:
```
https://uni-rpc.reece.sh/
https://uni-api.reece.sh/
```
but this is not accessible to web-app because of CORS


## Explanation of the solution
* proxy via aws gatetway


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes