### PR TITLE
RC-v1.8: Invest sections mobile layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "yup": "^0.32.9"
   },
   "resolutions": {
-    "tailwindcss": "3.2.4",
+    "tailwindcss": "3.2.7",
     "loader-utils@^2.0.0": "^2.0.4",
     "loader-utils@^3.2.0": "^3.2.1"
   },
@@ -93,6 +93,7 @@
     "@babel/plugin-syntax-flow": "^7.18.6",
     "@babel/plugin-transform-react-jsx": "^7.20.13",
     "@peculiar/webcrypto": "^1.4.0",
+    "@tailwindcss/container-queries": "^0.1.0",
     "@testing-library/dom": "^8.20.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.4.0",
@@ -125,6 +126,7 @@
     "source-map-explorer": "^2.5.2",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
+    "tailwindcss": "^3.2.7",
     "typescript": "<4.8.0",
     "url": "^0.11.0",
     "web-vitals": "^3.1.1"

--- a/src/pages/Admin/Charity/Account/Balances.tsx
+++ b/src/pages/Admin/Charity/Account/Balances.tsx
@@ -15,7 +15,7 @@ export default function Balances({ type }: { type: AccountType }) {
       messages={{ loading: <Skeleton />, error: "Failed to get balances" }}
     >
       {({ total, free, invested, symbol }) => (
-        <div className="grid grid-cols-3 gap-6">
+        <div className="grid gap-4 @3xl:grid-cols-3 @3xl:gap-6">
           <Amount title="Total value" symbol={symbol}>
             {total}
           </Amount>

--- a/src/pages/Admin/Charity/Account/index.tsx
+++ b/src/pages/Admin/Charity/Account/index.tsx
@@ -5,8 +5,10 @@ import Positions from "./Positions";
 export default function Account({ type }: { type: AccountType }) {
   return (
     <div>
-      <h2 className="font-bold text-[2rem] capitalize mb-8">{type} Account</h2>
-      <h5 className="text-2xl font-bold mb-8">Overview</h5>
+      <h2 className="font-bold text-[2rem] capitalize mb-8 max-sm:text-center">
+        {type} Account
+      </h2>
+      <h5 className="text-2xl font-bold mb-8 max-sm:text-center">Overview</h5>
       <Balances type={type} />
       <h5 className="text-2xl font-bold my-8 capitalize">{type} Positions</h5>
       <Positions type={type} />

--- a/src/pages/Admin/Charity/Invest/index.tsx
+++ b/src/pages/Admin/Charity/Invest/index.tsx
@@ -5,7 +5,9 @@ import Investments from "./Invesments";
 export default function Invest() {
   return (
     <div>
-      <h3 className="font-bold text-[2rem] mb-8">Invest Dashboard</h3>
+      <h3 className="font-bold text-[2rem] mb-8 max-sm:text-center">
+        Invest Dashboard
+      </h3>
       <Balances />
       <h3 className="font-bold text-2xl mt-8 mb-4">Investments options</h3>
       <AccountTabs

--- a/src/pages/Admin/Charity/Settings/StrategyEditor/Fields/Field.tsx
+++ b/src/pages/Admin/Charity/Settings/StrategyEditor/Fields/Field.tsx
@@ -19,8 +19,8 @@ const inputStyle = "field-input bg-transparent text-center w-16 py-2";
 export default function Field({ name, idx, remove, staticVal, type }: Props) {
   const { register } = useFormContext<FormValues>();
   return (
-    <div className="px-6 py-7 grid grid-cols-[1fr_repeat(4,auto)] gap-3 items-center border border-prim rounded font-work bg-orange-l6 dark:bg-blue-d7">
-      <p className="text-gray-d1 dark:text-gray mr-auto">{name}</p>
+    <div className="p-4 sm:px-6 sm:py-7 grid grid-cols-[1fr_repeat(4,auto)] gap-3 items-center border border-prim rounded font-work bg-orange-l6 dark:bg-blue-d7">
+      <p className="text-gray-d1 dark:text-gray mr-auto break-all">{name}</p>
 
       <Icon type={type === "liquid" ? "Liquid" : "Lock"} />
       {staticVal ? (

--- a/src/pages/Admin/Charity/Settings/StrategyEditor/Form.tsx
+++ b/src/pages/Admin/Charity/Settings/StrategyEditor/Form.tsx
@@ -24,7 +24,9 @@ export default function Form({ type }: Props) {
         reset();
       }}
     >
-      <h3 className="font-bold text-lg mb-6">Update {type} strategy</h3>
+      <h3 className="font-bold text-lg mb-6 max-sm:text-center">
+        Update {type} strategy
+      </h3>
 
       <Fields classes="mt-4" type={type} />
 

--- a/src/pages/Admin/Charity/Settings/index.tsx
+++ b/src/pages/Admin/Charity/Settings/index.tsx
@@ -6,8 +6,10 @@ import { settings } from "../routes";
 export default function Settings() {
   return (
     <div>
-      <h2 className="text-[2rem] font-bold mb-8">Settings</h2>
-      <div className="rounded border border-prim p-6">
+      <h2 className="text-[2rem] font-bold mb-8 max-sm:text-center">
+        Settings
+      </h2>
+      <div className="@container rounded border border-prim p-6">
         <h3 className="font-bold text-2xl mb-10">Auto-invest</h3>
         {/** future: create plan */}
         <AccountTabs
@@ -26,11 +28,11 @@ export default function Settings() {
 
 function Strategy({ type }: { type: AccountType }) {
   return (
-    <div className="flex py-7 px-6 items-center border border-prim rounded justify-between">
+    <div className="@lg:flex py-7 px-6 items-center border border-prim rounded justify-between">
       <h4 className="text-xl font-bold">Default {type} strategy</h4>
       <Link
         to={`${settings.edit}/${type}`}
-        className="btn-outline-filled px-8 py-2"
+        className="btn-outline-filled px-8 py-2 mt-4 @lg:mt-0"
       >
         Edit
       </Link>

--- a/src/pages/Admin/Charity/common/Balances/Balance.tsx
+++ b/src/pages/Admin/Charity/common/Balances/Balance.tsx
@@ -11,7 +11,7 @@ export default function Balance({ type }: Props) {
   const { data, ...rest } = useAssetsQuery({ endowId: id });
 
   return (
-    <div className="rounded border border-prim bg-orange-l6 dark:bg-blue-d6">
+    <div className="@container rounded border border-prim bg-orange-l6 dark:bg-blue-d6">
       <h4 className="uppercase text-xl font-bold mb-5 pt-5 px-4">
         {type} account
       </h4>
@@ -29,8 +29,12 @@ export default function Balance({ type }: Props) {
       >
         {({ total, free, invested, symbol }) => {
           return (
-            <div className="flex gap-8 px-4">
-              <Amount title="Total value" classes="mr-auto" symbol={symbol}>
+            <div className="grid grid-cols-[auto_1fr] gap-y-5 justify-self-start gap-x-8 @lg:flex @lg:gap-x-8 px-4">
+              <Amount
+                title="Total value"
+                classes="col-span-full @lg:mr-auto"
+                symbol={symbol}
+              >
                 {humanize(total, 2)}
               </Amount>
               <Amount title="Free balance" symbol={symbol}>

--- a/src/pages/Admin/Charity/common/Balances/index.tsx
+++ b/src/pages/Admin/Charity/common/Balances/index.tsx
@@ -2,7 +2,7 @@ import Balance from "./Balance";
 
 export default function Balances() {
   return (
-    <div className="grid gap-4 md:grid-cols-2">
+    <div className="grid gap-4 @4xl:grid-cols-2">
       <Balance type="liquid" />
       <Balance type="locked" />
     </div>

--- a/src/pages/Admin/Charity/common/Investment/index.tsx
+++ b/src/pages/Admin/Charity/common/Investment/index.tsx
@@ -15,9 +15,9 @@ export default function Investment({
   const { showModal } = useModalContext();
 
   return (
-    <div className="border border-prim rounded bg-orange-l6 dark:bg-blue-d6">
+    <div className="@container border border-prim rounded bg-orange-l6 dark:bg-blue-d6">
       <p className="p-6 font-work">{maskAddress(address)}</p>
-      <div className="border-t border-prim flex justify-between p-6">
+      <div className="border-t border-prim grid @md:flex @md:justify-between p-6">
         <div>
           <p className="text-xs uppercase text-gray-d1 dark:text-gray mb-1">
             Current balance
@@ -31,7 +31,7 @@ export default function Investment({
           onClick={() =>
             showModal(action === "invest" ? Investor : Redeemer, props)
           }
-          className="btn-outline-filled px-8 py-2"
+          className="btn-outline-filled px-8 py-2 text-sm mt-6 @md:mt-0 @md:text-base"
         >
           {action}
         </button>

--- a/src/pages/Admin/Layout.tsx
+++ b/src/pages/Admin/Layout.tsx
@@ -9,7 +9,7 @@ export default function Layout({ linkGroups }: { linkGroups: LinkGroup[] }) {
       <SidebarOpener className="md:hidden" linkGroups={linkGroups} />
       <Sidebar className="max-md:hidden" linkGroups={linkGroups} />
       {/** views */}
-      <div className="p-10 @container">
+      <div className="px-6 py-8 md:p-10 @container">
         <Outlet />
       </div>
     </div>

--- a/src/pages/Admin/Layout.tsx
+++ b/src/pages/Admin/Layout.tsx
@@ -9,7 +9,7 @@ export default function Layout({ linkGroups }: { linkGroups: LinkGroup[] }) {
       <SidebarOpener className="md:hidden" linkGroups={linkGroups} />
       <Sidebar className="max-md:hidden" linkGroups={linkGroups} />
       {/** views */}
-      <div className="p-10">
+      <div className="p-10 @container">
         <Outlet />
       </div>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -120,4 +120,5 @@ module.exports = {
       },
     },
   },
+  plugins: [require("@tailwindcss/container-queries")],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,6 +3796,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/container-queries@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@tailwindcss/container-queries@npm:0.1.0"
+  peerDependencies:
+    tailwindcss: ">=3.2.0"
+  checksum: dcf5d1720280be115393351db274a21df4f552f20ebc2441421b190f1112550a9310b146de15fa627029469850421e4bcf07966a78d589103259e6eb1bd2a1f5
+  languageName: node
+  linkType: hard
+
 "@terra-money/legacy.proto@npm:@terra-money/terra.proto@^0.1.7":
   version: 0.1.7
   resolution: "@terra-money/terra.proto@npm:0.1.7"
@@ -5436,6 +5445,7 @@ __metadata:
     "@keplr-wallet/wc-qrcode-modal": ^0.11.31
     "@peculiar/webcrypto": ^1.4.0
     "@reduxjs/toolkit": ^1.9.0
+    "@tailwindcss/container-queries": ^0.1.0
     "@terra-money/terra.js": ^3.1.7
     "@terra-money/wallet-provider": ^3.11.1
     "@testing-library/dom": ^8.20.0
@@ -5491,6 +5501,7 @@ __metadata:
     source-map-explorer: ^2.5.2
     stream-browserify: ^3.0.0
     stream-http: ^3.2.0
+    tailwindcss: ^3.2.7
     typescript: <4.8.0
     url: ^0.11.0
     web-vitals: ^3.1.1
@@ -14410,6 +14421,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-selector-parser@npm:^6.0.11":
+  version: 6.0.11
+  resolution: "postcss-selector-parser@npm:6.0.11"
+  dependencies:
+    cssesc: ^3.0.0
+    util-deprecate: ^1.0.2
+  checksum: 0b01aa9c2d2c8dbeb51e9b204796b678284be9823abc8d6d40a8b16d4149514e922c264a8ed4deb4d6dbced564b9be390f5942c058582d8656351516d6c49cde
+  languageName: node
+  linkType: hard
+
 "postcss-svgo@npm:^5.1.0":
   version: 5.1.0
   resolution: "postcss-svgo@npm:5.1.0"
@@ -14450,6 +14471,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.0.9":
+  version: 8.4.21
+  resolution: "postcss@npm:8.4.21"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: e39ac60ccd1542d4f9d93d894048aac0d686b3bb38e927d8386005718e6793dbbb46930f0a523fe382f1bbd843c6d980aaea791252bf5e176180e5a4336d9679
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.1.10":
   version: 8.4.18
   resolution: "postcss@npm:8.4.18"
@@ -14469,17 +14501,6 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: 10eee25efd77868036403858577da0cefaf2e0905feeaba5770d5438ccdddba3d01cba8063e96b8aac4c6daa0ed413dd5ae0554a433a3c4db38df1d134cffc1f
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.18":
-  version: 8.4.19
-  resolution: "postcss@npm:8.4.19"
-  dependencies:
-    nanoid: ^3.3.4
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.2
-  checksum: 62782723a385f92b7525f66d29614624de7c5643855423db3a5efd9287e677650300192749adddbbb6734cea9b1d5f5fd4f6ea00ca3f9a95dbbb88f835f5ca64
   languageName: node
   linkType: hard
 
@@ -16880,9 +16901,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:3.2.4":
-  version: 3.2.4
-  resolution: "tailwindcss@npm:3.2.4"
+"tailwindcss@npm:3.2.7":
+  version: 3.2.7
+  resolution: "tailwindcss@npm:3.2.7"
   dependencies:
     arg: ^5.0.2
     chokidar: ^3.5.3
@@ -16898,12 +16919,12 @@ __metadata:
     normalize-path: ^3.0.0
     object-hash: ^3.0.0
     picocolors: ^1.0.0
-    postcss: ^8.4.18
+    postcss: ^8.0.9
     postcss-import: ^14.1.0
     postcss-js: ^4.0.0
     postcss-load-config: ^3.1.4
     postcss-nested: 6.0.0
-    postcss-selector-parser: ^6.0.10
+    postcss-selector-parser: ^6.0.11
     postcss-value-parser: ^4.2.0
     quick-lru: ^5.1.1
     resolve: ^1.22.1
@@ -16912,7 +16933,7 @@ __metadata:
   bin:
     tailwind: lib/cli.js
     tailwindcss: lib/cli.js
-  checksum: ec187d180c722ec4f57537f2216c7b21269b525f12aaf353cea464d939c3e6286a1221eb3e1206e45d1f015f296171309ad4d9952899b0245cd07d9500a9401f
+  checksum: 819446bf67acea1fc738f345d80f328b7bb6e6ef4b24070249a11219307045881cf97baed6258cbdcede7fa18886e9c9c41fd0fa087b3e987cf2948560a2f164
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ticket(s): close #1757 


## Explanation of the solution
simply using screen variants `sm: md: lg:` etc would not suffice
like in this example
<img width="819" alt="image" src="https://user-images.githubusercontent.com/89639563/222389536-fe77a849-bb37-4120-bbeb-d4ad600dc159.png">

since `<SideBar/>` would activate only when screen size is `md: 768px` - views would need to base media query with something like `w  = screen - sidebar-width`

A more natural solution is to use [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries) so that components would depend on the container they are in
<img width="819" alt="image" src="https://user-images.githubusercontent.com/89639563/222390559-ef5d789d-c5b4-4c10-90ad-e33aef18160c.png">

in this example, even though the screen is not yet `md` - smaller width styles are applied because components now depend on their container


* Install tailwind plugin for `container queries` since it's not yet included on standard install
* install `tailwindcss` to get rid of yarn peer requirements warning

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
invest dashboard mobile layout
<img width="369" alt="image" src="https://user-images.githubusercontent.com/89639563/222391357-db0f90f1-d443-45ef-a360-b13fdd7f0851.png">


When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes