### PR TITLE
Fix `getPayloadDiff` bug: update `isNaN` uses to `Number.isNaN`

### DIFF
--- a/src/helpers/admin/getPayloadDiff.test.ts
+++ b/src/helpers/admin/getPayloadDiff.test.ts
@@ -77,7 +77,7 @@ describe("getPayloadDiff", () => {
       )
     ).toStrictEqual({});
   });
-  test("objects", () => {
+  test("both the same string in prev and next", () => {
     expect(
       getPayloadDiff(
         //prettier ignore

--- a/src/helpers/admin/getPayloadDiff.test.ts
+++ b/src/helpers/admin/getPayloadDiff.test.ts
@@ -77,4 +77,13 @@ describe("getPayloadDiff", () => {
       )
     ).toStrictEqual({});
   });
+  test("objects", () => {
+    expect(
+      getPayloadDiff(
+        //prettier ignore
+        { a: "a" },
+        { a: "a" }
+      )
+    ).toStrictEqual({});
+  });
 });

--- a/src/helpers/admin/getPayloadDiff.ts
+++ b/src/helpers/admin/getPayloadDiff.ts
@@ -28,7 +28,7 @@ export function getPayloadDiff<T extends object>(prev: T, next: T): Partial<T> {
 }
 
 function areDiff(val1: any, val2: any): boolean {
-  if (isNaN(val1) && isNaN(val2)) {
+  if (Number.isNaN(val1) && Number.isNaN(val2)) {
     //two NaNs treated as they are the same
     return /** areDiff? */ false;
   }
@@ -49,5 +49,5 @@ function hasValue(val: any, exempts: any[] = []): boolean {
 
 // NaN | undefined | null | "" are treated as noValue
 function hasNoValue(val: any): boolean {
-  return val == null || val === "" || isNaN(val);
+  return val == null || val === "" || Number.isNaN(val);
 }


### PR DESCRIPTION

## Explanation of the solution
Added a simple test showing the current implementation has a bug introduced with #1914:
```ts
  test("both the same string in prev and next", () => {
    expect(
      getPayloadDiff(
        { a: "a" },
        { a: "a" }
      )
    ).toStrictEqual({});
  });
```
This was failing as the func was returning `{ a: "a" }`.

Issue is that `isNaN` is used to check for `NaN` in `getPayloadDiff` (see [code](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/RC-v1.8/src/helpers/admin/getPayloadDiff.ts#L31)), which returns `true` for almost all non-numeric values (first converts the value to number and then checks if it's `NaN`). To fix this, `Number.isNaN` should be used to check if passed values are `NaN`, as it first checks if the passed value is a `number` at all before checking for `NaN` (see docs https://www.w3schools.com/jsref/jsref_isnan.asp)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes