### PR TITLE
Remove widget link

### DIFF
--- a/src/App/Header/MobileNav/Menu/AdminMobileNavPortal.tsx
+++ b/src/App/Header/MobileNav/Menu/AdminMobileNavPortal.tsx
@@ -49,13 +49,13 @@ export function AdminMobileNavPortal({ id }: { id: number }) {
             >
               Proposals
             </NavLink>
-            <NavLink
+            {/*            <NavLink
               end
               to={`${appRoutes.admin}/${id}/${adminRoutes.widget_config}/${id}`}
               className={navLinkStyle}
             >
               Embed Widget
-            </NavLink>
+            </NavLink>*/}
           </div>
         </>,
         document.querySelector(`#${adminMobileNavId}`)!

--- a/src/pages/Admin/Charity/Nav.tsx
+++ b/src/pages/Admin/Charity/Nav.tsx
@@ -4,7 +4,7 @@ import { adminRoutes } from "constants/routes";
 import { useAdminResources } from "../Guard";
 
 export default function Nav() {
-  const { endowmentId } = useAdminResources();
+  // const { endowmentId } = useAdminResources();
 
   return (
     <div className="hidden lg:flex justify-end">
@@ -20,13 +20,13 @@ export default function Nav() {
       <NavLink end to={adminRoutes.proposals} className={styler}>
         Proposals
       </NavLink>
-      <NavLink
+      {/*      <NavLink
         end
         to={`${adminRoutes.widget_config}/${endowmentId}`}
         className={styler}
       >
         Embed Widget
-      </NavLink>
+      </NavLink>*/}
     </div>
   );
 }


### PR DESCRIPTION
Contributes to #1802 

## Explanation of the solution
Temp removal of the Widget page link from all navs (until the beta testing period is done and ready for public rollout)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## UI changes for review
None