### PR TITLE
[Bug Fix] Updated Charity Registration Submit's API Version

### DIFF
--- a/src/services/aws/registration/registration.ts
+++ b/src/services/aws/registration/registration.ts
@@ -136,7 +136,7 @@ const registration_api = aws.injectEndpoints({
     submit: builder.mutation<SubmitResult, { ref: string; chain_id: string }>({
       invalidatesTags: [{ type: "admin", id: adminTags.registration }],
       query: ({ ref, chain_id }) => ({
-        url: `v2/registration/${ref}/submit`,
+        url: `v3/registration/${ref}/submit`,
         method: "POST",
         body: { chain_id },
       }),


### PR DESCRIPTION
Ticket(s):
- [1.7.1 testing - Registration failed](https://app.clickup.com/t/860pvpex2)

## Explanation of the solution
Updated the version of the API for Charity Registration Submit from `v2` to `v3`. The `v3` endpoint does not include the `Profile` fields when creating an application proposal.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go through the typical registration process, verify that you can submit your application without errors

## UI changes for review
N/A