### PR TITLE
use account tabs

### DIFF
--- a/src/pages/Admin/Charity/Withdraws/Withdrawer/index.tsx
+++ b/src/pages/Admin/Charity/Withdraws/Withdrawer/index.tsx
@@ -1,20 +1,10 @@
-import { Tab } from "@headlessui/react";
-import { useLocation } from "react-router-dom";
-import { AccountType } from "types/contracts";
 import { useAdminResources } from "pages/Admin/Guard";
 import { useStateQuery } from "services/juno/account";
 import QueryLoader from "components/QueryLoader";
+import AccountTabs from "../../common/AccountTabs";
 import WithdrawForm from "./WithdrawForm";
 
-const accTypeObj: { [key in AccountType]: string } = {
-  liquid: "",
-  locked: "",
-};
-const accountTypes = Object.keys(accTypeObj) as AccountType[];
-
 export default function Withdrawer() {
-  const { state } = useLocation(); //state is set from dashboard withdraw link
-  const type = state as AccountType;
   const { id } = useAdminResources();
   const queryState = useStateQuery({ id });
 
@@ -27,38 +17,17 @@ export default function Withdrawer() {
       }}
     >
       {({ tokens_on_hand }) => (
-        <Tab.Group
-          as="div"
-          className="flex flex-col items-center max-w-lg p-8 gap-6 dark:bg-blue-d6 border border-prim rounded"
-          defaultIndex={type === "locked" ? 1 : 0}
+        <AccountTabs
+          classes={{
+            container:
+              "flex flex-col items-center max-w-lg p-8 gap-6 dark:bg-blue-d6 border border-prim rounded",
+            tabs: "grid grid-cols-2 place-items-center gap-1 w-full h-10 p-1 border border-prim rounded-3xl",
+            tab: "rounded-2xl flex items-center justify-center w-full h-full uppercase text-sm font-bold focus:outline-none aria-selected:bg-orange-l5 aria-selected:dark:bg-blue-d4 aria-selected:border aria-selected:border-prim",
+          }}
         >
-          <Tab.List className="grid grid-cols-2 place-items-center gap-1 w-full h-10 p-1 border border-prim rounded-3xl">
-            {accountTypes.map((accType) => (
-              <Tab
-                key={`tab-list-${accType}`}
-                className={({ selected }) =>
-                  `${
-                    selected
-                      ? "bg-orange-l5 dark:bg-blue-d4 border border-prim"
-                      : ""
-                  } rounded-2xl flex items-center justify-center w-full h-full uppercase text-sm font-bold focus:outline-none`
-                }
-              >
-                {accType}
-              </Tab>
-            ))}
-          </Tab.List>
-          <Tab.Panels>
-            {accountTypes.map((accType) => (
-              <Tab.Panel key={`tab-panel-${accType}`}>
-                <WithdrawForm
-                  balance={tokens_on_hand[accType]}
-                  type={accType}
-                />
-              </Tab.Panel>
-            ))}
-          </Tab.Panels>
-        </Tab.Group>
+          <WithdrawForm type="liquid" balance={tokens_on_hand["liquid"]} />
+          <WithdrawForm type="locked" balance={tokens_on_hand["locked"]} />
+        </AccountTabs>
       )}
     </QueryLoader>
   );


### PR DESCRIPTION
Ticket(s):
-
@misicnenad, saw we can now remove that account type state and reuse `AccountTabs` component - hope we could include in your PR

## Explanation of the solution
* use account tabs
* copy paste styles
* remove account type state since no more withdraw link

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes