### PR TITLE
Active in should show HQ Country if empty

### DIFF
--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -62,12 +62,12 @@ export default function Card({
                 {hq.city && hq.city !== PLACEHOLDER_CITY ? `, ${hq.city}` : ""}
               </p>
             )}
-            {!isEmpty(active_in_countries) && (
-              <p className="line-clamp-2">
-                <span className="font-semibold">Active in:</span>{" "}
-                {active_in_countries.join(" ,")}
-              </p>
-            )}
+            <p className="line-clamp-2">
+              <span className="font-semibold">Active in:</span>{" "}
+              {isEmpty(active_in_countries)
+                ? hq.country
+                : active_in_countries.join(" ,")}
+            </p>
           </div>
           <div className="mt-auto empty:hidden grid gap-3">
             {/** UN SDGs - always on bottom */}

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Details.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Details.tsx
@@ -19,11 +19,11 @@ export default function Details() {
       {!!profile.street_address && (
         <Detail title="address">{profile.street_address}</Detail>
       )}
-      {!isEmpty(profile.active_in_countries) && (
-        <Detail title="active in">
-          {profile.active_in_countries.join(", ")}
-        </Detail>
-      )}
+      <Detail title="active in">
+        {isEmpty(profile.active_in_countries)
+          ? profile.hq.country
+          : profile.active_in_countries.join(", ")}
+      </Detail>
       {/* <Detail title="endowment address">
         <span className="flex items-center gap-4 w-full">
           <span className="hidden sm:block">


### PR DESCRIPTION
Ticket(s):
- https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1753

## Explanation of the solution
Based on work in @SovereignAndrey's draft PR https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/1756/files#diff-970588d33b9c9fecc3a980b881fcd975eaf15183e504ef25b83cb31c37007fa1

**NOTE**: will be able to verify the work is done correctly 100% once https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/1783 is merged in.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to marketplace
- verify charities with no "active countries" show their HQ countries as "active in" ones
- verify the same on profile pages (details column)
