### PR TITLE
[Hot Fix] Increase Minimum Ethereum Withdraw Amount from 20 to 40 USDC

### DIFF
--- a/src/constants/contracts.ts
+++ b/src/constants/contracts.ts
@@ -27,7 +27,7 @@ const testnet:Contracts = {
   index_fund:      "juno1d26dmz9zld4n8pzjpqae5m95adnfalvz47vldpwfzsplw4umcjmqhkle94",
   cw4GrpApTeam:    "juno1qkphn8h2rnyqjjtfh8j8dtuqgh5cac57nq2286tsljducqp4lwfqac44jm",
   cw3ApTeam:       "juno1ukpw6g9dqfw3fk2mqchplgcz4jaukttf6tpyrht7sw00t7mn7dpsjwpfhs",
-  accounts:        "juno1cyd63pk2wuvjkqmhlvp9884z4h89rqtn8w8xgz9m28hjd2kzj2cqf070uz",
+  accounts:        "juno1d4v5h5yr920xjjwcuret5n3meee5l04c58fpjhghdgml8kp57spqvmg4lx",
   cw4GrpCharityReviewTeam:"juno12lgc6d44c0y0tnef8fwjq8d9arrw5jgvrg8ydju5kz7nek9px72qvu8aw0",
   cw3CharityReviewTeam:   "juno1lstuws59hjswletwmskefdajhq76pz9tlfq84perndemrzztda0q6jc3nr",
   cw4GrpImpactReviewTeam: "juno1m7gwjd4slsnsh6l7c36g7n5c5nhqewfr9lsx6hf2w48wftcm3qssfxdswq",

--- a/src/constants/contracts.ts
+++ b/src/constants/contracts.ts
@@ -27,7 +27,7 @@ const testnet:Contracts = {
   index_fund:      "juno1d26dmz9zld4n8pzjpqae5m95adnfalvz47vldpwfzsplw4umcjmqhkle94",
   cw4GrpApTeam:    "juno1qkphn8h2rnyqjjtfh8j8dtuqgh5cac57nq2286tsljducqp4lwfqac44jm",
   cw3ApTeam:       "juno1ukpw6g9dqfw3fk2mqchplgcz4jaukttf6tpyrht7sw00t7mn7dpsjwpfhs",
-  accounts:        "juno1d4v5h5yr920xjjwcuret5n3meee5l04c58fpjhghdgml8kp57spqvmg4lx",
+  accounts:        "juno1cyd63pk2wuvjkqmhlvp9884z4h89rqtn8w8xgz9m28hjd2kzj2cqf070uz",
   cw4GrpCharityReviewTeam:"juno12lgc6d44c0y0tnef8fwjq8d9arrw5jgvrg8ydju5kz7nek9px72qvu8aw0",
   cw3CharityReviewTeam:   "juno1lstuws59hjswletwmskefdajhq76pz9tlfq84perndemrzztda0q6jc3nr",
   cw4GrpImpactReviewTeam: "juno1m7gwjd4slsnsh6l7c36g7n5c5nhqewfr9lsx6hf2w48wftcm3qssfxdswq",

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Form.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Form.tsx
@@ -23,7 +23,8 @@ export default function Form() {
         our cross-chain pipelines.
       </Warning>
       <Warning classes="mb-2">
-        The minimum withdrawal for Ethereum & Binance is $20 USDC.
+        The minimum withdrawal for Ethereum & Binance is $40 & $20 USDC,
+        respectively.
       </Warning>
       <Warning classes="mb-2">
         We recommend not using crypto exchange addresses for withdrawals. We are

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/schema.ts
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/schema.ts
@@ -29,8 +29,15 @@ const amount: (arg: TNetwork) => SchemaShape<Amount> = (network) => ({
                * NOTE: this is on the assumption that endow TOH would just be USDC
                * for other tokens, must first get dollar amount
                */
-              "minimum 20 USDC",
-              () => (network === chainIds.juno ? true : +val >= 20)
+              network === chainIds.ethereum
+                ? "minimum 40 USDC"
+                : "minimum 20 USDC",
+              () =>
+                network === chainIds.juno
+                  ? true
+                  : network === chainIds.ethereum
+                  ? +val >= 40
+                  : +val >= 20
             )
         )
   ),


### PR DESCRIPTION
## Explanation of the solution
Based from an [announcement from Axelar](https://twitter.com/Axl_Satellite/status/1634510337557897218), we need to increase the minimum amount for Ethereum withdrawals.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- connect an admin wallet from `testnet` and verify that the schema check for Ethereum withdraw is now 40 USDC
- Binance withdraws should stay the same

## UI changes for review
<img width="455" alt="Screenshot 2023-03-13 at 12 14 57" src="https://user-images.githubusercontent.com/65009749/224606832-0a896f9b-37fd-4e86-ac44-e11c105bd0c6.png">
