### PR TITLE
Lowercase 'Balance' -> 'balance' when querying giftcard balances

### DIFF
--- a/src/services/juno/queryContract/queryObjects.ts
+++ b/src/services/juno/queryContract/queryObjects.ts
@@ -30,7 +30,7 @@ export const queryObject: {
 
   /** giftcard */
   giftcardBalance({ addr }) {
-    return { Balance: { address: addr } };
+    return { balance: { address: addr } };
   },
 
   /** cw4 member */


### PR DESCRIPTION

## Explanation of the solution
We're getting an error when querying giftcard balances.

URL: https://api.uni.junonetwork.io/cosmwasm/wasm/v1/contract/juno1zfjggfdjadcgd4f2jugw440vfdecf5erqfy0ts9f5v9yucmu99rqdsy6j6/smart/eyJCYWxhbmNlIjp7ImFkZHJlc3MiOiJqdW5vMWs3amttdnprcnIzcnY0aHRxdm1oNjNmMGZtdm04OWRmcHFjNnk1In19

Error: ``"Error parsing into type gift_cards::msg::QueryMsg: unknown variant `Balance`, expected one of `balance`, `config`, `deposit`: query wasm contract failed: invalid request"``

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- open browser console
- connect Charity 1 wallet
- open browser network tab
- verify giftcard balance query successfully returns result
