### PR TITLE
Fix withdraw table prop link

### DIFF
--- a/src/components/Icon/icons.ts
+++ b/src/components/Icon/icons.ts
@@ -97,7 +97,7 @@ import {
   MdWidgets,
 } from "react-icons/md";
 import {
-  RiFileSearchLine,
+  RiFileSearchFill,
   RiMapPin2Line,
   RiMoneyDollarCircleFill,
 } from "react-icons/ri";
@@ -149,7 +149,7 @@ export const icons = {
   FatArrowDownload: IoMdDownload,
   FileDownload: MdOutlineFileDownload,
   FileUpload: MdOutlineUploadFile,
-  FileSearch: RiFileSearchLine,
+  FileSearch: RiFileSearchFill,
   Filter: MdOutlineFilterAlt,
   FilterLeft: BsFilterLeft,
   Forward: MdOutlineArrowForwardIos,

--- a/src/pages/Admin/Charity/Withdraws/Transactions/Actions.tsx
+++ b/src/pages/Admin/Charity/Withdraws/Transactions/Actions.tsx
@@ -7,7 +7,7 @@ export default function Actions({ proposalId }: { proposalId: number }) {
     <Link
       title="View Proposal"
       className="flex justify-center items-center hover:text-orange active:text-orange-d1"
-      to={`${adminRoutes.proposal}/${proposalId}`}
+      to={`../${adminRoutes.proposal}/${proposalId}`}
     >
       <Icon type="FileSearch" className="w-6 h-6" />
     </Link>

--- a/src/pages/Admin/Charity/Withdraws/Transactions/Table/LogRow.tsx
+++ b/src/pages/Admin/Charity/Withdraws/Transactions/Table/LogRow.tsx
@@ -52,7 +52,7 @@ export default function LogRow(
       </QueryLoader>
 
       <span className="grid grid-cols-[1fr_auto] gap-2 items-center">
-        <span className="max-w-[16rem] truncate">{target_wallet}</span>
+        <span className="truncate">{target_wallet}</span>
         <Copier text={target_wallet} classes="w-6 h-6 hover:text-orange" />
       </span>
 


### PR DESCRIPTION
Ticket(s):
- https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1709

## Explanation of the solution
Fixes for PR #1876 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to http://localhost:4200/admin/1/withdraws
- verify Tx table UI matches Figma
- verify clicking "Action" proposal link in the withdraws table navigates to the correct URL

## UI changes for review

- previous:
![image](https://user-images.githubusercontent.com/19427053/224265463-f0e2cc3d-8ea1-4184-b66b-af1685163153.png)
- current (closer to Figma): 
![image](https://user-images.githubusercontent.com/19427053/224264658-858dbf42-e6f6-4d48-8794-b45af2bf6b8d.png)
