### PR TITLE
move balances to state query

### DIFF
--- a/src/helpers/admin/getTagPayloads.ts
+++ b/src/helpers/admin/getTagPayloads.ts
@@ -54,7 +54,7 @@ export function getTagPayloads(type?: ProposalMeta["type"]): TagPayload[] {
     case "acc_withdraw":
       _tags.push({
         type: "account",
-        id: accountTags.balance,
+        id: accountTags.state,
       });
       break;
 

--- a/src/pages/Admin/Charity/Dashboard/Balance.tsx
+++ b/src/pages/Admin/Charity/Dashboard/Balance.tsx
@@ -1,6 +1,6 @@
 import { AccountType } from "types/contracts";
 import { useAdminResources } from "pages/Admin/Guard";
-import { useBalanceQuery } from "services/juno/account";
+import { useStateQuery } from "services/juno/account";
 import QueryLoader from "components/QueryLoader";
 import Holdings from "../Holdings";
 import { accountTypeDisplayValue } from "../constants";
@@ -8,7 +8,7 @@ import { accountTypeDisplayValue } from "../constants";
 type Props = { type: AccountType };
 export default function Balance({ type }: Props) {
   const { endowmentId } = useAdminResources();
-  const queryState = useBalanceQuery({ id: endowmentId });
+  const queryState = useStateQuery({ id: endowmentId });
 
   return (
     <div className="rounded p-3 border border-prim bg-orange-l6 dark:bg-blue-d6">
@@ -22,9 +22,7 @@ export default function Balance({ type }: Props) {
           error: "Failed to get balances",
         }}
       >
-        {(balance) => (
-          <Holdings {...balance.tokens_on_hand[type]} type={type} />
-        )}
+        {(state) => <Holdings {...state.tokens_on_hand[type]} type={type} />}
       </QueryLoader>
     </div>
   );

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/index.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/index.tsx
@@ -1,11 +1,11 @@
 import { Tab } from "@headlessui/react";
 import { useLocation } from "react-router-dom";
-import { AccountType, EndowmentBalance } from "types/contracts";
+import { AccountType, EndowmentState } from "types/contracts";
 import { accountTypeDisplayValue } from "../../constants";
 import Withdrawer from "./Withdrawer";
 
 const tabs: AccountType[] = ["liquid", "locked"];
-export default function WithdrawTabs({ tokens_on_hand }: EndowmentBalance) {
+export default function WithdrawTabs({ tokens_on_hand }: EndowmentState) {
   const { state } = useLocation(); //state is set from dashboard withdraw link
   const type = state as AccountType;
   return (

--- a/src/pages/Admin/Charity/Withdraws/index.tsx
+++ b/src/pages/Admin/Charity/Withdraws/index.tsx
@@ -1,12 +1,12 @@
 import { useAdminResources } from "pages/Admin/Guard";
-import { useBalanceQuery } from "services/juno/account";
+import { useStateQuery } from "services/juno/account";
 import QueryLoader from "components/QueryLoader";
 import Transactions from "./Transactions";
 import WithdrawTabs from "./WithdrawTabs";
 
 export default function Withdraws() {
   const { endowmentId } = useAdminResources();
-  const queryState = useBalanceQuery({ id: endowmentId });
+  const queryState = useStateQuery({ id: endowmentId });
 
   return (
     <div className="grid content-start font-work">

--- a/src/services/juno/account.ts
+++ b/src/services/juno/account.ts
@@ -24,17 +24,17 @@ export const account_api = junoApi.injectEndpoints({
         };
       },
     }),
-    balance: builder.query<Result<"accBalance">, Args<"accBalance">>({
-      providesTags: [{ type: "account", id: accountTags.balance }],
-      query: (args) => genQueryPath("accBalance", args, accounts),
-      transformResponse: (res: Res<"accBalance">) => {
+    state: builder.query<Result<"accState">, Args<"accState">>({
+      providesTags: [{ type: "account", id: accountTags.state }],
+      query: (args) => genQueryPath("accState", args, accounts),
+      transformResponse: (res: Res<"accState">) => {
         return res.data;
       },
     }),
   }),
 });
 
-export const { useBalanceQuery, useEndowmentsQuery } = account_api;
+export const { useStateQuery, useEndowmentsQuery } = account_api;
 
 async function getEndowments(
   limit: 50,

--- a/src/services/juno/queryContract/queryObjects.ts
+++ b/src/services/juno/queryContract/queryObjects.ts
@@ -87,7 +87,7 @@ export const queryObject: {
   accEndowment({ id }) {
     return { endowment: { id } };
   },
-  accBalance({ id }) {
-    return { balance: { id } };
+  accState({ id }) {
+    return { state: { id } };
   },
 };

--- a/src/services/juno/queryContract/types.ts
+++ b/src/services/juno/queryContract/types.ts
@@ -7,10 +7,10 @@ import {
   CW4Member,
   CW20Balance,
   CW20Info,
-  EndowmentBalance,
   EndowmentDetails,
   EndowmentEntry,
   EndowmentQueryOptions,
+  EndowmentState,
   FundDetails,
   GenericBalance,
   GovConfig,
@@ -114,10 +114,10 @@ export interface ContractQueries {
     res: Q<EndowmentDetails>;
     result: EndowmentDetails;
   };
-  accBalance: {
+  accState: {
     args: { id: number };
-    res: Q<EndowmentBalance>;
-    result: EndowmentBalance;
+    res: Q<EndowmentState>;
+    result: EndowmentState;
   };
 }
 

--- a/src/services/juno/tags.ts
+++ b/src/services/juno/tags.ts
@@ -47,7 +47,7 @@ export enum accountTags {
   endowment = "endowment",
   endowments = "endowments",
   profile = "profile",
-  balance = "balance",
+  state = "state",
 }
 
 export const defaultProposalTags: FullTagDescription<JunoTag>[] = [

--- a/src/types/contracts/account.ts
+++ b/src/types/contracts/account.ts
@@ -19,14 +19,18 @@ export interface BalanceInfo {
   liquid: GenericBalance;
 }
 
+export interface DonationsReceived {
+  locked: number;
+  liquid: number;
+}
+
 type VaultWithBalance = [string /** vauld addr */, string /** vault balance */];
 
-export interface EndowmentBalance {
+export interface EndowmentState {
   tokens_on_hand: BalanceInfo;
-  oneoff_locked: VaultWithBalance[];
-  oneoff_liquid: VaultWithBalance[];
-  strategies_locked: VaultWithBalance[];
-  strategies_liquid: VaultWithBalance[];
+  donations_received: DonationsReceived;
+  closing_endowment: boolean;
+  closing_beneficiary?: string;
 }
 
 interface RebalanceDetails {


### PR DESCRIPTION
Ticket(s):
- N/A

## Explanation of the solution
Cosmwasm `v1.9` contracts moved the query of balances into the state query (for a given endowment ID). This PR updates the web app to use the right query endpoint and added needed query logic, interfaces and types to do so. 

Ex. View Admin dashboard for on-chain balance query: http://localhost:4200/admin/1

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## UI changes for review
None