### PR TITLE
no need for createLinkGroupsFunction just to pass `id`

### DIFF
--- a/src/pages/Admin/Charity/WidgetConfigurer/useWidgetConfigurer.ts
+++ b/src/pages/Admin/Charity/WidgetConfigurer/useWidgetConfigurer.ts
@@ -9,8 +9,12 @@ import useLoadDefaultEndowmentName from "./useLoadDefaultEndowmentName";
 const NO_ID_MESSAGE = "Please select an organization";
 
 export default function useWidgetConfigurer() {
-  const { endowId: id } = useParams<{ endowId: string }>();
-  const endowId = idParamToNum(id);
+  const { endowId: id, id: adminId } = useParams<{
+    endowId: string;
+    id: string;
+  }>();
+  //if no endow-id passed, use admin-id
+  const endowId = idParamToNum(id || adminId);
 
   const [updateTriggered, setUpdateTriggered] = useState(false);
 

--- a/src/pages/Admin/Charity/index.tsx
+++ b/src/pages/Admin/Charity/index.tsx
@@ -75,7 +75,7 @@ function createLinkGroups(endowId: number): LinkGroup[] {
         LINKS[adminRoutes.proposals],
         {
           ...LINKS[adminRoutes.widget_config],
-          to: `${LINKS[adminRoutes.widget_config].to}/${endowId}`,
+          to: `${LINKS[adminRoutes.widget_config].to}`,
         },
       ],
     },


### PR DESCRIPTION
Ticket(s):


## Explanation of the solution
* just get `id` from `useParams` to avoid this 
* comment
https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/1804#discussion_r1111661617

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes