### PR TITLE
FIX: limit giftcard denom to usdc on mainnet

### DIFF
--- a/src/pages/Gift/Purchase/Purchaser/index.tsx
+++ b/src/pages/Gift/Purchase/Purchaser/index.tsx
@@ -4,6 +4,8 @@ import { FormValues } from "./types";
 import { TokenWithAmount } from "types/slices";
 import { WithWallet } from "contexts/WalletContext";
 import { FormStep } from "slices/gift";
+import { IS_TEST } from "constants/env";
+import { denoms } from "constants/tokens";
 import Form from "./Form";
 import { schema } from "./schema";
 
@@ -12,10 +14,12 @@ export default function Purchaser({
   wallet,
   ...state
 }: WithWallet<FormStep> & { classes?: string }) {
-  const _tokens: TokenWithAmount[] = wallet.coins.map((t) => ({
-    ...t,
-    amount: "0",
-  }));
+  const _tokens: TokenWithAmount[] = wallet.coins
+    .filter((t) => IS_TEST || t.token_id === denoms.axlusdc)
+    .map((t) => ({
+      ...t,
+      amount: "0",
+    }));
 
   const methods = useForm<FormValues>({
     mode: "onChange",


### PR DESCRIPTION
Ticket(s):
https://app.clickup.com/t/860pvdw4z

## Explanation of the solution
* add filter in when network = mainnet

## Instructions on making this work
* to test: override juno lcd and rpc endpoints to avoid CORs

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes