### PR TITLE
Update canius-lite version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6722,17 +6722,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001370, caniuse-lite@npm:^1.0.30001373":
-  version: 1.0.30001382
-  resolution: "caniuse-lite@npm:1.0.30001382"
-  checksum: 186ec65230bf315c4dbfb2785be811653869aaa7713c5e83dfa9ca9396be371f5e02a0dfe56b9c7069ad9ecff811d316b507d8a7c700d429e423d8808dee5771
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001400":
-  version: 1.0.30001443
-  resolution: "caniuse-lite@npm:1.0.30001443"
-  checksum: e39c17c54c7a2e263c05a7391b1126014be88826e5cacd6cf9e976b87c5a3a3ea3e53ff5d410093dbd56fac7b50fba4d55c2fa4d6b9c6bd28202886d7fedfd70
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001370, caniuse-lite@npm:^1.0.30001373, caniuse-lite@npm:^1.0.30001400":
+  version: 1.0.30001455
+  resolution: "caniuse-lite@npm:1.0.30001455"
+  checksum: afefd8a908993c032b5dc899156d961e59b2ed50b2b2cb9f51d388d8ac9fe0a65993e08b78213016ac0cc793cc77338c20cd961ef2f7dd726cd7157ab69b70c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation of the solution
We should all update `canius-lite` pkg versions locally as it can reduce the app bundle size, see https://github.com/browserslist/update-db#readme

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
