### PR TITLE
Rename `Documentation.level` to `tier` to align with other types

### DIFF
--- a/src/pages/Registration/Steps/Dashboard/index.tsx
+++ b/src/pages/Registration/Steps/Dashboard/index.tsx
@@ -55,7 +55,7 @@ function Dashboard() {
       <Step
         num={2}
         disabled={isStepDisabled}
-        status={`Level ${documentation.level}`}
+        status={`Level ${documentation.tier}`}
       />
       <Step num={3} disabled={isStepDisabled} />
 

--- a/src/pages/Registration/Steps/Documentation/index.tsx
+++ b/src/pages/Registration/Steps/Documentation/index.tsx
@@ -15,7 +15,7 @@ function Documentation() {
     resolver: yupResolver(schema),
     defaultValues: doc
       ? {
-          ...(({ level, ...doc }) => doc)(doc),
+          ...(({ tier, ...doc }) => doc)(doc),
         }
       : {
           proofOfIdentity: genFileAsset([]),

--- a/src/pages/Registration/Steps/Documentation/types.ts
+++ b/src/pages/Registration/Steps/Documentation/types.ts
@@ -1,6 +1,6 @@
 import { Documentation } from "pages/Registration/types";
 
 type Key = keyof Documentation;
-const _level: Key = "level";
+const _tier: Key = "tier";
 
-export type FormValues = Omit<Documentation, typeof _level>;
+export type FormValues = Omit<Documentation, typeof _tier>;

--- a/src/pages/Registration/Steps/getRegistrationState.ts
+++ b/src/pages/Registration/Steps/getRegistrationState.ts
@@ -125,7 +125,7 @@ function formatDocumentation({
     activeInCountries: ActiveInCountries.map((c) => ({ label: c, value: c })),
 
     //meta
-    level: Tier,
+    tier: Tier,
     hasAuthority: true,
     hasAgreedToTerms: true,
   };

--- a/src/pages/Registration/types.ts
+++ b/src/pages/Registration/types.ts
@@ -55,7 +55,7 @@ export type Documentation = {
   //so user won't click again on resume
   hasAuthority: boolean;
   hasAgreedToTerms: boolean;
-  level: EndowmentTierNum;
+  tier: EndowmentTierNum;
 
   hqCountry: CountryOption;
   // general info

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -1,5 +1,5 @@
 import { Keplr } from "@keplr-wallet/types";
-import { EndowmentType } from "../../contracts";
+import { EndowmentTierNum, EndowmentType } from "../../contracts";
 import { NetworkType, UNSDG_NUMS } from "../../lists";
 
 type EndowmentBase = {
@@ -75,7 +75,7 @@ export type EndowmentProfileUpdate = {
   social_media_url_tiktok: string;
   street_address: string;
   tagline: string;
-  tier: number /** 1 - 3  */;
+  tier: EndowmentTierNum /** 1 - 3  */;
   url: string | null;
 };
 


### PR DESCRIPTION
## Explanation of the solution
- update type of `EndowmentProfileUpdate.tier` from `number` to `EndowmentTierNum`
- rename `Documentation.level` to `tier` to align with other types

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes