### PR TITLE
Update CheckField input to be a controlled component

### DIFF
--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -1,6 +1,6 @@
 import { ErrorMessage } from "@hookform/error-message";
 import { PropsWithChildren } from "react";
-import { FieldValues, Path, useFormContext } from "react-hook-form";
+import { Controller, FieldValues, Path, useFormContext } from "react-hook-form";
 import { Classes } from "./types";
 import { unpack } from "./helpers";
 
@@ -16,34 +16,43 @@ export function CheckField<T extends FieldValues>({
   disabled?: boolean;
   required?: boolean;
 }>) {
-  const {
-    register,
-    formState: { errors, isSubmitting },
-  } = useFormContext<T>();
+  const { control } = useFormContext<T>();
 
   const id = `__${name}`;
   const { container, input: int, lbl, error } = unpack(classes);
 
   return (
-    <div className={`check-field ${container}`}>
-      <input
-        className={int + " peer"}
-        type="checkbox"
-        {...register(name)}
-        id={id}
-        disabled={isSubmitting || disabled}
-      />
-      <label data-required={required} className={lbl} htmlFor={id}>
-        {children}
-      </label>
+    <Controller
+      control={control}
+      name={name}
+      render={({
+        field: { value, onChange },
+        formState: { isSubmitting, errors },
+      }) => (
+        <div className={`check-field ${container}`}>
+          <input
+            className={int + " peer"}
+            type="checkbox"
+            checked={value}
+            onChange={(e) => onChange(e.target.checked)}
+            id={id}
+            disabled={isSubmitting || disabled}
+          />
+          {!!children && (
+            <label data-required={required} className={lbl} htmlFor={id}>
+              {children}
+            </label>
+          )}
 
-      <ErrorMessage
-        data-error
-        errors={errors}
-        name={name as any}
-        as="p"
-        className={error}
-      />
-    </div>
+          <ErrorMessage
+            data-error
+            errors={errors}
+            name={name as any}
+            as="p"
+            className={error}
+          />
+        </div>
+      )}
+    />
   );
 }


### PR DESCRIPTION
Ticket(s):
- https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1942

## Explanation of the solution
Making the `CheckField` a ["controlled" component](https://react-hook-form.com/api/usecontroller/controller/) makes it easier to use the underlying form context as the "single source of truth", thus enabling us to use the same component connected to the same form context value, but in different subcomponents on the same page (e.g. Donations/Table + Donations/MobileTable).

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify checkboxes work as before, e.g. in Register flow
