### PR TITLE
Hide 'load more' btn on donations table when no items are there to load

### DIFF
--- a/src/pages/Donations/LoadMoreBtn.tsx
+++ b/src/pages/Donations/LoadMoreBtn.tsx
@@ -14,7 +14,7 @@ export default function LoadMoreBtn({
       type="button"
       onClick={onLoadMore}
       disabled={disabled}
-      className="flex items-center justify-center gap-3 uppercase text-sm font-bold border-x border-b border-prim rounded-b h-12 mb-4 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-gray aria-disabled:bg-gray-l3 aria-disabled:dark:bg-bluegray disabled:dark:bg-bluegray"
+      className="flex items-center justify-center gap-3 uppercase text-sm font-bold rounded-b w-full h-12 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-gray aria-disabled:bg-gray-l3 aria-disabled:dark:bg-bluegray disabled:dark:bg-bluegray"
     >
       {isLoading ? (
         <>

--- a/src/pages/Donations/LoadMoreBtn.tsx
+++ b/src/pages/Donations/LoadMoreBtn.tsx
@@ -1,0 +1,28 @@
+import LoaderRing from "components/LoaderRing";
+
+export default function LoadMoreBtn({
+  onLoadMore,
+  disabled,
+  isLoading,
+}: {
+  onLoadMore(): void;
+  disabled: boolean;
+  isLoading: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onLoadMore}
+      disabled={disabled}
+      className="flex items-center justify-center gap-3 uppercase text-sm font-bold border-x border-b border-prim rounded-b h-12 mb-4 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-gray aria-disabled:bg-gray-l3 aria-disabled:dark:bg-bluegray disabled:dark:bg-bluegray"
+    >
+      {isLoading ? (
+        <>
+          <LoaderRing thickness={10} classes="w-6" /> Loading...
+        </>
+      ) : (
+        "Load More"
+      )}
+    </button>
+  );
+}

--- a/src/pages/Donations/MobileTable.tsx
+++ b/src/pages/Donations/MobileTable.tsx
@@ -96,14 +96,14 @@ export default function MobileTable({
             )}
           </Disclosure>
         ))}
+        {hasMore && (
+          <LoadMoreBtn
+            onLoadMore={onLoadMore}
+            disabled={disabled}
+            isLoading={isLoading}
+          />
+        )}
       </div>
-      {hasMore && (
-        <LoadMoreBtn
-          onLoadMore={onLoadMore}
-          disabled={disabled}
-          isLoading={isLoading}
-        />
-      )}
     </>
   );
 }

--- a/src/pages/Donations/MobileTable.tsx
+++ b/src/pages/Donations/MobileTable.tsx
@@ -5,83 +5,106 @@ import Icon, { DrawerIcon } from "components/Icon";
 import useKYC from "components/KYC/useKYC";
 import useSort from "hooks/useSort";
 import { humanize } from "helpers";
+import LoadMoreBtn from "./LoadMoreBtn";
 
