### PR TITLE
FIX: redundant max buttons on token-field (gift-purchase)

### DIFF
--- a/src/components/TokenField/Steps.tsx
+++ b/src/components/TokenField/Steps.tsx
@@ -9,26 +9,27 @@ export default function Steps({
 }: AmountOptionsProps) {
   const base = token.min_donation_amnt || 100;
   const precision = new Decimal(token.min_donation_amnt).decimalPlaces();
+  const steps = scale.map((s) => roundDownToNum(s * base, precision));
+
+  //only show steps if balance is gte all steps
+  if (!steps.every((s) => token.balance >= s)) return null;
 
   return (
     <div className="grid grid-cols-5 gap-2 text-xs">
-      {scale.map((s) => {
-        const step = roundDownToNum(s * base, precision);
-        return (
-          <button
-            type="button"
-            key={s}
-            onClick={() => onSetAmount(step)}
-            className={`${
-              step === Number(token.amount)
-                ? "bg-blue-l3 border-blue-l3 dark:bg-blue-d2 dark:border-blue-d2"
-                : "bg-blue-l4 dark:bg-blue-d4 border-prim"
-            }  rounded-full py-1.5 border`}
-          >
-            {step > token.balance ? "Max" : humanize(step, precision)}
-          </button>
-        );
-      })}
+      {steps.map((step) => (
+        <button
+          type="button"
+          key={step}
+          onClick={() => onSetAmount(step)}
+          className={`${
+            step === Number(token.amount)
+              ? "bg-blue-l3 border-blue-l3 dark:bg-blue-d2 dark:border-blue-d2"
+              : "bg-blue-l4 dark:bg-blue-d4 border-prim"
+          }  rounded-full py-1.5 border`}
+        >
+          {humanize(step, precision)}
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/components/TokenField/Steps.tsx
+++ b/src/components/TokenField/Steps.tsx
@@ -12,7 +12,7 @@ export default function Steps({
   const steps = scale.map((s) => roundDownToNum(s * base, precision));
 
   //only show steps if balance is gte all steps
-  if (!steps.every((s) => token.balance >= s)) return null;
+  if (token.balance < Math.max(...steps)) return null;
 
   return (
     <div className="grid grid-cols-5 gap-2 text-xs">


### PR DESCRIPTION
Ticket(s):
-
<img width="551" alt="image" src="https://user-images.githubusercontent.com/89639563/226521491-ccaf82fd-7d92-4c01-94b7-0cba1bb3014d.png">
* caused by logic `step > balance ? "max" : step`


## Explanation of the solution
only show steps when user's balance is greater than all steps. since steps 
are computed based on tokens `min_donation_amount` (not fixed like it's overkill to show users `10, 50, 100, 200` when 
donating `ETH` for example )

prevents the need to handle edges
1. given steps `1.0, 2.0, 3.0, 4.0, 5.0` what if user's balance is `3.2` should we 
* show `max` in like `1, 2, max, 4, 5`
* limit options to `1, 2, max`

also reduces form errors, since clicking a step ` > balance` would just show "not enough balance"


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes