### PR TITLE
open header logo in new tab/page

### DIFF
--- a/src/App/Header/Logo.tsx
+++ b/src/App/Header/Logo.tsx
@@ -1,14 +1,14 @@
 import angelProtocolLogo from "assets/images/angelprotocol-beta-horiz-wht.svg";
+import ExtLink from "components/ExtLink";
 
 export default function Logo() {
   return (
-    <a
+    <ExtLink
       href="https://angelprotocol.io/"
       title="Go to Marketing page"
       className="w-32"
-      target="_blank"
     >
       <img src={angelProtocolLogo} alt="" className="w-full h-full" />
-    </a>
+    </ExtLink>
   );
 }


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/860pwp9wq

## Explanation of the solution
Adds a blank target to main header logo.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## UI changes for review
None