### PR TITLE
Remove string template from app title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <!-- Primary Meta Tags -->
-    <title>Support an impact organization - {APP_NAME}</title>
+    <title>Support an impact organization - Angel Giving</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Explanation of the solution
String templates appearing while the app is loading the JS parts (containing the `APP_NAME` constant).

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify app title no longer contains string templates while loading

## UI changes for review

Before while loading the page (the JS parts):
![image](https://user-images.githubusercontent.com/19427053/218956308-98b28868-8833-4c08-996b-1041353cdc64.png)

After:
![image](https://user-images.githubusercontent.com/19427053/218956659-f8f23501-4add-42e6-a499-d0d514b9711b.png)

