### PR TITLE
Fix img size bug

### DIFF
--- a/src/components/ImgEditor/ImgCropper.tsx
+++ b/src/components/ImgEditor/ImgCropper.tsx
@@ -7,11 +7,17 @@ import Modal from "components/Modal";
 
 type Props = {
   preview: string;
+  type: string;
   aspect: [number, number];
   onSave(blob: Blob | null): void;
 };
 
-export default function ImgCropper({ preview, aspect: [x, y], onSave }: Props) {
+export default function ImgCropper({
+  preview,
+  type,
+  aspect: [x, y],
+  onSave,
+}: Props) {
   const { closeModal } = useModalContext();
 
   const cropperRef = useRef<Cropper>();
@@ -35,7 +41,7 @@ export default function ImgCropper({ preview, aspect: [x, y], onSave }: Props) {
       cropperRef.current.getCroppedCanvas().toBlob((blob) => {
         onSave(blob);
         closeModal();
-      });
+      }, type);
     }
   }
 

--- a/src/components/ImgEditor/ImgCropper.tsx
+++ b/src/components/ImgEditor/ImgCropper.tsx
@@ -7,9 +7,9 @@ import Modal from "components/Modal";
 
 type Props = {
   preview: string;
-  type: string;
+  type: string; // original file type, will be the same for blob in `onSave(blob: Blob)`
   aspect: [number, number];
-  onSave(blob: Blob | null): void;
+  onSave(blob: Blob | null): void; // blob.type is the same as Props.type
 };
 
 export default function ImgCropper({

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -4,6 +4,7 @@ import { useDropzone } from "react-dropzone";
 import { FieldValues, useFormContext } from "react-hook-form";
 import { ImgLink, Props } from "./types";
 import Icon from "components/Icon";
+import { humanize } from "helpers";
 import useImgEditor from "./useImgEditor";
 
 type Key = keyof ImgLink;
@@ -112,8 +113,13 @@ export default function ImgEditor<T extends FieldValues, K extends keyof T>(
       <p className="text-xs text-gray-d1 dark:text-gray mt-2">
         <span>
           Valid types are: PDF, JPG, PNG and WEBP. File should be less than 1MB.
-          Cropped file size can be different from the original's.{" "}
-          {file ? `Current cropped file size: ${file.size / BYTES_IN_MB}.` : ""}
+          Cropped file size can be different from the original's.
+          <br />
+          {file
+            ? `Current cropped file size: ${humanize(
+                file.size / BYTES_IN_MB
+              )}MB.`
+            : ""}
         </span>{" "}
         <ErrorMessage
           errors={errors}

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -116,7 +116,7 @@ export default function ImgEditor<T extends FieldValues, K extends keyof T>(
           Cropped file size can be different from the original's.
           <br />
           {file
-            ? `Current cropped file size: ${humanize(
+            ? `Current cropped image size: ${humanize(
                 file.size / BYTES_IN_MB
               )}MB.`
             : ""}

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -112,11 +112,10 @@ export default function ImgEditor<T extends FieldValues, K extends keyof T>(
       </div>
       <p className="text-xs text-gray-d1 dark:text-gray mt-2">
         <span>
-          Valid types are: PDF, JPG, PNG and WEBP. File should be less than 1MB.
-          Cropped file size can be different from the original's.
+          Valid types are: JPG, JPEG, PNG and WEBP. Original uploaded image should be less than 1MB in size.
           <br />
           {file
-            ? `Current cropped image size: ${humanize(
+            ? `Current (cropped) image size: ${humanize(
                 file.size / BYTES_IN_MB
               )}MB.`
             : ""}

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -9,6 +9,8 @@ import useImgEditor from "./useImgEditor";
 type Key = keyof ImgLink;
 const fileKey: Key = "file";
 
+const BYTES_IN_MB = 1e6;
+
 export default function ImgEditor<T extends FieldValues, K extends keyof T>(
   props: Props<T, K>
 ) {
@@ -22,6 +24,7 @@ export default function ImgEditor<T extends FieldValues, K extends keyof T>(
   const {
     onDrop,
     handleOpenCropper,
+    file,
     isInitial,
     noneUploaded,
     handleReset,
@@ -108,7 +111,8 @@ export default function ImgEditor<T extends FieldValues, K extends keyof T>(
       </div>
       <p className="text-xs text-gray-d1 dark:text-gray mt-2">
         <span>
-          Valid types are: PDF, JPG, PNG and WEBP. File should be less than 1MB.
+          Valid types are: PDF, JPG, PNG and WEBP. File should be less than 1MB.{" "}
+          {file ? `Current cropped file size: ${file.size / BYTES_IN_MB}` : ""}
         </span>{" "}
         <ErrorMessage
           errors={errors}

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -111,8 +111,9 @@ export default function ImgEditor<T extends FieldValues, K extends keyof T>(
       </div>
       <p className="text-xs text-gray-d1 dark:text-gray mt-2">
         <span>
-          Valid types are: PDF, JPG, PNG and WEBP. File should be less than 1MB.{" "}
-          {file ? `Current cropped file size: ${file.size / BYTES_IN_MB}` : ""}
+          Valid types are: PDF, JPG, PNG and WEBP. File should be less than 1MB.
+          Cropped file size can be different from the original's.{" "}
+          {file ? `Current cropped file size: ${file.size / BYTES_IN_MB}.` : ""}
         </span>{" "}
         <ErrorMessage
           errors={errors}

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -112,7 +112,8 @@ export default function ImgEditor<T extends FieldValues, K extends keyof T>(
       </div>
       <p className="text-xs text-gray-d1 dark:text-gray mt-2">
         <span>
-          Valid types are: JPG, JPEG, PNG and WEBP. Original uploaded image should be less than 1MB in size.
+          Valid types are: JPG, JPEG, PNG and WEBP. Original uploaded image
+          should be less than 1MB in size.
           <br />
           {file
             ? `Current (cropped) image size: ${humanize(

--- a/src/components/ImgEditor/useImgEditor.ts
+++ b/src/components/ImgEditor/useImgEditor.ts
@@ -37,6 +37,7 @@ export default function useImgEditor<T extends FieldValues, K extends keyof T>({
         showModal(ImgCropper, {
           preview,
           aspect,
+          type: newFile.type,
           onSave(blob) {
             handleCropResult(blob, newFile);
           },
@@ -52,6 +53,7 @@ export default function useImgEditor<T extends FieldValues, K extends keyof T>({
     showModal(ImgCropper, {
       preview,
       aspect,
+      type: currFile.type,
       onSave(blob) {
         handleCropResult(blob, currFile);
       },

--- a/src/components/ImgEditor/useImgEditor.ts
+++ b/src/components/ImgEditor/useImgEditor.ts
@@ -24,7 +24,7 @@ export default function useImgEditor<T extends FieldValues, K extends keyof T>({
     field: { value: currFile, onChange: onFileChange, ref },
   } = useController<T>({ name: filePath });
 
-  const { publicUrl, preview }: ImgLink = watch(name as any);
+  const { publicUrl, preview, file }: ImgLink = watch(name as any);
   const isInitial = preview === publicUrl;
   const noneUploaded = !publicUrl && !preview;
 
@@ -88,6 +88,7 @@ export default function useImgEditor<T extends FieldValues, K extends keyof T>({
     noneUploaded,
     handleReset,
     preview,
+    file,
     ref,
   };
 }

--- a/src/pages/Admin/Charity/EditProfile/schema.ts
+++ b/src/pages/Admin/Charity/EditProfile/schema.ts
@@ -15,8 +15,10 @@ export const VALID_MIME_TYPES = [
   "image/svg",
 ];
 
+const BYTES_IN_MB = 1e6;
+
 const fileObj = Yup.object().shape<SchemaShape<ImgLink>>({
-  file: genFileSchema(1e6, VALID_MIME_TYPES).when("publicUrl", {
+  file: genFileSchema(BYTES_IN_MB, VALID_MIME_TYPES).when("publicUrl", {
     is: (value: string) => !value,
     then: (schema) => schema.required("required"),
   }),

--- a/src/pages/Registration/Steps/Documentation/schema.ts
+++ b/src/pages/Registration/Steps/Documentation/schema.ts
@@ -10,6 +10,8 @@ import { requiredString } from "schemas/string";
 import { MAX_SDGS } from "constants/unsdgs";
 
 export const MB_LIMIT = 25;
+const BYTES_IN_MB = 1e6;
+
 const VALID_MIME_TYPES = [
   "image/jpeg",
   "image/png",
@@ -21,10 +23,10 @@ const previewsKey: keyof Asset = "previews";
 
 function genAssetShape(isRequired: boolean = false): SchemaShape<Asset> {
   return {
-    files: Yup.array(genFileSchema(MB_LIMIT * 1e6, VALID_MIME_TYPES)).when(
-      previewsKey,
-      (previews: FileObject[], schema: any) =>
-        previews.length <= 0 && isRequired ? schema.min(1, "required") : schema
+    files: Yup.array(
+      genFileSchema(MB_LIMIT * BYTES_IN_MB, VALID_MIME_TYPES)
+    ).when(previewsKey, (previews: FileObject[], schema: any) =>
+      previews.length <= 0 && isRequired ? schema.min(1, "required") : schema
     ),
   };
 }

--- a/src/schemas/file.ts
+++ b/src/schemas/file.ts
@@ -1,6 +1,11 @@
 import * as Yup from "yup";
 
-export const genFileSchema = (size: number, types: string[]) =>
+/**
+ * @param maxSize maximum file size in bytes
+ * @param types an array of strings representing valid MIME types
+ * @returns Yup schema for validating files
+ */
+export const genFileSchema = (maxSize: number, types: string[]) =>
   Yup.mixed<File>()
     .test({
       name: "must be of correct type",
@@ -10,5 +15,5 @@ export const genFileSchema = (size: number, types: string[]) =>
     .test({
       name: "must be less than size limit",
       message: "exceeds file size limit",
-      test: (file) => (file?.size || 0) <= size,
+      test: (file) => (file?.size || 0) <= maxSize,
     });

--- a/src/schemas/file.ts
+++ b/src/schemas/file.ts
@@ -15,5 +15,8 @@ export const genFileSchema = (maxSize: number, types: string[]) =>
     .test({
       name: "must be less than size limit",
       message: "exceeds file size limit",
-      test: (file) => (file?.size || 0) <= maxSize,
+      test: (file) => {
+        console.log(`genFileSchema file.size:${file?.size}`);
+        return (file?.size || 0) <= maxSize;
+      },
     });

--- a/src/schemas/file.ts
+++ b/src/schemas/file.ts
@@ -15,8 +15,5 @@ export const genFileSchema = (maxSize: number, types: string[]) =>
     .test({
       name: "must be less than size limit",
       message: "exceeds file size limit",
-      test: (file) => {
-        console.log(`genFileSchema file.size:${file?.size}`);
-        return (file?.size || 0) <= maxSize;
-      },
+      test: (file) => (file?.size || 0) <= maxSize,
     });

--- a/src/services/juno/tags.ts
+++ b/src/services/juno/tags.ts
@@ -9,7 +9,7 @@ export const rootTags = [
   "custom",
 ] as const;
 
-type JunoTag = typeof rootTags[number];
+type JunoTag = (typeof rootTags)[number];
 
 export enum adminTags {
   proposals = "proposals",

--- a/src/services/juno/tags.ts
+++ b/src/services/juno/tags.ts
@@ -9,7 +9,7 @@ export const rootTags = [
   "custom",
 ] as const;
 
-type JunoTag = (typeof rootTags)[number];
+type JunoTag = typeof rootTags[number];
 
 export enum adminTags {
   proposals = "proposals",


### PR DESCRIPTION
Ticket(s):
- https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1973

## Explanation of the solution
- the size of the uploaded file gets automatically increased once cropped due to the way `cropperjs` works, see official docs section ["Known Issues"](https://github.com/fengyuanchen/cropperjs#known-issues)
- additionally, all image types were being converted to PNG, no matter the original type
- to address this, all that was necessary was to set the cropped file's type to be the same as the original's (see ["Known Issues"](https://github.com/fengyuanchen/cropperjs#known-issues))
- the things is that this results in a cropped img size smaller from the original, which is to be expected
- problem is that occasionally, especially for PNGs, if the image was previously compressed, the canvas API used by `cropperjs` actually *removes this compression*, thus increasing the image size (see [this answer](https://github.com/fengyuanchen/cropperjs/issues/538#issuecomment-508450556) and [this answer](https://github.com/fengyuanchen/cropperjs/issues/804) on related GH issues)
- even when the image size is reduced as expected, the user might still be confused to find out that their image with a size larger than 1 MB was uploaded with no problems
- to address both of these issues, updated the existing tooltip from:
`Valid types are: PDF, JPG, PNG and WEBP. File should be less than 1MB.`
to:
`Valid types are: PDF, JPG, PNG and WEBP. File should be less than 1MB. Cropped file size can be different from the original's. Current cropped file size: ${file.size / BYTES_IN_MB}.`

![image](https://user-images.githubusercontent.com/19427053/227182989-10ec6bb2-340c-4121-9880-70077d73e541.png)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- connect Charity 1 wallet on Juno
- go to http://localhost:4200/admin/1/edit-profile
- scroll to "Banner image of your organization"
- click "Upload" btn
- upload the image attached in this Discord message https://discord.com/channels/834976399228010527/857111094019883010/1088147435945197710
- move the cropping section to left- and right-most edges, like in image below:
![image](https://user-images.githubusercontent.com/19427053/227180371-79b3b659-0d1a-4432-92a0-be197ae8a08f.png)
- crop the image
- verify the cropped image size is no longer ~8 times larger (difference should be ~20Kb)
- verify the cropped image type is same as the original (PNG)
- repeat the same process with the version of that same image which was updated to be JPG ([link](https://user-images.githubusercontent.com/19427053/227178020-1b69909c-0286-4cf1-9534-88ba7b2917ae.jpg))
- verify the cropped image size is no longer ~8 times larger (should actually be smaller than original)
- verify the cropped image type is same as the original (JPG)

## UI changes for review

New tooltip (note: updated "file" to read "image"):
![image](https://user-images.githubusercontent.com/19427053/227183133-debc9e1f-d400-4830-8baf-750b82a51f0b.png)

With error message (forced by temporarily reducing valid img size) (note: updated "file" to read "image"):
![image](https://user-images.githubusercontent.com/19427053/227184071-dccfba34-81b7-450c-9c05-beb70105f16c.png)

