### PR TITLE
add a check for undefined array

### DIFF
--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -60,7 +60,7 @@ export default function Card({
             </p>
             <p className="line-clamp-2">
               <span className="font-semibold">Active in:</span>{" "}
-              {isEmpty(active_in_countries)
+              {!active_in_countries || isEmpty(active_in_countries)
                 ? hq_country
                 : active_in_countries.join(" ,")}
             </p>

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Details.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Details.tsx
@@ -20,7 +20,7 @@ export default function Details() {
         <Detail title="address">{profile.street_address}</Detail>
       )}
       <Detail title="active in">
-        {isEmpty(profile.active_in_countries)
+        {!!profile.active_in_countries && isEmpty(profile.active_in_countries)
           ? profile.hq_country
           : profile.active_in_countries.join(", ")}
       </Detail>


### PR DESCRIPTION
Ticket(s):
-

## Explanation of the solution
Cards in Marketplace & Profiles details col logic wasn't handling possiblilty of undefined `active_in_countries` array. Adds that check in before `isEmpty()` check. 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes