### PR TITLE
Create generic endowments `redux-toolkit` query

### DIFF
--- a/src/helpers/__tests__/cleanObject.test.ts
+++ b/src/helpers/__tests__/cleanObject.test.ts
@@ -4,10 +4,11 @@ import { cleanObject } from "../cleanObject";
 describe("cleanObject", () => {
   test("removes falsy values except 0", () => {
     expect(
-      cleanObject({ a: undefined, b: "", c: 0, d: null, e: "hello" })
+      cleanObject({ a: undefined, b: "", c: 0, d: null, e: "hello", f: [] })
     ).toStrictEqual({
       c: 0,
       e: "hello",
+      f: [],
     });
   });
 });

--- a/src/pages/Admin/Charity/EditProfile/index.tsx
+++ b/src/pages/Admin/Charity/EditProfile/index.tsx
@@ -1,7 +1,7 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import { FormProvider, useForm } from "react-hook-form";
 import { FlatFormValues, FormValues } from "./types";
-import { EndowmentProfile } from "types/aws";
+import { Endowment } from "types/aws";
 import { useAdminResources } from "pages/Admin/Guard";
 import { useProfileQuery } from "services/aws/aws";
 import Seo from "components/Seo";
@@ -24,7 +24,7 @@ export default function EditProfile() {
   return <FormWithContext {...profile} />;
 }
 
