### PR TITLE
Profile logo fix

### DIFF
--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -35,7 +35,7 @@ export default function Image({ img, className }: Props) {
           <img
             ref={ref}
             src={img.src}
-            className="object-contain w-full h-full"
+            className={`${className} object-contain w-full h-full`}
             alt=""
             onLoad={() => setLoading(false)}
           />

--- a/src/components/WalletSuite/ConnectedWallet/Details/Favourites/Favourite.tsx
+++ b/src/components/WalletSuite/ConnectedWallet/Details/Favourites/Favourite.tsx
@@ -10,10 +10,7 @@ export default function Favourite({ name, endowId, logo }: EndowmentBookmark) {
         to={appRoutes.profile + "/" + endowId}
         className="flex items-center gap-2 py-1 font-heading font-semibold text-sm hover:bg-orange-l5 dark:hover:bg-blue-d3 rounded"
       >
-        <Image
-          img={{ src: logo }}
-          className="w-4 h-4 border border-prim rounded-full"
-        />
+        <Image img={{ src: logo }} className="w-4 h-4 rounded-full" />
         <span className="truncate max-w-[200px]">{name}</span>
       </Link>
     </li>

--- a/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/MyEndowments.tsx
+++ b/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/MyEndowments.tsx
@@ -17,7 +17,7 @@ export default function MyEndowments({ endowments }: Props) {
         >
           <Image
             img={{ src: endowment.logo }}
-            className="w-10 h-10 border border-prim rounded-full"
+            className="w-10 h-10 rounded-full"
           />
 
           <div className="grid items-center">

--- a/src/components/WalletSuite/WalletSelectorOpener/Connector.tsx
+++ b/src/components/WalletSuite/WalletSelectorOpener/Connector.tsx
@@ -21,10 +21,7 @@ export default function Connector(props: Connection) {
       className="flex flex-col items-center justify-center gap-1 h-28 p-5 border border-gray-l3 rounded bg-white hover:bg-orange-l5 dark:bg-blue/50 hover:dark:bg-blue-d3 dark:border-none"
       onClick={handleConnect}
     >
-      <Image
-        img={{ src: props.logo }}
-        className="w-12 h-12 border border-prim rounded-full"
-      />
+      <Image img={{ src: props.logo }} className="w-12 h-12 rounded-full" />
       <span className="font-heading font-bold text-sm capitalize">
         {props.name}
       </span>


### PR DESCRIPTION
Ticket(s):
- [Profile logo bug#1975](https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1975)

## Explanation of the solution
Issue:
The <Image /> component wraps the image in a parent div tag and classname attribute {which usually contains rounded-full property} is passed to this div tag 
The property works for images of svg format but incase of png format this attribute is overridden by img classes

Solution 
I have passed className property to img tag as well to avoid this issue,
but to handle discrepancy from other svg icons (mainly the border one in connect wallet widget) 
removed certain class values from some files

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
![image](https://user-images.githubusercontent.com/23124046/227130528-e8918ff1-b880-487e-ad12-7a57d3c6e2e4.png)
![image](https://user-images.githubusercontent.com/23124046/227130589-1b7c4c0d-0c1d-4d03-bc14-d74aa231580c.png)
![image](https://user-images.githubusercontent.com/23124046/227130818-07cb7c14-0ccf-4559-9243-1ad6145c89fa.png)


When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes