### PR TITLE
Marketplace cards spacing removed

### DIFF
--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -47,33 +47,29 @@ export default function Card({
         />
         <div className="flex flex-col p-3 pb-4 gap-3">
           {/* ENDOWMENT NAME */}
-          <h3 className="font-bold text-ellipsis line-clamp-2">
-            {name}
-          </h3>
+          <h3 className="font-bold text-ellipsis line-clamp-2">{name}</h3>
           {/* TAGLINE */}
           {tagline && tagline !== PLACEHOLDER_TAGLINE ? (
             <p className="peer text-gray-d1 dark:text-gray text-sm -mt-2">
               {tagline}
             </p>
           ) : null}
+          {/* HQ & ACTIVE-IN COUNTRIES */}
+          <div className="text-gray-d1 dark:text-gray text-sm">
+            {hq.country && (
+              <p>
+                <span className="font-semibold">HQ:</span> {hq.country}
+                {hq.city && hq.city !== PLACEHOLDER_CITY ? `, ${hq.city}` : ""}
+              </p>
+            )}
+            {!isEmpty(active_in_countries) && (
+              <p className="line-clamp-2">
+                <span className="font-semibold">Active in:</span>{" "}
+                {active_in_countries.join(" ,")}
+              </p>
+            )}
+          </div>
           <div className="mt-auto empty:hidden grid gap-3">
-            {/* HQ & ACTIVE-IN COUNTRIES */}
-            <div className="text-gray-d1 dark:text-gray text-sm">
-              {hq.country && (
-                <p>
-                  <span className="font-semibold">HQ:</span> {hq.country}
-                  {hq.city && hq.city !== PLACEHOLDER_CITY
-                    ? `, ${hq.city}`
-                    : ""}
-                </p>
-              )}
-              {!isEmpty(active_in_countries) && (
-                <p className="line-clamp-2">
-                  <span className="font-semibold">Active in:</span>{" "}
-                  {active_in_countries.join(" ,")}
-                </p>
-              )}
-            </div>
             {/** UN SDGs - always on bottom */}
             {!isEmpty(sdgs) && (
               <div className="flex text-3xs font-bold uppercase gap-1 h-max-[40px]">


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/860pvppcw
- https://app.clickup.com/t/860pvpmvn

## Explanation of the solution
- Removes fixed widths for cards (save for clamp-2 on titles)
- Moves Countries items off the bottom to remove the perception of a large gap between the title/tagline and rest of the card

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## UI changes for review
![image](https://user-images.githubusercontent.com/85138450/217459996-393cbe0c-79c0-4139-8703-edc9b425b8a2.png)