### PR TITLE
HQ Country attribute refactor

### DIFF
--- a/src/pages/Admin/Charity/EditProfile/index.tsx
+++ b/src/pages/Admin/Charity/EditProfile/index.tsx
@@ -34,7 +34,7 @@ function FormWithContext(props: EndowmentProfile) {
   const flatInitial: FlatFormValues = {
     name: props.name,
     categories_sdgs: props.categories.sdgs,
-    hq_country: props.hq_country || "",
+    hq_country: props.hq_country,
     active_in_countries: props.active_in_countries,
     image: props.image || "",
     logo: props.logo || "",

--- a/src/pages/Admin/Charity/EditProfile/index.tsx
+++ b/src/pages/Admin/Charity/EditProfile/index.tsx
@@ -34,7 +34,7 @@ function FormWithContext(props: EndowmentProfile) {
   const flatInitial: FlatFormValues = {
     name: props.name,
     categories_sdgs: props.categories.sdgs,
-    hq_country: props.hq.country || "",
+    hq_country: props.hq_country || "",
     active_in_countries: props.active_in_countries,
     image: props.image || "",
     logo: props.logo || "",
@@ -57,7 +57,7 @@ function FormWithContext(props: EndowmentProfile) {
     ...flatInitial,
     image: { name: "", publicUrl: props.image, preview: props.image },
     logo: { name: "", publicUrl: props.logo, preview: props.logo },
-    hq_country: { flag: "", name: props.hq.country || "" },
+    hq_country: { flag: "", name: props.hq_country || "" },
     categories_sdgs: props.categories.sdgs.map((x) =>
       getSDGLabelValuePair(x, unsdgs[x].title)
     ),

--- a/src/pages/Admin/Charity/EditProfile/index.tsx
+++ b/src/pages/Admin/Charity/EditProfile/index.tsx
@@ -57,7 +57,7 @@ function FormWithContext(props: EndowmentProfile) {
     ...flatInitial,
     image: { name: "", publicUrl: props.image, preview: props.image },
     logo: { name: "", publicUrl: props.logo, preview: props.logo },
-    hq_country: { flag: "", name: props.hq_country || "" },
+    hq_country: { flag: "", name: props.hq_country },
     categories_sdgs: props.categories.sdgs.map((x) =>
       getSDGLabelValuePair(x, unsdgs[x].title)
     ),

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -55,7 +55,7 @@ export default function Card({
           ) : null}
           {/* HQ & ACTIVE-IN COUNTRIES */}
           <div className="text-gray-d1 dark:text-gray text-sm">
-            {hq_country && (
+   
               <p>
                 <span className="font-semibold">HQ:</span> {hq_country}
               </p>

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -9,7 +9,6 @@ import { isEmpty } from "helpers";
 import { appRoutes } from "constants/routes";
 import { unsdgs } from "constants/unsdgs";
 
-const PLACEHOLDER_CITY = "City";
 const PLACEHOLDER_TAGLINE = " ";
 
 export default function Card({
@@ -20,7 +19,7 @@ export default function Card({
   endow_type,
   categories: { sdgs },
   tagline,
-  hq,
+  hq_country,
   kyc_donors_only,
 }: EndowmentCard) {
   return (
@@ -56,16 +55,15 @@ export default function Card({
           ) : null}
           {/* HQ & ACTIVE-IN COUNTRIES */}
           <div className="text-gray-d1 dark:text-gray text-sm">
-            {hq.country && (
+            {hq_country && (
               <p>
-                <span className="font-semibold">HQ:</span> {hq.country}
-                {hq.city && hq.city !== PLACEHOLDER_CITY ? `, ${hq.city}` : ""}
+                <span className="font-semibold">HQ:</span> {hq_country}
               </p>
             )}
             <p className="line-clamp-2">
               <span className="font-semibold">Active in:</span>{" "}
               {isEmpty(active_in_countries)
-                ? hq.country
+                ? hq_country
                 : active_in_countries.join(" ,")}
             </p>
           </div>

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -55,11 +55,9 @@ export default function Card({
           ) : null}
           {/* HQ & ACTIVE-IN COUNTRIES */}
           <div className="text-gray-d1 dark:text-gray text-sm">
-   
-              <p>
-                <span className="font-semibold">HQ:</span> {hq_country}
-              </p>
-            )}
+            <p>
+              <span className="font-semibold">HQ:</span> {hq_country}
+            </p>
             <p className="line-clamp-2">
               <span className="font-semibold">Active in:</span>{" "}
               {isEmpty(active_in_countries)

--- a/src/pages/Profile/Body/Body.tsx
+++ b/src/pages/Profile/Body/Body.tsx
@@ -41,12 +41,12 @@ export default function Body() {
             </div>
             <p className="w-full font-normal text-lg">{profile.tagline}</p>
           </div>
-          {(profile.hq.country || profile.url) && (
+          {(profile.hq_country || profile.url) && (
             <div className="flex flex-col lg:flex-row gap-4 lg:gap-6 items-center w-full font-semibold text-base">
-              {profile.hq.country && (
+              {profile.hq_country && (
                 <span className="flex items-center gap-2 uppercase">
                   <Icon type="MapPin" className="h-6 w-6 text-orange" />
-                  {profile.hq.country}
+                  {profile.hq_country}
                 </span>
               )}
               {profile.url && (

--- a/src/pages/Profile/Body/Body.tsx
+++ b/src/pages/Profile/Body/Body.tsx
@@ -41,26 +41,24 @@ export default function Body() {
             </div>
             <p className="w-full font-normal text-lg">{profile.tagline}</p>
           </div>
-            <div className="flex flex-col lg:flex-row gap-4 lg:gap-6 items-center w-full font-semibold text-base">
-                <span className="flex items-center gap-2 uppercase">
-                  <Icon type="MapPin" className="h-6 w-6 text-orange" />
-                  {profile.hq_country}
-                </span>
-              )}
-              {profile.url && (
-                <span className="flex items-center gap-2">
-                  <Icon type="Globe" className="h-6 w-6 text-orange" />
-                  <ExtLink
-                    href={profile.url}
-                    title="organization website"
-                    className="cursor-pointer underline decoration-1 hover:text-orange hover:decoration-2"
-                  >
-                    {profile.url.replace(/^https?:\/\//i, "")}
-                  </ExtLink>
-                </span>
-              )}
-            </div>
-          )}
+          <div className="flex flex-col lg:flex-row gap-4 lg:gap-6 items-center w-full font-semibold text-base">
+            <span className="flex items-center gap-2 uppercase">
+              <Icon type="MapPin" className="h-6 w-6 text-orange" />
+              {profile.hq_country}
+            </span>
+            {profile.url && (
+              <span className="flex items-center gap-2">
+                <Icon type="Globe" className="h-6 w-6 text-orange" />
+                <ExtLink
+                  href={profile.url}
+                  title="organization website"
+                  className="cursor-pointer underline decoration-1 hover:text-orange hover:decoration-2"
+                >
+                  {profile.url.replace(/^https?:\/\//i, "")}
+                </ExtLink>
+              </span>
+            )}
+          </div>
         </div>
 
         <GeneralInfo className="order-4 lg:col-span-2 w-full h-full" />

--- a/src/pages/Profile/Body/Body.tsx
+++ b/src/pages/Profile/Body/Body.tsx
@@ -41,9 +41,7 @@ export default function Body() {
             </div>
             <p className="w-full font-normal text-lg">{profile.tagline}</p>
           </div>
-          {(profile.hq_country || profile.url) && (
             <div className="flex flex-col lg:flex-row gap-4 lg:gap-6 items-center w-full font-semibold text-base">
-              {profile.hq_country && (
                 <span className="flex items-center gap-2 uppercase">
                   <Icon type="MapPin" className="h-6 w-6 text-orange" />
                   {profile.hq_country}

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Details.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Details.tsx
@@ -21,7 +21,7 @@ export default function Details() {
       )}
       <Detail title="active in">
         {isEmpty(profile.active_in_countries)
-          ? profile.hq.country
+          ? profile.hq_country
           : profile.active_in_countries.join(", ")}
       </Detail>
       {/* <Detail title="endowment address">

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -86,11 +86,10 @@ export const aws = createApi({
     profile: builder.query<EndowmentProfile, number>({
       providesTags: ["profile"],
       query: (endowId) => `/v1/profile/${network}/endowment/${endowId}`,
-      transformResponse({ tagline, hq, ...rest }: EndowmentProfile) {
+      transformResponse({ tagline, ...rest }: EndowmentProfile) {
         //transform cloudsearch placeholders
         return {
           tagline: tagline === " " ? "" : tagline,
-          hq: { ...hq, city: hq.city === "City" ? "" : hq.city },
           ...rest,
         };
       },

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -3,7 +3,7 @@ import { CapitalizedEndowmentType } from "../../contracts";
 import { NetworkType, UNSDG_NUMS } from "../../lists";
 
 type EndowmentBase = {
-  hq: { country?: string; city?: string };
+  hq_country: string;
   active_in_countries: string[];
   categories: { sdgs: UNSDG_NUMS[] };
   id: number;


### PR DESCRIPTION
## Explanation of the solution
The `hq` object which previously contains the `city` and `country` fields is now changed to become just a top-level field, `hq_country`. This is due to `city` being deprecated and the `hq` object just containing one field. This make things like fetching (Marketplace card/s and Profile page) or profile updating (Endow Admin Profile Updating and Charity Reg Process) more consistent.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Verify that the Marketplace card/s are displayed correctly
- Verify that the HQ Country in an endowment's profile page is displayed correctly
- Try to update the `hq_country` of an endowment and verify that it runs smoothly ⛸️ 
- Double check that Marketplace card and Profile page for that endowment (if it did change)

## UI changes for review
None