### PR TITLE
Revert isPrevDark changes to enable light theme being saved

### DIFF
--- a/src/helpers/theme.ts
+++ b/src/helpers/theme.ts
@@ -12,8 +12,12 @@ export function isPrevDark() {
   const isSystemThemeDark = window.matchMedia(
     "(prefers-color-scheme: dark)"
   ).matches;
-  // user might not have previously selected a theme, so check system theme
-  return userTheme !== LIGHT || isSystemThemeDark;
+
+  return (
+    userTheme === DARK ||
+    //user might not previously selected theme so check for system theme
+    (!userTheme && isSystemThemeDark)
+  );
 }
 
 const htmlNode = document.documentElement;


### PR DESCRIPTION
Ticket(s):
- Closes https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1854

## Explanation of the solution
The problem was caused by changes in https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/1740, or more specifically [changes to `isPrevDark` logic](https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/1740/files#diff-8a9231381c2dba6c5450313a88611f18b7cef28a0beb77ff9d94958c90f8bdf3).

The new logic `return userTheme !== LIGHT || isSystemThemeDark;` basically meant "If the user didn't have a set theme or it was set to DARK, we assume previous theme was 'dark'. If it was set to LIGHT, **_ignore it_** and set the theme to whatever system theme is", which meant that even when the user manually set the theme to "light", if their system theme was "dark", the webapp theme would revert to "dark" as well (the "light theme" selection would never get remembered).

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- perform the repro steps from the issue description
- verify issue no longer appears