-export default function MobileTable({ donations, classes = "" }: TableProps) {
+export default function MobileTable({
+  donations,
+  classes = "",
+  disabled,
+  isLoading,
+  hasMore,
+  onLoadMore,
+}: TableProps) {
   const { sorted } = useSort(donations);
   const showKYCForm = useKYC();
 
   return (
-    <div className={`${classes} border border-prim rounded-t`}>
-      <div className="grid items-center grid-cols-[auto_1fr_auto] h-12 uppercase text-xs font-bold bg-orange-l6 dark:bg-blue-d7 border-b border-prim divide-x divide-prim rounded-t">
-        <div className="w-12" />
-        <div className="p-4">Recipient</div>
-        <div className="p-4 w-28 text-center">Date</div>
-      </div>
+    <>
+      <div
+        className={`${classes} border border-prim ${
+          hasMore ? "rounded-t" : "rounded"
+        }`}
+      >
+        <div className="grid items-center grid-cols-[auto_1fr_auto] h-12 uppercase text-xs font-bold bg-orange-l6 dark:bg-blue-d7 border-b border-prim divide-x divide-prim rounded-t">
+          <div className="w-12" />
+          <div className="p-4">Recipient</div>
+          <div className="p-4 w-28 text-center">Date</div>
+        </div>
 
-      {sorted.map((row, index) => (
-        <Disclosure
-          key={index}
-          as="div"
-          className="text-sm odd:bg-orange-l6 dark:even:bg-blue-d6 dark:odd:bg-blue-d7 w-full border-b last:border-0 border-prim"
-        >
-          {({ open }) => (
-            <>
-              <Disclosure.Button
-                className={`${
-                  open ? "bg-orange-l5 dark:bg-blue-d4" : ""
-                } w-full grid grid-cols-[auto_1fr_auto] divide-x divide-prim`}
-              >
-                <DrawerIcon
-                  size={24}
+        {sorted.map((row, index) => (
+          <Disclosure
+            key={index}
+            as="div"
+            className={`text-sm odd:bg-orange-l6 dark:even:bg-blue-d6 dark:odd:bg-blue-d7 w-full border-b last:border-0 border-prim ${
+              hasMore ? "" : "last:rounded-b"
+            }`}
+          >
+            {({ open }) => (
+              <>
+                <Disclosure.Button
                   className={`${
-                    open ? "text-orange" : ""
-                  } w-12 place-self-center`}
-                  isOpen={open}
-                />
-                <p className="text-sm p-4 text-left h-full truncate">
-                  {row.charityName}
-                </p>
-                <div className="p-4 text-center text-sm w-28">
-                  {new Date(row.date).toLocaleDateString()}
-                </div>
-              </Disclosure.Button>
-              <Disclosure.Panel className="w-full font-work divide-y divide-prim">
-                <Row title="Network">{row.chainName}</Row>
-                <Row title="Currency">{row.symbol}</Row>
-                <Row title="Amount">{humanize(row.amount, 3)}</Row>
-                <Row title="USD Value">{`$${humanize(row.usdValue, 2)}`}</Row>
-                <Row title="TX Hash">{row.hash}</Row>
-                <Row title="Status">
-                  <div
+                    open ? "bg-orange-l5 dark:bg-blue-d4" : ""
+                  } w-full grid grid-cols-[auto_1fr_auto] divide-x divide-prim`}
+                >
+                  <DrawerIcon
+                    size={24}
                     className={`${
-                      row.donationFinalized
-                        ? "bg-green"
-                        : "bg-gray-d1 dark:bg-gray"
-                    } font-body text-white px-2 py-0.5 rounded`}
-                  >
-                    {row.donationFinalized ? "RECEIVED" : "PENDING"}
+                      open ? "text-orange" : ""
+                    } w-12 place-self-center`}
+                    isOpen={open}
+                  />
+                  <p className="text-sm p-4 text-left h-full truncate">
+                    {row.charityName}
+                  </p>
+                  <div className="p-4 text-center text-sm w-28">
+                    {new Date(row.date).toLocaleDateString()}
                   </div>
-                </Row>
-                <Row title="Receipt">
-                  <button
-                    className="block"
-                    onClick={() =>
-                      showKYCForm({
-                        type: "post-donation",
-                        txHash: row.hash,
-                        classes: "grid gap-5",
-                      })
-                    }
-                  >
-                    <Icon type="FatArrowDownload" className="text-2xl" />
-                  </button>
-                </Row>
-              </Disclosure.Panel>
-            </>
-          )}
-        </Disclosure>
-      ))}
-    </div>
+                </Disclosure.Button>
+                <Disclosure.Panel className="w-full font-work divide-y divide-prim">
+                  <Row title="Network">{row.chainName}</Row>
+                  <Row title="Currency">{row.symbol}</Row>
+                  <Row title="Amount">{humanize(row.amount, 3)}</Row>
+                  <Row title="USD Value">{`$${humanize(row.usdValue, 2)}`}</Row>
+                  <Row title="TX Hash">{row.hash}</Row>
+                  <Row title="Status">
+                    <div
+                      className={`${
+                        row.donationFinalized
+                          ? "bg-green"
+                          : "bg-gray-d1 dark:bg-gray"
+                      } font-body text-white px-2 py-0.5 rounded`}
+                    >
+                      {row.donationFinalized ? "RECEIVED" : "PENDING"}
+                    </div>
+                  </Row>
+                  <Row title="Receipt" className="rounded-b">
+                    <button
+                      className="block"
+                      onClick={() =>
+                        showKYCForm({
+                          type: "post-donation",
+                          txHash: row.hash,
+                          classes: "grid gap-5",
+                        })
+                      }
+                    >
+                      <Icon type="FatArrowDownload" className="text-2xl" />
+                    </button>
+                  </Row>
+                </Disclosure.Panel>
+              </>
+            )}
+          </Disclosure>
+        ))}
+      </div>
+      {hasMore && (
+        <LoadMoreBtn
+          onLoadMore={onLoadMore}
+          disabled={disabled}
+          isLoading={isLoading}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/pages/Donations/MobileTable.tsx
+++ b/src/pages/Donations/MobileTable.tsx
@@ -19,92 +19,90 @@ export default function MobileTable({
   const showKYCForm = useKYC();
 
   return (
-    <>
-      <div
-        className={`${classes} border border-prim ${
-          hasMore ? "rounded-t" : "rounded"
-        }`}
-      >
-        <div className="grid items-center grid-cols-[auto_1fr_auto] h-12 uppercase text-xs font-bold bg-orange-l6 dark:bg-blue-d7 border-b border-prim divide-x divide-prim rounded-t">
-          <div className="w-12" />
-          <div className="p-4">Recipient</div>
-          <div className="p-4 w-28 text-center">Date</div>
-        </div>
-
-        {sorted.map((row, index) => (
-          <Disclosure
-            key={index}
-            as="div"
-            className={`text-sm odd:bg-orange-l6 dark:even:bg-blue-d6 dark:odd:bg-blue-d7 w-full border-b last:border-0 border-prim ${
-              hasMore ? "" : "last:rounded-b"
-            }`}
-          >
-            {({ open }) => (
-              <>
-                <Disclosure.Button
-                  className={`${
-                    open ? "bg-orange-l5 dark:bg-blue-d4" : ""
-                  } w-full grid grid-cols-[auto_1fr_auto] divide-x divide-prim`}
-                >
-                  <DrawerIcon
-                    size={24}
-                    className={`${
-                      open ? "text-orange" : ""
-                    } w-12 place-self-center`}
-                    isOpen={open}
-                  />
-                  <p className="text-sm p-4 text-left h-full truncate">
-                    {row.charityName}
-                  </p>
-                  <div className="p-4 text-center text-sm w-28">
-                    {new Date(row.date).toLocaleDateString()}
-                  </div>
-                </Disclosure.Button>
-                <Disclosure.Panel className="w-full font-work divide-y divide-prim">
-                  <Row title="Network">{row.chainName}</Row>
-                  <Row title="Currency">{row.symbol}</Row>
-                  <Row title="Amount">{humanize(row.amount, 3)}</Row>
-                  <Row title="USD Value">{`$${humanize(row.usdValue, 2)}`}</Row>
-                  <Row title="TX Hash">{row.hash}</Row>
-                  <Row title="Status">
-                    <div
-                      className={`${
-                        row.donationFinalized
-                          ? "bg-green"
-                          : "bg-gray-d1 dark:bg-gray"
-                      } font-body text-white px-2 py-0.5 rounded`}
-                    >
-                      {row.donationFinalized ? "RECEIVED" : "PENDING"}
-                    </div>
-                  </Row>
-                  <Row title="Receipt" className="rounded-b">
-                    <button
-                      className="block"
-                      onClick={() =>
-                        showKYCForm({
-                          type: "post-donation",
-                          txHash: row.hash,
-                          classes: "grid gap-5",
-                        })
-                      }
-                    >
-                      <Icon type="FatArrowDownload" className="text-2xl" />
-                    </button>
-                  </Row>
-                </Disclosure.Panel>
-              </>
-            )}
-          </Disclosure>
-        ))}
-        {hasMore && (
-          <LoadMoreBtn
-            onLoadMore={onLoadMore}
-            disabled={disabled}
-            isLoading={isLoading}
-          />
-        )}
+    <div
+      className={`${classes} border border-prim ${
+        hasMore ? "rounded-t" : "rounded"
+      }`}
+    >
+      <div className="grid items-center grid-cols-[auto_1fr_auto] h-12 uppercase text-xs font-bold bg-orange-l6 dark:bg-blue-d7 border-b border-prim divide-x divide-prim rounded-t">
+        <div className="w-12" />
+        <div className="p-4">Recipient</div>
+        <div className="p-4 w-28 text-center">Date</div>
       </div>
-    </>
+
+      {sorted.map((row, index) => (
+        <Disclosure
+          key={index}
+          as="div"
+          className={`text-sm odd:bg-orange-l6 dark:even:bg-blue-d6 dark:odd:bg-blue-d7 w-full border-b last:border-0 border-prim ${
+            hasMore ? "" : "last:rounded-b"
+          }`}
+        >
+          {({ open }) => (
+            <>
+              <Disclosure.Button
+                className={`${
+                  open ? "bg-orange-l5 dark:bg-blue-d4" : ""
+                } w-full grid grid-cols-[auto_1fr_auto] divide-x divide-prim`}
+              >
+                <DrawerIcon
+                  size={24}
+                  className={`${
+                    open ? "text-orange" : ""
+                  } w-12 place-self-center`}
+                  isOpen={open}
+                />
+                <p className="text-sm p-4 text-left h-full truncate">
+                  {row.charityName}
+                </p>
+                <div className="p-4 text-center text-sm w-28">
+                  {new Date(row.date).toLocaleDateString()}
+                </div>
+              </Disclosure.Button>
+              <Disclosure.Panel className="w-full font-work divide-y divide-prim">
+                <Row title="Network">{row.chainName}</Row>
+                <Row title="Currency">{row.symbol}</Row>
+                <Row title="Amount">{humanize(row.amount, 3)}</Row>
+                <Row title="USD Value">{`$${humanize(row.usdValue, 2)}`}</Row>
+                <Row title="TX Hash">{row.hash}</Row>
+                <Row title="Status">
+                  <div
+                    className={`${
+                      row.donationFinalized
+                        ? "bg-green"
+                        : "bg-gray-d1 dark:bg-gray"
+                    } font-body text-white px-2 py-0.5 rounded`}
+                  >
+                    {row.donationFinalized ? "RECEIVED" : "PENDING"}
+                  </div>
+                </Row>
+                <Row title="Receipt" className="rounded-b">
+                  <button
+                    className="block"
+                    onClick={() =>
+                      showKYCForm({
+                        type: "post-donation",
+                        txHash: row.hash,
+                        classes: "grid gap-5",
+                      })
+                    }
+                  >
+                    <Icon type="FatArrowDownload" className="text-2xl" />
+                  </button>
+                </Row>
+              </Disclosure.Panel>
+            </>
+          )}
+        </Disclosure>
+      ))}
+      {hasMore && (
+        <LoadMoreBtn
+          onLoadMore={onLoadMore}
+          disabled={disabled}
+          isLoading={isLoading}
+        />
+      )}
+    </div>
   );
 }
 

--- a/src/pages/Donations/Table.tsx
+++ b/src/pages/Donations/Table.tsx
@@ -23,71 +23,6 @@ export default function Table({
 
   const showKYCForm = useKYC();
 
-  const children = sorted.map((row) => (
-    <Cells
-      key={row.hash}
-      type="td"
-      cellClass={`p-3 border-t border-prim max-w-[256px] truncate ${
-        hasMore ? "" : "first:rounded-bl last:rounded-br"
-      }`}
-    >
-      <Link
-        to={`${appRoutes.profile}/${row.id}`}
-        className="flex items-center justify-between gap-1 cursor-pointer text-sm hover:underline"
-      >
-        <span className="truncate max-w-[12rem]">{row.charityName}</span>
-        <Icon type="ExternalLink" className="w-5 h-5" />
-      </Link>
-      <>{new Date(row.date).toLocaleDateString()}</>
-      <>{row.chainName}</>
-      <span className="font-body text-sm">{row.symbol}</span>
-      <>{humanize(row.amount, 3)}</>
-      <>{`$${humanize(row.usdValue, 2)}`}</>
-      <ExtLink
-        href={getTxUrl(row.chainId, row.hash)}
-        className="text-center text-angel-blue cursor-pointer uppercase text-sm"
-      >
-        {row.hash}
-      </ExtLink>
-      <div className="text-center text-white">
-        <span
-          className={`${
-            row.donationFinalized ? "bg-green" : "bg-gray-d1 dark:bg-gray"
-          } font-body px-2 py-0.5 rounded`}
-        >
-          {row.donationFinalized ? "RECEIVED" : "PENDING"}
-        </span>
-      </div>
-      <button
-        className="w-full flex justify-center"
-        onClick={() =>
-          showKYCForm({
-            type: "post-donation",
-            txHash: row.hash,
-            classes: "grid gap-5",
-          })
-        }
-      >
-        <Icon type="FatArrowDownload" className="text-2xl" />
-      </button>
-    </Cells>
-  ));
-  if (hasMore) {
-    children.push(
-      <td
-        colSpan={9}
-        key="load-more-btn"
-        className="border-t border-prim rounded-b"
-      >
-        <LoadMoreBtn
-          onLoadMore={onLoadMore}
-          disabled={disabled}
-          isLoading={isLoading}
-        />
-      </td>
-    );
-  }
-
   return (
     <table
       className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-prim`}
@@ -151,7 +86,77 @@ export default function Table({
         rowClass="even:bg-orange-l6 dark:odd:bg-blue-d6 dark:even:bg-blue-d7 divide-x divide-prim"
         selectedClass="bg-orange-l5 dark:bg-blue-d4"
       >
-        {children}
+        {sorted
+          .map((row) => (
+            <Cells
+              key={row.hash}
+              type="td"
+              cellClass={`p-3 border-t border-prim max-w-[256px] truncate ${
+                hasMore ? "" : "first:rounded-bl last:rounded-br"
+              }`}
+            >
+              <Link
+                to={`${appRoutes.profile}/${row.id}`}
+                className="flex items-center justify-between gap-1 cursor-pointer text-sm hover:underline"
+              >
+                <span className="truncate max-w-[12rem]">
+                  {row.charityName}
+                </span>
+                <Icon type="ExternalLink" className="w-5 h-5" />
+              </Link>
+              <>{new Date(row.date).toLocaleDateString()}</>
+              <>{row.chainName}</>
+              <span className="font-body text-sm">{row.symbol}</span>
+              <>{humanize(row.amount, 3)}</>
+              <>{`$${humanize(row.usdValue, 2)}`}</>
+              <ExtLink
+                href={getTxUrl(row.chainId, row.hash)}
+                className="text-center text-angel-blue cursor-pointer uppercase text-sm"
+              >
+                {row.hash}
+              </ExtLink>
+              <div className="text-center text-white">
+                <span
+                  className={`${
+                    row.donationFinalized
+                      ? "bg-green"
+                      : "bg-gray-d1 dark:bg-gray"
+                  } font-body px-2 py-0.5 rounded`}
+                >
+                  {row.donationFinalized ? "RECEIVED" : "PENDING"}
+                </span>
+              </div>
+              <button
+                className="w-full flex justify-center"
+                onClick={() =>
+                  showKYCForm({
+                    type: "post-donation",
+                    txHash: row.hash,
+                    classes: "grid gap-5",
+                  })
+                }
+              >
+                <Icon type="FatArrowDownload" className="text-2xl" />
+              </button>
+            </Cells>
+          ))
+          .concat(
+            hasMore ? (
+              <td
+                colSpan={9}
+                key="load-more-btn"
+                className="border-t border-prim rounded-b"
+              >
+                <LoadMoreBtn
+                  onLoadMore={onLoadMore}
+                  disabled={disabled}
+                  isLoading={isLoading}
+                />
+              </td>
+            ) : (
+              []
+            )
+          )}
       </TableSection>
     </table>
   );

--- a/src/pages/Donations/Table.tsx
+++ b/src/pages/Donations/Table.tsx
@@ -23,134 +23,136 @@ export default function Table({
 
   const showKYCForm = useKYC();
 
-  return (
-    <>
-      <table
-        className={`${classes} w-full text-sm ${
-          hasMore ? "rounded-t" : "rounded"
-        } border border-separate border-spacing-0 border-prim`}
+  const children = sorted.map((row) => (
+    <Cells
+      key={row.hash}
+      type="td"
+      cellClass={`p-3 border-t border-prim max-w-[256px] truncate ${
+        hasMore ? "" : "first:rounded-bl last:rounded-br"
+      }`}
+    >
+      <Link
+        to={`${appRoutes.profile}/${row.id}`}
+        className="flex items-center justify-between gap-1 cursor-pointer text-sm hover:underline"
       >
-        <TableSection
-          type="thead"
-          rowClass="bg-orange-l6 dark:bg-blue-d7 divide-x divide-prim"
+        <span className="truncate max-w-[12rem]">{row.charityName}</span>
+        <Icon type="ExternalLink" className="w-5 h-5" />
+      </Link>
+      <>{new Date(row.date).toLocaleDateString()}</>
+      <>{row.chainName}</>
+      <span className="font-body text-sm">{row.symbol}</span>
+      <>{humanize(row.amount, 3)}</>
+      <>{`$${humanize(row.usdValue, 2)}`}</>
+      <ExtLink
+        href={getTxUrl(row.chainId, row.hash)}
+        className="text-center text-angel-blue cursor-pointer uppercase text-sm"
+      >
+        {row.hash}
+      </ExtLink>
+      <div className="text-center text-white">
+        <span
+          className={`${
+            row.donationFinalized ? "bg-green" : "bg-gray-d1 dark:bg-gray"
+          } font-body px-2 py-0.5 rounded`}
         >
-          <Cells
-            type="th"
-            cellClass="px-3 py-4 text-xs uppercase font-semibold text-left first:rounded-tl last:rounded-tr"
-          >
-            <HeaderButton
-              onClick={handleHeaderClick("charityName")}
-              _activeSortKey={sortKey}
-              _sortKey="charityName"
-              _sortDirection={sortDirection}
-            >
-              Recipient
-            </HeaderButton>
-            <HeaderButton
-              onClick={handleHeaderClick("date")}
-              _activeSortKey={sortKey}
-              _sortKey="date"
-              _sortDirection={sortDirection}
-            >
-              Date
-            </HeaderButton>
-            <HeaderButton
-              onClick={handleHeaderClick("chainName")}
-              _activeSortKey={sortKey}
-              _sortKey="chainName"
-              _sortDirection={sortDirection}
-            >
-              Network
-            </HeaderButton>
-            <>Currency</>
-            <HeaderButton
-              onClick={handleHeaderClick("amount")}
-              _activeSortKey={sortKey}
-              _sortKey="amount"
-              _sortDirection={sortDirection}
-            >
-              Amount
-            </HeaderButton>
-            <HeaderButton
-              onClick={handleHeaderClick("usdValue")}
-              _activeSortKey={sortKey}
-              _sortKey="usdValue"
-              _sortDirection={sortDirection}
-            >
-              USD Value
-            </HeaderButton>
-            <>TX Hash</>
-            <span className="flex justify-center">Status</span>
-            <span className="flex justify-center">Receipt</span>
-          </Cells>
-        </TableSection>
-        <TableSection
-          type="tbody"
-          rowClass="even:bg-orange-l6 dark:odd:bg-blue-d6 dark:even:bg-blue-d7 divide-x divide-prim"
-          selectedClass="bg-orange-l5 dark:bg-blue-d4"
-        >
-          {sorted.map((row) => (
-            <Cells
-              key={row.hash}
-              type="td"
-              cellClass={`p-3 border-t border-prim max-w-[256px] truncate ${
-                hasMore ? "" : "first:rounded-bl last:rounded-br"
-              }`}
-            >
-              <Link
-                to={`${appRoutes.profile}/${row.id}`}
-                className="flex items-center justify-between gap-1 cursor-pointer text-sm hover:underline"
-              >
-                <span className="truncate max-w-[12rem]">
-                  {row.charityName}
-                </span>
-                <Icon type="ExternalLink" className="w-5 h-5" />
-              </Link>
-              <>{new Date(row.date).toLocaleDateString()}</>
-              <>{row.chainName}</>
-              <span className="font-body text-sm">{row.symbol}</span>
-              <>{humanize(row.amount, 3)}</>
-              <>{`$${humanize(row.usdValue, 2)}`}</>
-              <ExtLink
-                href={getTxUrl(row.chainId, row.hash)}
-                className="text-center text-angel-blue cursor-pointer uppercase text-sm"
-              >
-                {row.hash}
-              </ExtLink>
-              <div className="text-center text-white">
-                <span
-                  className={`${
-                    row.donationFinalized
-                      ? "bg-green"
-                      : "bg-gray-d1 dark:bg-gray"
-                  } font-body px-2 py-0.5 rounded`}
-                >
-                  {row.donationFinalized ? "RECEIVED" : "PENDING"}
-                </span>
-              </div>
-              <button
-                className="w-full flex justify-center"
-                onClick={() =>
-                  showKYCForm({
-                    type: "post-donation",
-                    txHash: row.hash,
-                    classes: "grid gap-5",
-                  })
-                }
-              >
-                <Icon type="FatArrowDownload" className="text-2xl" />
-              </button>
-            </Cells>
-          ))}
-        </TableSection>
-      </table>
-      {hasMore && (
+          {row.donationFinalized ? "RECEIVED" : "PENDING"}
+        </span>
+      </div>
+      <button
+        className="w-full flex justify-center"
+        onClick={() =>
+          showKYCForm({
+            type: "post-donation",
+            txHash: row.hash,
+            classes: "grid gap-5",
+          })
+        }
+      >
+        <Icon type="FatArrowDownload" className="text-2xl" />
+      </button>
+    </Cells>
+  ));
+  if (hasMore) {
+    children.push(
+      <td
+        colSpan={9}
+        key="load-more-btn"
+        className="border-t border-prim rounded-b"
+      >
         <LoadMoreBtn
           onLoadMore={onLoadMore}
           disabled={disabled}
           isLoading={isLoading}
         />
-      )}
-    </>
+      </td>
+    );
+  }
+
+  return (
+    <table
+      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-prim`}
+    >
+      <TableSection
+        type="thead"
+        rowClass="bg-orange-l6 dark:bg-blue-d7 divide-x divide-prim"
+      >
+        <Cells
+          type="th"
+          cellClass="px-3 py-4 text-xs uppercase font-semibold text-left first:rounded-tl last:rounded-tr"
+        >
+          <HeaderButton
+            onClick={handleHeaderClick("charityName")}
+            _activeSortKey={sortKey}
+            _sortKey="charityName"
+            _sortDirection={sortDirection}
+          >
+            Recipient
+          </HeaderButton>
+          <HeaderButton
+            onClick={handleHeaderClick("date")}
+            _activeSortKey={sortKey}
+            _sortKey="date"
+            _sortDirection={sortDirection}
+          >
+            Date
+          </HeaderButton>
+          <HeaderButton
+            onClick={handleHeaderClick("chainName")}
+            _activeSortKey={sortKey}
+            _sortKey="chainName"
+            _sortDirection={sortDirection}
+          >
+            Network
+          </HeaderButton>
+          <>Currency</>
+          <HeaderButton
+            onClick={handleHeaderClick("amount")}
+            _activeSortKey={sortKey}
+            _sortKey="amount"
+            _sortDirection={sortDirection}
+          >
+            Amount
+          </HeaderButton>
+          <HeaderButton
+            onClick={handleHeaderClick("usdValue")}
+            _activeSortKey={sortKey}
+            _sortKey="usdValue"
+            _sortDirection={sortDirection}
+          >
+            USD Value
+          </HeaderButton>
+          <>TX Hash</>
+          <span className="flex justify-center">Status</span>
+          <span className="flex justify-center">Receipt</span>
+        </Cells>
+      </TableSection>
+      <TableSection
+        type="tbody"
+        rowClass="even:bg-orange-l6 dark:odd:bg-blue-d6 dark:even:bg-blue-d7 divide-x divide-prim"
+        selectedClass="bg-orange-l5 dark:bg-blue-d4"
+      >
+        {children}
+      </TableSection>
+    </table>
   );
 }

--- a/src/pages/Donations/Table.tsx
+++ b/src/pages/Donations/Table.tsx
@@ -8,124 +8,149 @@ import TableSection, { Cells } from "components/TableSection";
 import useSort from "hooks/useSort";
 import { getTxUrl, humanize } from "helpers";
 import { appRoutes } from "constants/routes";
+import LoadMoreBtn from "./LoadMoreBtn";
 
-export default function Table({ donations, classes = "" }: TableProps) {
+export default function Table({
+  donations,
+  classes = "",
+  disabled,
+  isLoading,
+  hasMore,
+  onLoadMore,
+}: TableProps) {
   const { handleHeaderClick, sorted, sortDirection, sortKey } =
     useSort(donations);
 
   const showKYCForm = useKYC();
 
   return (
-    <table
-      className={`${classes} w-full text-sm rounded-t border border-separate border-spacing-0 border-prim`}
-    >
-      <TableSection
-        type="thead"
-        rowClass="bg-orange-l6 dark:bg-blue-d7 divide-x divide-prim"
+    <>
+      <table
+        className={`${classes} w-full text-sm ${
+          hasMore ? "rounded-t" : "rounded"
+        } border border-separate border-spacing-0 border-prim`}
       >
-        <Cells
-          type="th"
-          cellClass="px-3 py-4 text-xs uppercase font-semibold text-left first:rounded-tl last:rounded-tr"
+        <TableSection
+          type="thead"
+          rowClass="bg-orange-l6 dark:bg-blue-d7 divide-x divide-prim"
         >
-          <HeaderButton
-            onClick={handleHeaderClick("charityName")}
-            _activeSortKey={sortKey}
-            _sortKey="charityName"
-            _sortDirection={sortDirection}
-          >
-            Recipient
-          </HeaderButton>
-          <HeaderButton
-            onClick={handleHeaderClick("date")}
-            _activeSortKey={sortKey}
-            _sortKey="date"
-            _sortDirection={sortDirection}
-          >
-            Date
-          </HeaderButton>
-          <HeaderButton
-            onClick={handleHeaderClick("chainName")}
-            _activeSortKey={sortKey}
-            _sortKey="chainName"
-            _sortDirection={sortDirection}
-          >
-            Network
-          </HeaderButton>
-          <>Currency</>
-          <HeaderButton
-            onClick={handleHeaderClick("amount")}
-            _activeSortKey={sortKey}
-            _sortKey="amount"
-            _sortDirection={sortDirection}
-          >
-            Amount
-          </HeaderButton>
-          <HeaderButton
-            onClick={handleHeaderClick("usdValue")}
-            _activeSortKey={sortKey}
-            _sortKey="usdValue"
-            _sortDirection={sortDirection}
-          >
-            USD Value
-          </HeaderButton>
-          <>TX Hash</>
-          <span className="flex justify-center">Status</span>
-          <span className="flex justify-center">Receipt</span>
-        </Cells>
-      </TableSection>
-      <TableSection
-        type="tbody"
-        rowClass="even:bg-orange-l6 dark:odd:bg-blue-d6 dark:even:bg-blue-d7 divide-x divide-prim"
-        selectedClass="bg-orange-l5 dark:bg-blue-d4"
-      >
-        {sorted.map((row) => (
           <Cells
-            key={row.hash}
-            type="td"
-            cellClass="p-3 border-t border-prim max-w-[256px] truncate"
+            type="th"
+            cellClass="px-3 py-4 text-xs uppercase font-semibold text-left first:rounded-tl last:rounded-tr"
           >
-            <Link
-              to={`${appRoutes.profile}/${row.id}`}
-              className="flex items-center justify-between gap-1 cursor-pointer text-sm hover:underline"
+            <HeaderButton
+              onClick={handleHeaderClick("charityName")}
+              _activeSortKey={sortKey}
+              _sortKey="charityName"
+              _sortDirection={sortDirection}
             >
-              <span className="truncate max-w-[12rem]">{row.charityName}</span>
-              <Icon type="ExternalLink" className="w-5 h-5" />
-            </Link>
-            <>{new Date(row.date).toLocaleDateString()}</>
-            <>{row.chainName}</>
-            <span className="font-body text-sm">{row.symbol}</span>
-            <>{humanize(row.amount, 3)}</>
-            <>{`$${humanize(row.usdValue, 2)}`}</>
-            <ExtLink
-              href={getTxUrl(row.chainId, row.hash)}
-              className="text-center text-angel-blue cursor-pointer uppercase text-sm"
+              Recipient
+            </HeaderButton>
+            <HeaderButton
+              onClick={handleHeaderClick("date")}
+              _activeSortKey={sortKey}
+              _sortKey="date"
+              _sortDirection={sortDirection}
             >
-              {row.hash}
-            </ExtLink>
-            <div className="text-center text-white">
-              <span
-                className={`${
-                  row.donationFinalized ? "bg-green" : "bg-gray-d1 dark:bg-gray"
-                } font-body px-2 py-0.5 rounded`}
-              >
-                {row.donationFinalized ? "RECEIVED" : "PENDING"}
-              </span>
-            </div>
-            <button
-              className="w-full flex justify-center"
-              onClick={() =>
-                showKYCForm({
-                  type: "post-donation",
-                  txHash: row.hash,
-                  classes: "grid gap-5",
-                })
-              }
+              Date
+            </HeaderButton>
+            <HeaderButton
+              onClick={handleHeaderClick("chainName")}
+              _activeSortKey={sortKey}
+              _sortKey="chainName"
+              _sortDirection={sortDirection}
             >
-              <Icon type="FatArrowDownload" className="text-2xl" />
-            </button>
+              Network
+            </HeaderButton>
+            <>Currency</>
+            <HeaderButton
+              onClick={handleHeaderClick("amount")}
+              _activeSortKey={sortKey}
+              _sortKey="amount"
+              _sortDirection={sortDirection}
+            >
+              Amount
+            </HeaderButton>
+            <HeaderButton
+              onClick={handleHeaderClick("usdValue")}
+              _activeSortKey={sortKey}
+              _sortKey="usdValue"
+              _sortDirection={sortDirection}
+            >
+              USD Value
+            </HeaderButton>
+            <>TX Hash</>
+            <span className="flex justify-center">Status</span>
+            <span className="flex justify-center">Receipt</span>
           </Cells>
-        ))}
-      </TableSection>
-    </table>
+        </TableSection>
+        <TableSection
+          type="tbody"
+          rowClass="even:bg-orange-l6 dark:odd:bg-blue-d6 dark:even:bg-blue-d7 divide-x divide-prim"
+          selectedClass="bg-orange-l5 dark:bg-blue-d4"
+        >
+          {sorted.map((row) => (
+            <Cells
+              key={row.hash}
+              type="td"
+              cellClass={`p-3 border-t border-prim max-w-[256px] truncate ${
+                hasMore ? "" : "first:rounded-bl last:rounded-br"
+              }`}
+            >
+              <Link
+                to={`${appRoutes.profile}/${row.id}`}
+                className="flex items-center justify-between gap-1 cursor-pointer text-sm hover:underline"
+              >
+                <span className="truncate max-w-[12rem]">
+                  {row.charityName}
+                </span>
+                <Icon type="ExternalLink" className="w-5 h-5" />
+              </Link>
+              <>{new Date(row.date).toLocaleDateString()}</>
+              <>{row.chainName}</>
+              <span className="font-body text-sm">{row.symbol}</span>
+              <>{humanize(row.amount, 3)}</>
+              <>{`$${humanize(row.usdValue, 2)}`}</>
+              <ExtLink
+                href={getTxUrl(row.chainId, row.hash)}
+                className="text-center text-angel-blue cursor-pointer uppercase text-sm"
+              >
+                {row.hash}
+              </ExtLink>
+              <div className="text-center text-white">
+                <span
+                  className={`${
+                    row.donationFinalized
+                      ? "bg-green"
+                      : "bg-gray-d1 dark:bg-gray"
+                  } font-body px-2 py-0.5 rounded`}
+                >
+                  {row.donationFinalized ? "RECEIVED" : "PENDING"}
+                </span>
+              </div>
+              <button
+                className="w-full flex justify-center"
+                onClick={() =>
+                  showKYCForm({
+                    type: "post-donation",
+                    txHash: row.hash,
+                    classes: "grid gap-5",
+                  })
+                }
+              >
+                <Icon type="FatArrowDownload" className="text-2xl" />
+              </button>
+            </Cells>
+          ))}
+        </TableSection>
+      </table>
+      {hasMore && (
+        <LoadMoreBtn
+          onLoadMore={onLoadMore}
+          disabled={disabled}
+          isLoading={isLoading}
+        />
+      )}
+    </>
   );
 }

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -53,7 +53,8 @@ export default function Donations() {
 
   const { isLoading, isError, data, originalArgs } = queryState;
 
-  const [loadMore, { isLoading: isLoadingNextPage }] = useLazyDonationsQuery();
+  const [loadMore, { isLoading: isLoadingNextPage, isError: isErrorNextPage }] =
+    useLazyDonationsQuery();
 
   async function loadNextPage() {
     //button is hidden when there's no more
@@ -90,6 +91,7 @@ export default function Donations() {
           isLoading ||
           isLoadingNextPage ||
           isError ||
+          isErrorNextPage ||
           isDebouncing ||
           !data?.Items ||
           isEmpty(data.Items)
@@ -108,7 +110,7 @@ export default function Donations() {
           className="text-gray-d2 dark:text-gray absolute top-1/2 -translate-y-1/2 left-3"
         />
         <input
-          disabled={isError}
+          disabled={isError || isErrorNextPage}
           className="p-3 pl-10 placeholder:text-gray-d1 dark:placeholder:text-gray bg-transparent w-full outline-none disabled:bg-gray-l2 dark:disabled:bg-bluegray-d1"
           type="text"
           placeholder="Search donations..."
@@ -117,7 +119,13 @@ export default function Donations() {
         />
       </div>
       <Filter
-        isDisabled={isLoading || isLoadingNextPage || isError || isDebouncing}
+        isDisabled={
+          isLoading ||
+          isLoadingNextPage ||
+          isError ||
+          isErrorNextPage ||
+          isDebouncing
+        }
         setParams={setParams}
         donorAddress={address || ""}
         classes="max-lg:col-span-full max-lg:w-full"
@@ -126,7 +134,7 @@ export default function Donations() {
         queryState={{
           data: data?.Items,
           isLoading: isLoading || isDebouncing,
-          isError,
+          isError: isError || isErrorNextPage,
         }}
         messages={{
           loading: "Loading donations..",
@@ -147,7 +155,9 @@ export default function Donations() {
             {hasMore && (
               <LoadMoreBtn
                 onLoadMore={loadNextPage}
-                disabled={isLoading || isLoadingNextPage || isError}
+                disabled={
+                  isLoading || isLoadingNextPage || isError || isErrorNextPage
+                }
                 isLoading={isLoadingNextPage}
               />
             )}

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -13,7 +13,6 @@ import { useSetter } from "store/accessors";
 import useDebouncer from "hooks/useDebouncer";
 import { isEmpty } from "helpers";
 import Filter from "./Filter";
-import LoadMoreBtn from "./LoadMoreBtn";
 import MobileTable from "./MobileTable";
 import NoDonations from "./NoDonations";
 import Table from "./Table";
@@ -140,18 +139,19 @@ export default function Donations() {
             <Table
               donations={donations}
               classes="hidden max-lg:mt-4 lg:table"
+              hasMore={hasMore}
+              onLoadMore={loadNextPage}
+              disabled={isLoadingOrError}
+              isLoading={isLoadingNextPage}
             />
             <MobileTable
               donations={donations}
               classes="lg:hidden max-lg:mt-4"
+              hasMore={hasMore}
+              onLoadMore={loadNextPage}
+              disabled={isLoadingOrError}
+              isLoading={isLoadingNextPage}
             />
-            {hasMore && (
-              <LoadMoreBtn
-                onLoadMore={loadNextPage}
-                disabled={isLoadingOrError}
-                isLoading={isLoadingNextPage}
-              />
-            )}
           </div>
         )}
       </QueryLoader>

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -81,21 +81,20 @@ export default function Donations() {
 
   const hasMore = !!data?.ItemCutoff;
 
+  const isLoadingOrError =
+    isLoading ||
+    isLoadingNextPage ||
+    isError ||
+    isErrorNextPage ||
+    isDebouncing;
+
   return (
     <div className="grid grid-cols-[1fr_auto] content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container pt-8 lg:pt-20 pb-8">
       <h1 className="text-3xl font-bold max-lg:font-work max-lg:text-center max-lg:col-span-full max-lg:mb-4">
         My Donations
       </h1>
       <CsvExporter
-        aria-disabled={
-          isLoading ||
-          isLoadingNextPage ||
-          isError ||
-          isErrorNextPage ||
-          isDebouncing ||
-          !data?.Items ||
-          isEmpty(data.Items)
-        }
+        aria-disabled={isLoadingOrError || !data?.Items || isEmpty(data.Items)}
         classes="max-lg:row-start-5 max-lg:col-span-full lg:justify-self-end btn-orange px-8 py-3"
         headers={csvHeaders}
         data={data?.Items || []}
@@ -119,13 +118,7 @@ export default function Donations() {
         />
       </div>
       <Filter
-        isDisabled={
-          isLoading ||
-          isLoadingNextPage ||
-          isError ||
-          isErrorNextPage ||
-          isDebouncing
-        }
+        isDisabled={isLoadingOrError}
         setParams={setParams}
         donorAddress={address || ""}
         classes="max-lg:col-span-full max-lg:w-full"
@@ -155,9 +148,7 @@ export default function Donations() {
             {hasMore && (
               <LoadMoreBtn
                 onLoadMore={loadNextPage}
-                disabled={
-                  isLoading || isLoadingNextPage || isError || isErrorNextPage
-                }
+                disabled={isLoadingOrError}
                 isLoading={isLoadingNextPage}
               />
             )}

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -8,12 +8,12 @@ import {
 } from "services/apes";
 import CsvExporter from "components/CsvExporter";
 import Icon from "components/Icon";
-import LoaderRing from "components/LoaderRing";
 import QueryLoader from "components/QueryLoader";
 import { useSetter } from "store/accessors";
 import useDebouncer from "hooks/useDebouncer";
 import { isEmpty } from "helpers";
 import Filter from "./Filter";
+import LoadMoreBtn from "./LoadMoreBtn";
 import MobileTable from "./MobileTable";
 import NoDonations from "./NoDonations";
 import Table from "./Table";
@@ -145,20 +145,11 @@ export default function Donations() {
               classes="lg:hidden max-lg:mt-4"
             />
             {hasMore && (
-              <button
-                type="button"
-                onClick={loadNextPage}
+              <LoadMoreBtn
+                onLoadMore={loadNextPage}
                 disabled={isLoading || isLoadingNextPage || isError}
-                className="flex items-center justify-center gap-3 uppercase text-sm font-bold border-x border-b border-prim rounded-b h-12 mb-4 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-gray aria-disabled:bg-gray-l3 aria-disabled:dark:bg-bluegray disabled:dark:bg-bluegray"
-              >
-                {isLoadingNextPage ? (
-                  <>
-                    <LoaderRing thickness={10} classes="w-6" /> Loading...
-                  </>
-                ) : (
-                  "Load More"
-                )}
-              </button>
+                isLoading={isLoadingNextPage}
+              />
             )}
           </div>
         )}

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -144,20 +144,22 @@ export default function Donations() {
               donations={donations}
               classes="lg:hidden max-lg:mt-4"
             />
-            <button
-              type="button"
-              onClick={loadNextPage}
-              disabled={isLoading || isLoadingNextPage || isError || !hasMore}
-              className="flex items-center justify-center gap-3 uppercase text-sm font-bold border-x border-b border-prim rounded-b h-12 mb-4 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-gray aria-disabled:bg-gray-l3 aria-disabled:dark:bg-bluegray disabled:dark:bg-bluegray"
-            >
-              {isLoadingNextPage ? (
-                <>
-                  <LoaderRing thickness={10} classes="w-6" /> Loading...
-                </>
-              ) : (
-                "Load More"
-              )}
-            </button>
+            {hasMore && (
+              <button
+                type="button"
+                onClick={loadNextPage}
+                disabled={isLoading || isLoadingNextPage || isError}
+                className="flex items-center justify-center gap-3 uppercase text-sm font-bold border-x border-b border-prim rounded-b h-12 mb-4 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-gray aria-disabled:bg-gray-l3 aria-disabled:dark:bg-bluegray disabled:dark:bg-bluegray"
+              >
+                {isLoadingNextPage ? (
+                  <>
+                    <LoaderRing thickness={10} classes="w-6" /> Loading...
+                  </>
+                ) : (
+                  "Load More"
+                )}
+              </button>
+            )}
           </div>
         )}
       </QueryLoader>

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -84,7 +84,7 @@ export default function Donations() {
             />
             <MobileTable
               donations={donations}
-              classes="lg:hidden max-lg:mt-4"
+              classes="lg:hidden max-lg:my-4"
               hasMore={hasMore}
               onLoadMore={loadNextPage}
               disabled={isLoadingOrError}

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -1,91 +1,29 @@
-import { useState } from "react";
-import { useParams } from "react-router-dom";
-import { Donation, DonationsQueryParams } from "types/aws";
-import {
-  updateDonationsQueryData,
-  useDonationsQuery,
-  useLazyDonationsQuery,
-} from "services/apes";
+import { Donation } from "types/aws";
 import CsvExporter from "components/CsvExporter";
 import Icon from "components/Icon";
 import QueryLoader from "components/QueryLoader";
-import { useSetter } from "store/accessors";
-import useDebouncer from "hooks/useDebouncer";
 import { isEmpty } from "helpers";
 import Filter from "./Filter";
 import MobileTable from "./MobileTable";
 import NoDonations from "./NoDonations";
 import Table from "./Table";
+import useDonations from "./useDonations";
 
 export default function Donations() {
-  const { address } = useParams<{ address: string }>();
+  const {
+    address,
+    data,
+    hasMore,
+    isError,
+    isLoading,
+    isLoadingNextPage,
+    query,
+    loadNextPage,
+    onQueryChange,
+    setParams,
+  } = useDonations();
 
-  const dispatch = useSetter();
-
-  const [query, setQuery] = useState<string>("");
-  const [debouncedQuery, isDebouncing] = useDebouncer(query, 500);
-
-  const [params, setParams] = useState<DonationsQueryParams>({
-    id: address || "",
-  });
-
-  const queryState = useDonationsQuery(params, {
-    skip: !address,
-    selectFromResult({ data, ...rest }) {
-      if (!data?.Items) {
-        return { data, ...rest };
-      }
-
-      const filtered = data?.Items.filter(({ kycData, ...flatFields }) =>
-        Object.values(flatFields)
-          .reduce<string>((result, val) => `${val}` + result, "")
-          .toLocaleLowerCase()
-          .includes(debouncedQuery.toLocaleLowerCase())
-      );
-
-      return {
-        data: { Items: filtered, ItemCutoff: data.ItemCutoff },
-        ...rest,
-      };
-    },
-  });
-
-  const { isLoading, isError, data, originalArgs } = queryState;
-
-  const [loadMore, { isLoading: isLoadingNextPage, isError: isErrorNextPage }] =
-    useLazyDonationsQuery();
-
-  async function loadNextPage() {
-    //button is hidden when there's no more
-    if (
-      data?.ItemCutoff &&
-      originalArgs /** cards won't even show if no initial query is made */
-    ) {
-      const { data: newEndowRes } = await loadMore({
-        ...originalArgs,
-        start: data.ItemCutoff + 1,
-      });
-
-      if (newEndowRes) {
-        //pessimistic update to original cache data
-        dispatch(
-          updateDonationsQueryData("donations", originalArgs, (prevResult) => {
-            prevResult.Items.push(...newEndowRes.Items);
-            prevResult.ItemCutoff = newEndowRes.ItemCutoff;
-          })
-        );
-      }
-    }
-  }
-
-  const hasMore = !!data?.ItemCutoff;
-
-  const isLoadingOrError =
-    isLoading ||
-    isLoadingNextPage ||
-    isError ||
-    isErrorNextPage ||
-    isDebouncing;
+  const isLoadingOrError = isLoading || isLoadingNextPage || isError;
 
   return (
     <div className="grid grid-cols-[1fr_auto] content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container pt-8 lg:pt-20 pb-8">
@@ -108,12 +46,12 @@ export default function Donations() {
           className="text-gray-d2 dark:text-gray absolute top-1/2 -translate-y-1/2 left-3"
         />
         <input
-          disabled={isError || isErrorNextPage}
+          disabled={isError}
           className="p-3 pl-10 placeholder:text-gray-d1 dark:placeholder:text-gray bg-transparent w-full outline-none disabled:bg-gray-l2 dark:disabled:bg-bluegray-d1"
           type="text"
           placeholder="Search donations..."
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => onQueryChange(e.target.value)}
         />
       </div>
       <Filter
@@ -125,8 +63,8 @@ export default function Donations() {
       <QueryLoader
         queryState={{
           data: data?.Items,
-          isLoading: isLoading || isDebouncing,
-          isError: isError || isErrorNextPage,
+          isLoading: isLoading,
+          isError: isError,
         }}
         messages={{
           loading: "Loading donations..",

--- a/src/pages/Donations/types.ts
+++ b/src/pages/Donations/types.ts
@@ -3,4 +3,8 @@ import { Donation } from "types/aws";
 export type TableProps = {
   donations: Donation[];
   classes?: string;
+  onLoadMore(): void;
+  hasMore: boolean;
+  disabled: boolean;
+  isLoading: boolean;
 };

--- a/src/pages/Donations/useDonations.ts
+++ b/src/pages/Donations/useDonations.ts
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { DonationsQueryParams } from "types/aws";
+import {
+  updateDonationsQueryData,
+  useDonationsQuery,
+  useLazyDonationsQuery,
+} from "services/apes";
+import { useSetter } from "store/accessors";
+import useDebouncer from "hooks/useDebouncer";
+
+export default function useDonations() {
+  const { address } = useParams<{ address: string }>();
+
+  const dispatch = useSetter();
+
+  const [query, setQuery] = useState<string>("");
+  const [debouncedQuery, isDebouncing] = useDebouncer(query, 500);
+
+  const [params, setParams] = useState<DonationsQueryParams>({
+    id: address || "",
+  });
+
+  const queryState = useDonationsQuery(params, {
+    skip: !address,
+    selectFromResult({ data, ...rest }) {
+      if (!data?.Items) {
+        return { data, ...rest };
+      }
+
+      const filtered = data?.Items.filter(({ kycData, ...flatFields }) =>
+        Object.values(flatFields)
+          .reduce<string>((result, val) => `${val}` + result, "")
+          .toLocaleLowerCase()
+          .includes(debouncedQuery.toLocaleLowerCase())
+      );
+
+      return {
+        data: { Items: filtered, ItemCutoff: data.ItemCutoff },
+        ...rest,
+      };
+    },
+  });
+
+  const { isLoading, isError, data, originalArgs } = queryState;
+
+  const [loadMore, { isLoading: isLoadingNextPage, isError: isErrorNextPage }] =
+    useLazyDonationsQuery();
+
+  async function loadNextPage() {
+    //button is hidden when there's no more
+    if (
+      data?.ItemCutoff &&
+      originalArgs /** cards won't even show if no initial query is made */
+    ) {
+      const { data: newEndowRes } = await loadMore({
+        ...originalArgs,
+        start: data.ItemCutoff + 1,
+      });
+
+      if (newEndowRes) {
+        //pessimistic update to original cache data
+        dispatch(
+          updateDonationsQueryData("donations", originalArgs, (prevResult) => {
+            prevResult.Items.push(...newEndowRes.Items);
+            prevResult.ItemCutoff = newEndowRes.ItemCutoff;
+          })
+        );
+      }
+    }
+  }
+
+  const hasMore = !!data?.ItemCutoff;
+
+  return {
+    address,
+    data,
+    hasMore,
+    isError: isError || isErrorNextPage,
+    isLoading: isLoading || isDebouncing,
+    isLoadingNextPage,
+    query,
+    loadNextPage,
+    onQueryChange: setQuery,
+    setParams,
+  };
+}


### PR DESCRIPTION
## Explanation of the solution
Had to move the "load more" btn to `(Mobile)Table` component(s) as it the show/hide logic is closely related to how the table border styles are configured, so the code is clearer when those are grouped:
- "Load More" shown -> table bottom border should have no roundness
- "Load More" hidden -> table bottom border should have roundness
This was much harder to implement than anticipated.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes


## UI
### Desktop:
More to load:
![image](https://user-images.githubusercontent.com/19427053/221158291-3188f2ef-2cf9-413f-a21a-57cdb88e2efb.png)
All loaded:
![image](https://user-images.githubusercontent.com/19427053/221155600-7216e1e7-72dc-4ce0-acb0-f05fd411fcac.png)


### Mobile:
More to load:
![image](https://user-images.githubusercontent.com/19427053/221155412-e044d4c3-5b1b-4e57-b49a-cc95e3023412.png)
All loaded:
![image](https://user-images.githubusercontent.com/19427053/221155471-34d085ac-34c2-4fb0-88d5-a7da6b25cc0a.png)
