### PR TITLE
HOT FIX: Endow Designations & Marketplace Filters

### DIFF
--- a/src/pages/Marketplace/Sidebar/Designations.tsx
+++ b/src/pages/Marketplace/Sidebar/Designations.tsx
@@ -6,10 +6,13 @@ import { FilterOption, FlatFilter } from "./common";
 const options: FilterOption<EndowDesignation>[] = [
   { displayText: "Non-Profit", key: "non-profit", value: "Non-Profit" },
   {
-    displayText: "Religious Non-Profit",
-    key: "religious-non-profit",
-    value: "Religious Non-Profit",
+    displayText: "Religious Organization",
+    key: "religious-organization",
+    value: "Religious Organization",
   },
+  { displayText: "University", key: "university", value: "University" },
+  { displayText: "Hospital", key: "hospital", value: "Hospital" },
+  { displayText: "Other", key: "other", value: "Other" },
 ];
 
 export default function Designations() {

--- a/src/pages/Marketplace/Sidebar/index.tsx
+++ b/src/pages/Marketplace/Sidebar/index.tsx
@@ -5,7 +5,6 @@ import Designations from "./Designations";
 import KYCFilter from "./KYCFilter";
 import Regions from "./Regions";
 import SDGGroups from "./SDGGroups";
-import Types from "./Types";
 
 export default function Sidebar({ classes = "" }: { classes?: string }) {
   const dispatch = useSetter();
@@ -46,7 +45,6 @@ export default function Sidebar({ classes = "" }: { classes?: string }) {
 
       <div className="flex w-full px-2">
         <div className="flex flex-col w-full">
-          <Types />
           <Designations />
           <KYCFilter />
           <SDGGroups />

--- a/src/slices/components/marketFilter/constants.ts
+++ b/src/slices/components/marketFilter/constants.ts
@@ -47,7 +47,7 @@ export const initialState: FilterState = {
   isOpen: false,
   searchText: "",
   endow_types: ["Charity"],
-  endow_designation: ["Religious Non-Profit", "Non-Profit"],
+  endow_designation: ["Religious Organization", "Non-Profit"],
   kyc_only: [true, false],
   tiers: ["Level2", "Level3"],
 };

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -87,7 +87,12 @@ export type EndowmentProfileUpdate = {
 export type SortDirection = "asc" | "desc";
 export type EndowmentsSortKey = "name_internal" | "overall";
 
-export type EndowDesignation = "Non-Profit" | "Religious Non-Profit";
+export type EndowDesignation =
+  | "Non-Profit"
+  | "Religious Organization"
+  | "University"
+  | "Hospital"
+  | "Other";
 
 export type EndowmentsQueryParams = {
   query: string; //set to "matchAll" if no search query


### PR DESCRIPTION
…remove Type;

Ticket(s):
- N/A

## Explanation of the solution
- match naming & labels for religious orgs  vs non-profit
- expand designation types in filters sidebar to be inclusive
- remove un-need types filter (we only show Charities in the Marketplace, not Normal Endows.)

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## UI changes for review
