### PR TITLE
Route to a Widget page

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,6 +1,5 @@
 export enum appRoutes {
   index = "/",
-  aif = "/aif",
   dashboard = "/dashboard",
   marketplace = "/marketplace",
   leaderboard = "/leaderboard",
@@ -16,6 +15,7 @@ export enum appRoutes {
   donations = "/donations",
   donate = "/donate",
   donate_widget = "/donate-widget",
+  widget = "/widget",
   gift = "/gift",
 }
 


### PR DESCRIPTION
Ticket(s):
- N/A

## Explanation of the solution
Current product is shaping up to have publicly accessable widget page for anyone to build a widget for any endowment on our platform. This PR starts by moving the widget config page to a "Widget" route from the old "AIF" route (something that will no longer be needed due to AIFs living in a separate app/server).

### Other items left to do (in future PRs): 
- [x] Page should be public
- [ ] Endowment ID in URL path `/{id}` should be optional
    - [ ] if none, show dropdown of Endowments to pick on
    - [ ] if given, have said endowment selected

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## UI changes for review
None