### PR TITLE
Updated Types for Endowment Querying Params Due To V2.0 Contract Specs

### DIFF
--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -26,7 +26,7 @@ export default function Card({
     <div className="relative overflow-clip dark:bg-blue-d6 rounded-lg border border-prim hover:border-blue dark:hover:border-blue">
       <div className="absolute top-[14px] left-[14px] right-[14px] flex justify-between gap-3">
         <p className="bg-orange-l1 text-white font-semibold text-2xs rounded-sm uppercase px-2 py-0.5 font-heading">
-          {endow_type === "Charity" ? "Non-profit" : "For-profit"}
+          {endow_type === "charity" ? "Non-profit" : "For-profit"}
         </p>
         {kyc_donors_only && <KYCIcon className="ml-auto" />}
         <BookmarkBtn endowId={id} />

--- a/src/pages/Marketplace/Sidebar/Types.tsx
+++ b/src/pages/Marketplace/Sidebar/Types.tsx
@@ -1,11 +1,11 @@
-import { CapitalizedEndowmentType } from "types/contracts";
+import { EndowmentType } from "types/contracts";
 import { useGetter, useSetter } from "store/accessors";
 import { setTypes } from "slices/components/marketFilter";
 import { FilterOption, FlatFilter } from "./common";
 
-const options: FilterOption<CapitalizedEndowmentType>[] = [
-  { displayText: "Registered Non-Profit", key: "Charity", value: "Charity" },
-  { displayText: "Impact For-Profit", key: "Normal", value: "Normal" },
+const options: FilterOption<EndowmentType>[] = [
+  { displayText: "Registered Non-Profit", key: "Charity", value: "charity" },
+  { displayText: "Impact For-Profit", key: "Normal", value: "normal" },
   // { displayText: "Impact Crowdfunding", key: "ic", value: "ic" },
 ];
 

--- a/src/slices/components/marketFilter/constants.ts
+++ b/src/slices/components/marketFilter/constants.ts
@@ -46,10 +46,10 @@ export const initialState: FilterState = {
   region: { activities: {}, headquarters: {} },
   isOpen: false,
   searchText: "",
-  endow_types: ["Charity"],
+  endow_types: ["charity"],
   endow_designation: ["Religious Non-Profit", "Non-Profit"],
   kyc_only: [true, false],
-  tiers: ["Level2", "Level3"],
+  tiers: [2, 3],
 };
 
 export const clearedState: FilterState = {
@@ -60,8 +60,8 @@ export const clearedState: FilterState = {
   region: { activities: {}, headquarters: {} },
   isOpen: false,
   searchText: "",
-  endow_types: ["Charity"],
+  endow_types: ["charity"],
   endow_designation: [],
   kyc_only: [],
-  tiers: ["Level2", "Level3"],
+  tiers: [2, 3],
 };

--- a/src/slices/components/marketFilter/marketFilter.ts
+++ b/src/slices/components/marketFilter/marketFilter.ts
@@ -1,7 +1,7 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { RegionType, Sort } from "./types";
 import { EndowDesignation } from "types/aws";
-import { CapitalizedEndowmentType } from "types/contracts";
+import { EndowmentType } from "types/contracts";
 import { UNSDG_NUMS } from "types/lists";
 import { clearedState, initialState } from "./constants";
 
@@ -45,10 +45,7 @@ const marketFilter = createSlice({
     setSort: (state, { payload }: PayloadAction<Sort | undefined>) => {
       state.sort = payload;
     },
-    setTypes: (
-      state,
-      { payload }: PayloadAction<CapitalizedEndowmentType[]>
-    ) => {
+    setTypes: (state, { payload }: PayloadAction<EndowmentType[]>) => {
       state.endow_types = payload;
     },
     setDesignations: (

--- a/src/slices/components/marketFilter/types.ts
+++ b/src/slices/components/marketFilter/types.ts
@@ -1,5 +1,5 @@
 import { EndowDesignation, EndowmentsSortKey, SortDirection } from "types/aws";
-import { CapitalizedEndowmentType, EndowmentTier } from "types/contracts";
+import { EndowmentTierNum, EndowmentType } from "types/contracts";
 import { UNSDG_NUMS } from "types/lists";
 
 export type Sort = { key: EndowmentsSortKey; direction: SortDirection };
@@ -11,13 +11,13 @@ export type Regions = {
 export type FilterState = {
   isOpen: boolean;
   searchText: string;
-  endow_types: CapitalizedEndowmentType[];
+  endow_types: EndowmentType[];
   endow_designation: EndowDesignation[];
   sort?: Sort;
   sdgGroups: SdgGroups;
   region: { activities: Regions; headquarters: Regions };
   kyc_only: boolean[];
-  tiers: Exclude<EndowmentTier, "Level1">[];
+  tiers: Exclude<EndowmentTierNum, 1>[];
 };
 
 export type RegionType = keyof FilterState["region"];

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -1,5 +1,5 @@
 import { Keplr } from "@keplr-wallet/types";
-import { CapitalizedEndowmentType } from "../../contracts";
+import { EndowmentType } from "../../contracts";
 import { NetworkType, UNSDG_NUMS } from "../../lists";
 
 type EndowmentBase = {
@@ -44,7 +44,7 @@ export type EndowmentProfile = EndowmentBase & {
 };
 
 export type EndowmentCard = EndowmentBase & {
-  endow_type: CapitalizedEndowmentType;
+  endow_type: EndowmentType;
 };
 
 export type EndowmentIdName = Pick<EndowmentBase, "id" | "name">;
@@ -88,7 +88,7 @@ export type EndowmentsQueryParams = {
   query: string; //set to "matchAll" if no search query
   sort: "default" | `${EndowmentsSortKey}+${SortDirection}`;
   start?: number; //to load next page, set start to ItemCutOff + 1
-  endow_types: string | null; // comma separated CapitalizedEndowmentType values
+  endow_types: string | null; // comma separated EndowmentType values
   endow_designation?: string;
   sdgs: string | 0; // comma separated sdg values. The backend recognizes "0" as "no SDG was selected"
   tiers: string | null; // comma separated Exclude<EndowmentTier, "Level1"> values ("Level1" excluded for now)

--- a/src/types/contracts/common.ts
+++ b/src/types/contracts/common.ts
@@ -49,7 +49,6 @@ export type EndowmentStatus = {
   closed: 3;
 };
 export type EndowmentType = "charity" | "normal";
-// export type CapitalizedEndowmentType = Capitalize<EndowmentType>;
 export type EndowmentStatusText = keyof EndowmentStatus;
 export type EndowmentStatusNum = EndowmentStatus[EndowmentStatusText];
 export type EndowmentStatusStrNum = `${EndowmentStatusNum}`;

--- a/src/types/contracts/common.ts
+++ b/src/types/contracts/common.ts
@@ -52,7 +52,6 @@ export type EndowmentType = "charity" | "normal";
 export type EndowmentStatusText = keyof EndowmentStatus;
 export type EndowmentStatusNum = EndowmentStatus[EndowmentStatusText];
 export type EndowmentStatusStrNum = `${EndowmentStatusNum}`;
-// export type EndowmentTier = "Level1" | "Level2" | "Level3";
 export type EndowmentTierNum = 1 | 2 | 3;
 
 export type Categories = {

--- a/src/types/contracts/common.ts
+++ b/src/types/contracts/common.ts
@@ -49,11 +49,11 @@ export type EndowmentStatus = {
   closed: 3;
 };
 export type EndowmentType = "charity" | "normal";
-export type CapitalizedEndowmentType = Capitalize<EndowmentType>;
+// export type CapitalizedEndowmentType = Capitalize<EndowmentType>;
 export type EndowmentStatusText = keyof EndowmentStatus;
 export type EndowmentStatusNum = EndowmentStatus[EndowmentStatusText];
 export type EndowmentStatusStrNum = `${EndowmentStatusNum}`;
-export type EndowmentTier = "Level1" | "Level2" | "Level3";
+// export type EndowmentTier = "Level1" | "Level2" | "Level3";
 export type EndowmentTierNum = 1 | 2 | 3;
 
 export type Categories = {


### PR DESCRIPTION
Ticket(s):
- N/A

## Explanation of the solution
An update in AWS DB table is made in order to accept the new lowercase values for `endow_type`. There's also a new field called `endow_tier` that will replace the `tier` once v2.0 of the smart contracts is live in production.

This PR is created to update the `params` used for Marketplace cards querying. The `tiers` param's name remains unchanged and the required check is done in the Lambda itself.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Go to Marketplace and there should just be two endowment cards visible (endowment 11 and 19)

## UI changes for review

No major UI changes.