### PR TITLE
validate amount  on withdraw network change

### DIFF
--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Network.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Network.tsx
@@ -9,8 +9,9 @@ export default function Network() {
 
   useEffect(() => {
     (async () => {
-      //validate address on network change
+      //validate address and amount on network change
       await trigger("beneficiary");
+      await trigger("amounts");
     })();
   }, [network, trigger]);
 


### PR DESCRIPTION
Ticket(s):
-[Fix warning "minimum 20 USDC" appearing when switching the withdraw destination network to JUNO#1814](https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1814)

## Explanation of the solution
- now we trigger validations for amount also (along with beneficiery) on network change

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes