### PR TITLE
Add support for polygon local

### DIFF
--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -57,8 +57,8 @@ const _chains: { [key in chainIDs]: Info } = {
     addressExplorer: `${explorers[chainIDs.polygonTest]}/address`,
   },
   [chainIDs.polygonLocal]: {
-    txExplorer: `${explorers[chainIDs.polygonTest]}/tx`,
-    addressExplorer: `${explorers[chainIDs.polygonTest]}/address`,
+    txExplorer: "",
+    addressExplorer: "",
   },
   [chainIDs.junoMain]: {
     txExplorer: `${explorers[chainIDs.junoMain]}/txs`,

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -5,6 +5,7 @@ export enum chainIDs {
   junoTest = "uni-6",
   polygonMain = "137",
   polygonTest = "80001",
+  polygonLocal = "1337",
   binanceMain = "56",
   binanceTest = "97",
   ethMain = "1",
@@ -23,6 +24,7 @@ const explorers: { [key in chainIDs]: string } = {
   56: "https://bscscan.com",
   137: "https://polygonscan.com",
   80001: "https://mumbai.polygonscan.com",
+  1337: "",
   "juno-1": "https://www.mintscan.io/juno",
   "uni-6": "https://testnet.mintscan.io/juno-testnet",
   "phoenix-1": "https://finder.terra.money/mainnet",
@@ -51,6 +53,10 @@ const _chains: { [key in chainIDs]: Info } = {
     addressExplorer: `${explorers[chainIDs.polygonMain]}/address`,
   },
   [chainIDs.polygonTest]: {
+    txExplorer: `${explorers[chainIDs.polygonTest]}/tx`,
+    addressExplorer: `${explorers[chainIDs.polygonTest]}/address`,
+  },
+  [chainIDs.polygonLocal]: {
     txExplorer: `${explorers[chainIDs.polygonTest]}/tx`,
     addressExplorer: `${explorers[chainIDs.polygonTest]}/address`,
   },

--- a/src/contexts/WalletContext/constants.ts
+++ b/src/contexts/WalletContext/constants.ts
@@ -95,6 +95,7 @@ export const EVM_SUPPORTED_CHAINS: BaseChain[] = IS_TEST
       { chain_id: chainIDs.ethTest, chain_name: "Ethereum Testnet" },
       { chain_id: chainIDs.binanceTest, chain_name: "BNB Smart Chain Testnet" },
       { chain_id: chainIDs.polygonTest, chain_name: "Polygon Testnet" },
+      { chain_id: chainIDs.polygonLocal, chain_name: "Polygon Local" },
     ]
   : [
       { chain_id: chainIDs.ethMain, chain_name: "Ethereum Mainnet" },


### PR DESCRIPTION
Ticket(s):
related to
* #1912
* #1910 

## Explanation of the solution
* add `1337` rpc and tokens in AWS
* add `1337` in web-app


## Instructions on making this work
* in `hardhat.config.js` change `hardhat.chainId` to `1337` before running local node
* add any of the initial 20 private/public key pair to metamask
* switch to `polygon-local` 
<img width="352" alt="image" src="https://user-images.githubusercontent.com/89639563/226547024-35e5ac70-c245-43ce-b6bb-6b3daf71477a.png">

* verify balance query working
<img width="363" alt="image" src="https://user-images.githubusercontent.com/89639563/226547114-60489496-4974-45de-9104-9b9f1f41f55b.png">


- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes