### PR TITLE
Display `tokens_on_hand` Balance in Endow Profile Page

### DIFF
--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
@@ -2,13 +2,13 @@ import { humanize } from "helpers";
 import { useProfileContext } from "../../../ProfileContext";
 
 export default function Balances() {
-  const { total_liq, total_lock, overall } = useProfileContext();
+  const { on_hand_liq, on_hand_lock, on_hand_overall } = useProfileContext();
 
   return (
     <div className="flex flex-col items-center gap-4 w-full">
-      <Balance title="Total Value" amount={overall} />
-      <Balance title="Total Endowment Account" amount={total_lock} />
-      <Balance title="Total Current Account" amount={total_liq} />
+      <Balance title="Total Value" amount={on_hand_overall} />
+      <Balance title="Total Endowment Account" amount={on_hand_lock} />
+      <Balance title="Total Current Account" amount={on_hand_liq} />
     </div>
   );
 }

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -30,9 +30,15 @@ export type EndowmentProfile = EndowmentBase & {
   };
   street_address?: string;
 
+  // represents total cumulative balances
   total_liq: number;
   total_lock: number;
   overall: number;
+
+  // represents tokens on hand balances (takes into account withdrawn funds)
+  on_hand_liq: number;
+  on_hand_lock: number;
+  on_hand_overall: number;
 
   url?: string;
 };


### PR DESCRIPTION
Ticket(s):
- Closes #1843

## Explanation of the solution
There's a discrepancy when an endowment admin checks their balance from the Admin page and when they check it from the Profile page. The Admin page balance shows the `tokens_on_hand` balance which makes sense so that they will know if they can still withdraw funds. The Profile page balance shows the `donations_received` balance which is a cumulative metric, it does not take into account the withdrawn funds. And before the [implementation of the new fields](https://github.com/AngelProtocolFinance/devops/pull/200) in AWS, we don't have this `tokens_on_hand` fields in our DB records.

To address this discrepancy in the balances displayed, we have to use the new "on-hand" fields returned by the fetch endpoint. These are `on_hand_liq, on_hand_lock, on_hand_overall`.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Connect an admin wallet
- Open "your" endowment's Admin page in a new tab & on current tab, open "your" Profile page
- Make sure that the balances shown in the Admin page is the same with the Profile page

## UI changes for review
None