### PR TITLE
Help in Registration Link Added

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -15,3 +15,5 @@ export const SUPPORT =
   "https://share-eu1.hsforms.com/14aljI0OEQje2DDmJiZoLFgetp37";
 
 export const TERMS_OF_USE = `${BASE_DOMAIN}/terms-of-use`;
+
+export const HELP_REGISTRATION = `https://intercom.help/angel-giving/en/articles/6628120-how-do-i-sign-up-register-as-a-charity`;

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -15,5 +15,3 @@ export const SUPPORT =
   "https://share-eu1.hsforms.com/14aljI0OEQje2DDmJiZoLFgetp37";
 
 export const TERMS_OF_USE = `${BASE_DOMAIN}/terms-of-use`;
-
-export const HELP_REGISTRATION = `https://intercom.help/angel-giving/en/articles/6628120-how-do-i-sign-up-register-as-a-charity`;

--- a/src/pages/Registration/Signup/Form.tsx
+++ b/src/pages/Registration/Signup/Form.tsx
@@ -4,12 +4,22 @@ import ExtLink from "components/ExtLink";
 import { CheckField, Field } from "components/form";
 import { Separator } from "components/registration";
 import { APP_NAME } from "constants/common";
-import { HELP_REGISTRATION, PRIVACY_POLICY } from "constants/urls";
+import { PRIVACY_POLICY } from "constants/urls";
 import routes from "../routes";
 import useSubmit from "./useSubmit";
 
+const NEED_HELP_ARTICLE_ID = 6628120;
+
 export default function Form({ classes = "" }: { classes?: string }) {
   const { submit, isSubmitting } = useSubmit();
+
+  const openIntercomHelp = () => {
+    const w = window as any;
+    if ("Intercom" in w) {
+      w.Intercom("showArticle", NEED_HELP_ARTICLE_ID);
+    }
+  };
+
   return (
     <form
       onSubmit={submit}
@@ -58,12 +68,13 @@ export default function Form({ classes = "" }: { classes?: string }) {
         Resume your registration
       </Link>
 
-      <ExtLink
-        className="underline text-orange justify-self-center mt-6 text-xs"
-        href={HELP_REGISTRATION}
+      <button
+        type="button"
+        className="underline text-orange justify-self-center mt-6 text-sm"
+        onClick={openIntercomHelp}
       >
         Need Help?
-      </ExtLink>
+      </button>
     </form>
   );
 }

--- a/src/pages/Registration/Signup/Form.tsx
+++ b/src/pages/Registration/Signup/Form.tsx
@@ -4,7 +4,7 @@ import ExtLink from "components/ExtLink";
 import { CheckField, Field } from "components/form";
 import { Separator } from "components/registration";
 import { APP_NAME } from "constants/common";
-import { PRIVACY_POLICY } from "constants/urls";
+import { HELP_REGISTRATION, PRIVACY_POLICY } from "constants/urls";
 import routes from "../routes";
 import useSubmit from "./useSubmit";
 
@@ -57,6 +57,13 @@ export default function Form({ classes = "" }: { classes?: string }) {
       >
         Resume your registration
       </Link>
+
+      <ExtLink
+        className="underline text-orange justify-self-center mt-6 text-xs"
+        href={HELP_REGISTRATION}
+      >
+        Need Help?
+      </ExtLink>
     </form>
   );
 }


### PR DESCRIPTION
Ticket(s):
- [1.7.1 testing - add a link to the register help page on the register page itself.#1813](https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1813)

## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to http://localhost:4200/register
- verify a link (styles button underneath) appears with text "Need help?"
- click on "Need help?"
- verify article https://intercom.help/angel-giving/en/articles/6628120-how-do-i-sign-up-register-as-a-nonprofit opens inside Intercom messenger box.

## UI changes for review

**EDIT 2023-03-06 by @misicnenad**:
Opening the article inside Intercom messenger:
![image](https://user-images.githubusercontent.com/19427053/223174450-d6881d85-e185-4208-a91f-276250e5949a.png)
