### PR TITLE
Fix: Removing rounded borders on connector icons

### DIFF
--- a/src/components/WalletSuite/WalletSelectorOpener/Connector.tsx
+++ b/src/components/WalletSuite/WalletSelectorOpener/Connector.tsx
@@ -23,7 +23,7 @@ export default function Connector(props: Connection) {
     >
       <Image
         src={props.logo}
-        className="w-12 h-12 border border-prim rounded-full"
+        className="w-12 h-12 rounded-full"
       />
       <span className="font-heading font-bold text-sm capitalize">
         {props.name}


### PR DESCRIPTION
Closes #1930

## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

Removing the rounded borders on connector icons