### PR TITLE
Register link added to Header menu

### DIFF
--- a/src/App/Header/DesktopNav.tsx
+++ b/src/App/Header/DesktopNav.tsx
@@ -18,6 +18,9 @@ export default function DesktopNav({ classes = "" }: { classes?: string }) {
       <a href={`${BASE_DOMAIN}/about-angel-giving/`} className={styles}>
         About
       </a>
+      <NavLink className={styler} to={appRoutes.register}>
+        Register
+      </NavLink>
     </nav>
   );
 }

--- a/src/App/Header/MobileNav/Menu/Links.tsx
+++ b/src/App/Header/MobileNav/Menu/Links.tsx
@@ -32,6 +32,9 @@ export default function Links() {
       <a href={`${BASE_DOMAIN}/about-angel-giving/`} className={navStyle}>
         About
       </a>
+      <NavLink className={navLinkStyle} to={appRoutes.register}>
+        Register
+      </NavLink>
       <span
         className={`flex justify-between items-center mt-4 ${commonNavItemStyle}`}
       >


### PR DESCRIPTION
Ticket(s):
- N/A

## Explanation of the solution
- Adds a header menu link to Register page (`/register`) on both desktop and mobile 

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## UI changes for review
### Desktop header 
![register-desktop-header](https://user-images.githubusercontent.com/85138450/226500182-d56b015f-963c-45ea-a82f-d2d0bfa07de7.png)

### Mobile header 
![register-mobile-header](https://user-images.githubusercontent.com/85138450/226500193-221375ea-8147-4ab9-8fe5-040c3ba51f17.png)