-function FormWithContext(props: EndowmentProfile) {
+function FormWithContext(props: Endowment) {
   const { active_in_countries = [] } = props;
   // could just add to useForm.defaultValue - but not Partial here
   const flatInitial: FlatFormValues = {

--- a/src/pages/Admin/Charity/EditProfile/types.ts
+++ b/src/pages/Admin/Charity/EditProfile/types.ts
@@ -1,8 +1,10 @@
 import { CountryOption } from "services/types";
-import { EndowmentProfileUpdate } from "types/aws";
+import { EndowmentCloudSearchParams } from "types/aws";
 import { UNSDG_NUMS } from "types/lists";
 import { ImgLink } from "components/ImgEditor";
 import { OptionType } from "components/Selector";
+
+export type EndowmentProfileUpdate = Required<EndowmentCloudSearchParams>;
 
 type K = keyof EndowmentProfileUpdate;
 const _logo: K = "logo";
@@ -14,6 +16,13 @@ const _general: K = "categories_general";
 const _id: K = "id";
 const _tier: K = "tier";
 const _owner: K = "owner";
+const _endow_type: K = "endow_type";
+const _total_liq: K = "total_liq";
+const _total_lock: K = "total_lock";
+const _overall: K = "overall";
+const _on_hand_liq: K = "on_hand_liq";
+const _on_hand_lock: K = "on_hand_lock";
+const _on_hand_overall: K = "on_hand_overall";
 
 export type FlatFormValues = Omit<
   EndowmentProfileUpdate,
@@ -24,6 +33,13 @@ export type FlatFormValues = Omit<
   | typeof _id
   | typeof _tier
   | typeof _owner
+  | typeof _endow_type
+  | typeof _total_liq
+  | typeof _total_lock
+  | typeof _overall
+  | typeof _on_hand_liq
+  | typeof _on_hand_lock
+  | typeof _on_hand_overall
 >;
 
 export type FormValues = Omit<

--- a/src/pages/Admin/Charity/EditProfile/types.ts
+++ b/src/pages/Admin/Charity/EditProfile/types.ts
@@ -1,10 +1,10 @@
 import { CountryOption } from "services/types";
-import { EndowmentCloudSearchParams } from "types/aws";
+import { EndowmentCloudSearchFields } from "types/aws";
 import { UNSDG_NUMS } from "types/lists";
 import { ImgLink } from "components/ImgEditor";
 import { OptionType } from "components/Selector";
 
-export type EndowmentProfileUpdate = Required<EndowmentCloudSearchParams>;
+export type EndowmentProfileUpdate = Required<EndowmentCloudSearchFields>;
 
 type K = keyof EndowmentProfileUpdate;
 const _logo: K = "logo";

--- a/src/pages/Admin/Charity/EditProfile/useEditProfile.ts
+++ b/src/pages/Admin/Charity/EditProfile/useEditProfile.ts
@@ -1,6 +1,9 @@
 import { SubmitHandler, useFormContext } from "react-hook-form";
-import { FormValues as FV, FlatFormValues } from "./types";
-import { EndowmentProfileUpdate } from "types/aws";
+import {
+  EndowmentProfileUpdate,
+  FormValues as FV,
+  FlatFormValues,
+} from "./types";
 import { useAdminResources } from "pages/Admin/Guard";
 import { useEditProfileMutation } from "services/aws/aws";
 import { useModalContext } from "contexts/ModalContext";

--- a/src/pages/Admin/Charity/WidgetConfigurer/WidgetUrlGenerator/EndowmentCombobox/Combobox.tsx
+++ b/src/pages/Admin/Charity/WidgetConfigurer/WidgetUrlGenerator/EndowmentCombobox/Combobox.tsx
@@ -13,7 +13,7 @@ const TEMPLATE_RESULT: {
   [key in keyof FormValues["endowIdName"]]: FormValues["endowIdName"][key];
 } = {
   id: -1,
-  name: "",
+  name: "name",
 };
 
 const containerStyle =

--- a/src/pages/Admin/Charity/WidgetConfigurer/WidgetUrlGenerator/EndowmentCombobox/Combobox.tsx
+++ b/src/pages/Admin/Charity/WidgetConfigurer/WidgetUrlGenerator/EndowmentCombobox/Combobox.tsx
@@ -3,12 +3,19 @@ import { ErrorMessage } from "@hookform/error-message";
 import React, { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { EndowmentIdName } from "types/aws";
-import { useEndowmentIdNamesQuery } from "services/aws/aws";
+import { useEndowmentsQuery } from "services/aws/aws";
 import { DrawerIcon } from "components/Icon";
 import QueryLoader from "components/QueryLoader";
 import useDebouncer from "hooks/useDebouncer";
 import { unsdgs } from "constants/unsdgs";
 import { FormValues } from "../../schema";
+
+const ENDOW_ID_NAME_OBJ: {
+  [key in keyof EndowmentIdName]: any;
+} = {
+  id: "",
+  name: "",
+};
 
 const containerStyle =
   "absolute top-full mt-2 z-10 w-full bg-white dark:bg-blue-d6 shadow-lg rounded overflow-y-scroll scroller";
@@ -23,7 +30,7 @@ export default function Combobox() {
 
   const [debouncedQuery] = useDebouncer(query, 500);
 
-  const { data, isLoading, isError } = useEndowmentIdNamesQuery({
+  const { data, isLoading, isError } = useEndowmentsQuery({
     query: debouncedQuery || "matchall",
     sort: "default",
     endow_types: "Charity",
@@ -31,6 +38,7 @@ export default function Combobox() {
     sdgs: Object.keys(unsdgs).join(","),
     kyc_only: "true,false",
     start: 0,
+    templateResult: ENDOW_ID_NAME_OBJ,
   });
 
   return (

--- a/src/pages/Admin/Charity/WidgetConfigurer/WidgetUrlGenerator/EndowmentCombobox/Combobox.tsx
+++ b/src/pages/Admin/Charity/WidgetConfigurer/WidgetUrlGenerator/EndowmentCombobox/Combobox.tsx
@@ -10,7 +10,7 @@ import useDebouncer from "hooks/useDebouncer";
 import { unsdgs } from "constants/unsdgs";
 import { FormValues } from "../../schema";
 
-const ENDOW_ID_NAME_OBJ: {
+const TEMPLATE_RESULT: {
   [key in keyof EndowmentIdName]: any;
 } = {
   id: "",
@@ -38,7 +38,7 @@ export default function Combobox() {
     sdgs: Object.keys(unsdgs).join(","),
     kyc_only: "true,false",
     start: 0,
-    templateResult: ENDOW_ID_NAME_OBJ,
+    templateResult: TEMPLATE_RESULT,
   });
 
   return (

--- a/src/pages/Admin/Charity/WidgetConfigurer/WidgetUrlGenerator/EndowmentCombobox/Combobox.tsx
+++ b/src/pages/Admin/Charity/WidgetConfigurer/WidgetUrlGenerator/EndowmentCombobox/Combobox.tsx
@@ -2,7 +2,6 @@ import { Combobox as HuiCombobox } from "@headlessui/react";
 import { ErrorMessage } from "@hookform/error-message";
 import React, { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import { EndowmentIdName } from "types/aws";
 import { useEndowmentsQuery } from "services/aws/aws";
 import { DrawerIcon } from "components/Icon";
 import QueryLoader from "components/QueryLoader";
@@ -11,9 +10,9 @@ import { unsdgs } from "constants/unsdgs";
 import { FormValues } from "../../schema";
 
 const TEMPLATE_RESULT: {
-  [key in keyof EndowmentIdName]: any;
+  [key in keyof FormValues["endowIdName"]]: FormValues["endowIdName"][key];
 } = {
-  id: "",
+  id: -1,
   name: "",
 };
 
@@ -57,7 +56,7 @@ export default function Combobox() {
             ref={ref}
             placeholder="Select an endowment..."
             onChange={(event) => setQuery(event.target.value)}
-            displayValue={(value: EndowmentIdName) => value.name}
+            displayValue={(value: FormValues["endowIdName"]) => value.name}
             className="pl-4"
           />
 

--- a/src/pages/Admin/Charity/WidgetConfigurer/schema.ts
+++ b/src/pages/Admin/Charity/WidgetConfigurer/schema.ts
@@ -1,8 +1,8 @@
-import { EndowmentProfile } from "types/aws";
+import { Endowment } from "types/aws";
 import { OptionType } from "components/Selector";
 
 export type FormValues = {
-  endowIdName: Pick<EndowmentProfile, "id" | "name">;
+  endowIdName: Pick<Endowment, "id" | "name">;
   hideText: boolean;
   hideAdvancedOptions: boolean;
   unfoldAdvancedOptions: boolean;

--- a/src/pages/Admin/Charity/WidgetConfigurer/schema.ts
+++ b/src/pages/Admin/Charity/WidgetConfigurer/schema.ts
@@ -1,8 +1,8 @@
-import { EndowmentIdName } from "types/aws";
+import { EndowmentProfile } from "types/aws";
 import { OptionType } from "components/Selector";
 
 export type FormValues = {
-  endowIdName: EndowmentIdName;
+  endowIdName: Pick<EndowmentProfile, "id" | "name">;
   hideText: boolean;
   hideAdvancedOptions: boolean;
   unfoldAdvancedOptions: boolean;

--- a/src/pages/DonateWidget/EndowmentLoader.tsx
+++ b/src/pages/DonateWidget/EndowmentLoader.tsx
@@ -1,11 +1,11 @@
 import { ReactElement } from "react";
 import { useParams } from "react-router-dom";
-import { EndowmentProfile } from "types/aws";
+import { Endowment } from "types/aws";
 import { useProfileQuery } from "services/aws/aws";
 import QueryLoader from "components/QueryLoader";
 import { idParamToNum } from "helpers";
 
-type Props = { children(data: EndowmentProfile): ReactElement };
+type Props = { children(data: Endowment): ReactElement };
 
 export default function EndowmentLoader({ children }: Props) {
   const { id } = useParams<{ id: string }>();

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { Link } from "react-router-dom";
-import { EndowmentCard } from "types/aws";
+import { EndowmentCard } from "./types";
 import { UNSDG_NUMS } from "types/lists";
 import BookmarkBtn from "components/BookmarkBtn";
 import Icon from "components/Icon";

--- a/src/pages/Marketplace/Cards/types.ts
+++ b/src/pages/Marketplace/Cards/types.ts
@@ -1,0 +1,14 @@
+import { Endowment } from "types/aws";
+
+export type EndowmentCard = Pick<
+  Endowment,
+  | "active_in_countries"
+  | "name"
+  | "image"
+  | "id"
+  | "endow_type"
+  | "categories"
+  | "tagline"
+  | "hq_country"
+  | "kyc_donors_only"
+>;

--- a/src/pages/Marketplace/Cards/useCards.ts
+++ b/src/pages/Marketplace/Cards/useCards.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EndowmentCard, EndowmentProfileUpdate } from "types/aws";
+import { EndowmentCard } from "types/aws";
 import {
   updateAWSQueryData,
   useEndowmentsQuery,
@@ -7,22 +7,18 @@ import {
 } from "services/aws/aws";
 import { useGetter, useSetter } from "store/accessors";
 
-type EndowCardFields = keyof (Omit<EndowmentCard, "hq" | "categories"> &
-  /** replace with cloudsearch specific field format */
-  Pick<EndowmentProfileUpdate, "hq_country" | "categories_sdgs">);
-
 const TEMPLATE_RESULT: {
-  [key in EndowCardFields]: any; //we care only for keys
+  [key in keyof EndowmentCard]: EndowmentCard[key]; //we care only for keys
 } = {
   hq_country: "",
-  active_in_countries: "",
-  categories_sdgs: "",
-  id: "",
+  active_in_countries: [],
+  categories: { sdgs: [] },
+  id: -1,
   image: "",
-  kyc_donors_only: "",
+  kyc_donors_only: false,
   name: "",
   tagline: "",
-  endow_type: "",
+  endow_type: "Charity",
 };
 
 export default function useCards() {

--- a/src/pages/Marketplace/Cards/useCards.ts
+++ b/src/pages/Marketplace/Cards/useCards.ts
@@ -11,7 +11,7 @@ type EndowCardFields = keyof (Omit<EndowmentCard, "hq" | "categories"> &
   /** replace with cloudsearch specific field format */
   Pick<EndowmentProfileUpdate, "hq_country" | "categories_sdgs">);
 
-const endowCardObj: {
+const TEMPLATE_RESULT: {
   [key in EndowCardFields]: any; //we care only for keys
 } = {
   hq_country: "",
@@ -73,7 +73,7 @@ export default function useCards() {
     ...(activityCountries ? { active_in_countries: activityCountries } : {}),
     start: 0,
     limit: 15,
-    templateResult: endowCardObj,
+    templateResult: TEMPLATE_RESULT,
   });
 
   const [loadMore, { isLoading: isLoadingNextPage }] = useLazyEndowmentsQuery();

--- a/src/pages/Marketplace/Cards/useCards.ts
+++ b/src/pages/Marketplace/Cards/useCards.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { EndowmentCard } from "types/aws";
+import { EndowmentCard } from "./types";
 import {
   updateAWSQueryData,
   useEndowmentsQuery,
@@ -18,7 +18,7 @@ const TEMPLATE_RESULT: {
   kyc_donors_only: false,
   name: "",
   tagline: "",
-  endow_type: "Charity",
+  endow_type: "charity",
 };
 
 export default function useCards() {

--- a/src/pages/Marketplace/Cards/useCards.ts
+++ b/src/pages/Marketplace/Cards/useCards.ts
@@ -10,14 +10,14 @@ import { useGetter, useSetter } from "store/accessors";
 const TEMPLATE_RESULT: {
   [key in keyof EndowmentCard]: EndowmentCard[key]; //we care only for keys
 } = {
-  hq_country: "",
+  hq_country: "country",
   active_in_countries: [],
   categories: { sdgs: [] },
   id: -1,
-  image: "",
+  image: "img",
   kyc_donors_only: false,
-  name: "",
-  tagline: "",
+  name: "name",
+  tagline: "tagline",
   endow_type: "charity",
 };
 

--- a/src/pages/Profile/ProfileContext.ts
+++ b/src/pages/Profile/ProfileContext.ts
@@ -1,9 +1,9 @@
 import { createContext, useContext } from "react";
-import { EndowmentProfile } from "types/aws";
+import { Endowment } from "types/aws";
 
-const ProfileContext = createContext<EndowmentProfile>({} as EndowmentProfile);
+const ProfileContext = createContext<Endowment>({} as Endowment);
 
-export const useProfileContext = (): EndowmentProfile => {
+export const useProfileContext = (): Endowment => {
   const val = useContext(ProfileContext);
 
   if (Object.entries(val).length <= 0) {

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -2,6 +2,7 @@ import { createApi, fetchBaseQuery, retry } from "@reduxjs/toolkit/query/react";
 import {
   ADR36Payload,
   EndowmentCard,
+  EndowmentCloudSearchParams,
   EndowmentProfile,
   EndowmentsQueryParams,
   NewAIF,
@@ -46,11 +47,12 @@ export const aws = createApi({
     >({
       providesTags: ["endowments"],
       query: ({ templateResult, ...params }) => {
+        const returnParam = createReturnParam(templateResult);
         return {
           url: `/v3/endowments/${network}`,
           params: {
             ...params,
-            return: Object.keys(templateResult).join(","),
+            return: returnParam,
           },
         };
       },
@@ -149,3 +151,18 @@ export const useLazyEndowmentsQuery = () => {
     }));
   return [func, ...rest] as [typeof func, ...typeof rest];
 };
+
+function createReturnParam(templateResult: Partial<EndowmentCard>): string {
+  const { categories, ...okFields } = templateResult;
+
+  const cloudSearchParams: EndowmentCloudSearchParams = {
+    ...okFields,
+  };
+
+  if (!!categories) {
+    // doesn't matter what the value is, it's only important to have a defined `categories_sdgs` key
+    cloudSearchParams.categories_sdgs = categories.sdgs;
+  }
+
+  return Object.keys(cloudSearchParams).join(",");
+}

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -2,7 +2,7 @@ import { createApi, fetchBaseQuery, retry } from "@reduxjs/toolkit/query/react";
 import {
   ADR36Payload,
   Endowment,
-  EndowmentCloudSearchParams,
+  EndowmentCloudSearchFields,
   EndowmentsQueryParams,
   NewAIF,
   PaginatedAWSQueryRes,
@@ -152,7 +152,7 @@ export const useLazyEndowmentsQuery = () => {
 function createReturnParam(templateResult: Partial<Endowment>): string {
   const { categories, ...okFields } = templateResult;
 
-  const cloudSearchParams: EndowmentCloudSearchParams = {
+  const cloudSearchParams: EndowmentCloudSearchFields = {
     ...okFields,
   };
 

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -42,7 +42,7 @@ export const aws = createApi({
   endpoints: (builder) => ({
     endowments: builder.query<
       PaginatedAWSQueryRes<Partial<Endowment>[]>,
-      EndowmentsQueryParams & { templateResult: Partial<Endowment> }
+      EndowmentsQueryParams<Partial<Endowment>>
     >({
       providesTags: ["endowments"],
       query: ({ templateResult, ...params }) => {
@@ -127,22 +127,20 @@ export const {
 } = aws;
 
 export const useEndowmentsQuery = <T extends Partial<Endowment>>(
-  qParams: EndowmentsQueryParams & { templateResult: T }
+  qParams: EndowmentsQueryParams<T>
 ) => {
   const result = aws.endpoints.endowments.useQuery(qParams);
   return {
     ...result,
     data: result.data as PaginatedAWSQueryRes<T[]>,
-    originalArgs: result.originalArgs as EndowmentsQueryParams & {
-      templateResult: T;
-    },
+    originalArgs: result.originalArgs as EndowmentsQueryParams<T>,
   };
 };
 
 export const useLazyEndowmentsQuery = () => {
   const [fetch, ...rest] = aws.endpoints.endowments.useLazyQuery();
   const func = <T extends Partial<Endowment>>(
-    params: EndowmentsQueryParams & { templateResult: T }
+    params: EndowmentsQueryParams<T>
   ) =>
     fetch(params).then((res) => ({
       ...res,

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -10,6 +10,7 @@ import {
 } from "types/aws";
 import { NetworkType } from "types/lists";
 import { createAuthToken } from "helpers";
+import { cleanObject } from "helpers/cleanObject";
 import { IS_TEST } from "constants/env";
 import { APIs } from "constants/urls";
 
@@ -150,16 +151,35 @@ export const useLazyEndowmentsQuery = () => {
 };
 
 function createReturnParam(templateResult: Partial<Endowment>): string {
-  const { categories, ...okFields } = templateResult;
-
-  const cloudSearchParams: EndowmentCloudSearchFields = {
-    ...okFields,
+  const cloudSearchFields: EndowmentCloudSearchFields = {
+    active_in_countries: templateResult.active_in_countries,
+    categories_sdgs: templateResult.categories?.sdgs,
+    endow_type: templateResult.endow_type,
+    hq_country: templateResult.hq_country,
+    id: templateResult.id,
+    image: templateResult.image,
+    kyc_donors_only: templateResult.kyc_donors_only,
+    logo: templateResult.logo,
+    name: templateResult.name,
+    on_hand_liq: templateResult.on_hand_liq,
+    on_hand_lock: templateResult.on_hand_lock,
+    on_hand_overall: templateResult.on_hand_overall,
+    overall: templateResult.overall,
+    overview: templateResult.overview,
+    registration_number: templateResult.registration_number,
+    social_media_url_discord: templateResult.social_media_urls?.discord,
+    social_media_url_facebook: templateResult.social_media_urls?.facebook,
+    social_media_url_instagram: templateResult.social_media_urls?.instagram,
+    social_media_url_linkedin: templateResult.social_media_urls?.linkedin,
+    social_media_url_tiktok: templateResult.social_media_urls?.tiktok,
+    social_media_url_twitter: templateResult.social_media_urls?.twitter,
+    social_media_url_youtube: templateResult.social_media_urls?.youtube,
+    street_address: templateResult.street_address,
+    tagline: templateResult.tagline,
+    total_liq: templateResult.total_liq,
+    total_lock: templateResult.total_lock,
+    url: templateResult.url,
   };
 
-  if (!!categories) {
-    // doesn't matter what the value is, it's only important to have a defined `categories_sdgs` key
-    cloudSearchParams.categories_sdgs = categories.sdgs;
-  }
-
-  return Object.keys(cloudSearchParams).join(",");
+  return Object.keys(cleanObject(cloudSearchFields)).join(",");
 }

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -1,9 +1,8 @@
 import { createApi, fetchBaseQuery, retry } from "@reduxjs/toolkit/query/react";
 import {
   ADR36Payload,
-  EndowmentCard,
+  Endowment,
   EndowmentCloudSearchParams,
-  EndowmentProfile,
   EndowmentsQueryParams,
   NewAIF,
   PaginatedAWSQueryRes,
@@ -42,8 +41,8 @@ export const aws = createApi({
   baseQuery: awsBaseQuery,
   endpoints: (builder) => ({
     endowments: builder.query<
-      PaginatedAWSQueryRes<Partial<EndowmentCard>[]>,
-      EndowmentsQueryParams & { templateResult: Partial<EndowmentCard> }
+      PaginatedAWSQueryRes<Partial<Endowment>[]>,
+      EndowmentsQueryParams & { templateResult: Partial<Endowment> }
     >({
       providesTags: ["endowments"],
       query: ({ templateResult, ...params }) => {
@@ -76,10 +75,10 @@ export const aws = createApi({
       },
       transformResponse: (response: { data: any }) => response,
     }),
-    profile: builder.query<EndowmentProfile, number>({
+    profile: builder.query<Endowment, number>({
       providesTags: ["profile"],
       query: (endowId) => `/v1/profile/${network}/endowment/${endowId}`,
-      transformResponse({ tagline, ...rest }: EndowmentProfile) {
+      transformResponse({ tagline, ...rest }: Endowment) {
         //transform cloudsearch placeholders
         return {
           tagline: tagline === " " ? "" : tagline,
@@ -87,7 +86,7 @@ export const aws = createApi({
         };
       },
     }),
-    editProfile: builder.mutation<EndowmentProfile, ADR36Payload>({
+    editProfile: builder.mutation<Endowment, ADR36Payload>({
       invalidatesTags: ["endowments", "profile", "walletProfile"],
       query: (payload) => {
         return {
@@ -127,7 +126,7 @@ export const {
   },
 } = aws;
 
-export const useEndowmentsQuery = <T extends Partial<EndowmentCard>>(
+export const useEndowmentsQuery = <T extends Partial<Endowment>>(
   qParams: EndowmentsQueryParams & { templateResult: T }
 ) => {
   const result = aws.endpoints.endowments.useQuery(qParams);
@@ -142,7 +141,7 @@ export const useEndowmentsQuery = <T extends Partial<EndowmentCard>>(
 
 export const useLazyEndowmentsQuery = () => {
   const [fetch, ...rest] = aws.endpoints.endowments.useLazyQuery();
-  const func = <T extends Partial<EndowmentCard>>(
+  const func = <T extends Partial<Endowment>>(
     params: EndowmentsQueryParams & { templateResult: T }
   ) =>
     fetch(params).then((res) => ({
@@ -152,7 +151,7 @@ export const useLazyEndowmentsQuery = () => {
   return [func, ...rest] as [typeof func, ...typeof rest];
 };
 
-function createReturnParam(templateResult: Partial<EndowmentCard>): string {
+function createReturnParam(templateResult: Partial<Endowment>): string {
   const { categories, ...okFields } = templateResult;
 
   const cloudSearchParams: EndowmentCloudSearchParams = {

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -2,7 +2,7 @@ import { Keplr } from "@keplr-wallet/types";
 import { EndowmentType } from "../../contracts";
 import { NetworkType, UNSDG_NUMS } from "../../lists";
 
-type EndowmentBase = {
+export type Endowment = {
   hq_country: string;
   active_in_countries?: string[];
   categories: { sdgs: UNSDG_NUMS[] };
@@ -12,9 +12,9 @@ type EndowmentBase = {
 
   name: string;
   tagline: string;
-};
+  endow_type: EndowmentType;
 
-export type EndowmentProfile = EndowmentBase & {
+  // profile related
   contact_email: string;
   logo: string;
   overview: string;
@@ -43,16 +43,12 @@ export type EndowmentProfile = EndowmentBase & {
   url?: string;
 };
 
-export type EndowmentCard = EndowmentBase & {
-  endow_type: EndowmentType;
-};
-
 export type EndowmentCloudSearchParams = Partial<{
   id: number;
   owner: string;
   active_in_countries: string[];
   categories_general: string[];
-  endow_type: CapitalizedEndowmentType;
+  endow_type: EndowmentType;
   categories_sdgs: UNSDG_NUMS[];
   hq_country: string;
   image: string;

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -43,7 +43,7 @@ export type Endowment = {
   url?: string;
 };
 
-export type EndowmentCloudSearchParams = Partial<{
+export type EndowmentCloudSearchFields = Partial<{
   id: number;
   owner: string;
   active_in_countries: string[];

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -84,7 +84,7 @@ export type EndowmentsSortKey = "name_internal" | "overall";
 
 export type EndowDesignation = "Non-Profit" | "Religious Non-Profit";
 
-export type EndowmentsQueryParams = {
+export type EndowmentsQueryParams<T extends Partial<Endowment>> = {
   query: string; //set to "matchAll" if no search query
   sort: "default" | `${EndowmentsSortKey}+${SortDirection}`;
   start?: number; //to load next page, set start to ItemCutOff + 1
@@ -96,6 +96,10 @@ export type EndowmentsQueryParams = {
   hq_country?: string; //comma separated values
   active_in_countries?: string; //comma separated values
   limit?: number; // Number of items to be returned per request. If not provided, API defaults to return all
+
+  // temporary object representing the expected (template) result format/type
+  // to be converted to `return` CloudSearch param (comma separated field names to include in result)
+  templateResult: T;
 };
 
 export interface LeaderboardEntry {

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -52,6 +52,7 @@ export type EndowmentCloudSearchParams = Partial<{
   owner: string;
   active_in_countries: string[];
   categories_general: string[];
+  endow_type: CapitalizedEndowmentType;
   categories_sdgs: UNSDG_NUMS[];
   hq_country: string;
   image: string;
@@ -71,9 +72,16 @@ export type EndowmentCloudSearchParams = Partial<{
   tagline: string;
   tier: number /** 1 - 3  */;
   url: string | null;
-}>;
+  // represents total cumulative balances
+  total_liq: number;
+  total_lock: number;
+  overall: number;
 
-export type EndowmentProfileUpdate = Required<EndowmentCloudSearchParams>;
+  // represents tokens on hand balances (takes into account withdrawn funds)
+  on_hand_liq: number;
+  on_hand_lock: number;
+  on_hand_overall: number;
+}>;
 
 export type SortDirection = "asc" | "desc";
 export type EndowmentsSortKey = "name_internal" | "overall";

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -47,15 +47,9 @@ export type EndowmentCard = EndowmentBase & {
   endow_type: EndowmentType;
 };
 
-export type EndowmentIdName = Pick<EndowmentBase, "id" | "name">;
-
-export type EndowmentProfileUpdate = {
-  //required
+export type EndowmentCloudSearchParams = Partial<{
   id: number;
   owner: string;
-
-  /** optional, though set as required in this type
-  to force setting of default values - "", [], etc ..*/
   active_in_countries: string[];
   categories_general: string[];
   categories_sdgs: UNSDG_NUMS[];
@@ -77,7 +71,9 @@ export type EndowmentProfileUpdate = {
   tagline: string;
   tier: number /** 1 - 3  */;
   url: string | null;
-};
+}>;
+
+export type EndowmentProfileUpdate = Required<EndowmentCloudSearchParams>;
 
 export type SortDirection = "asc" | "desc";
 export type EndowmentsSortKey = "name_internal" | "overall";


### PR DESCRIPTION
## Explanation of the solution
Targeting the `GET /v3/endowments` endpoint can return *all the endowment data* we have in our DB. The thing is that in our code, we usually need only a subset of this data, e.g. when fetching marketplace cards or fetching endow ID & name in Widget configurer page. To do this:
- we created [two `redux-toolkit` query endpoints targeting the same AWS endpoint](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/RC-v1.8/src/services/aws/aws.ts#L44).
- we created duplicate types in the root [types/aws](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/RC-v1.8/src/types/aws/ap/index.ts#L5) namespace (`EndowmentBase, EndowmentProfile, EndowmentCard` are all subsets of the same type).
- we were missing any type or even indication that the reason we're flattening nested `Endowment[Base/Card/Profile]` fields because we're using CloudSearch in the backend (see [example](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/RC-v1.8/src/services/aws/aws.ts#L142)).

This PR is an attempt to address all three and simplify the logic at least a little bit. The way (or one way) to do this is to create a generic "fetch endowments` query that **can** return all fields, but pass a "template" (or "expected") object that represents the format of the result as well as the fields that the query should return over the network (using the [`returns` URL param](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/RC-v1.8/src/services/aws/aws.ts#L50)).

This PR introduces a new level of abstraction to allow reusing the same endpoint while maintaining type-safety, maintaining performance and maintaining the amount of data transferred over the network. Having an extra 50 lines of code to remove `useEndowmentCardsQuery` (doesn't return "endowment cards" but returns just "endowments") and `useEndowmentIdNameQuery` (ridiculous ad-hoc name), both of which are placed in the root `aws` service, but are used in only one specific place.


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify Marketplace cards are loaded as before
- verify navigating away and back to Marketplace reads Endowment cards data from cache (as before)
- verify admin sidebar header loads data as before
