### PR TITLE
Create generic `useTxSender`

### DIFF
--- a/src/App/Header/Airdrop/useClaimAirdrop.ts
+++ b/src/App/Header/Airdrop/useClaimAirdrop.ts
@@ -5,12 +5,12 @@ import { invalidateJunoTags } from "services/juno";
 import { govTags } from "services/juno/tags";
 import { useGetWallet } from "contexts/WalletContext";
 import Airdrop from "contracts/Airdrop";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { condense } from "helpers";
 
 export default function useClaimAirdrop(airdrops: Airdrops) {
   const { wallet } = useGetWallet();
-  const { sendTx, isSending } = useCosmosTxSender(true);
+  const { sendTx, isSending } = useTxSender(true);
 
   const totalClaimable = useMemo(
     () =>
@@ -29,7 +29,7 @@ export default function useClaimAirdrop(airdrops: Airdrops) {
     );
 
     await sendTx({
-      msgs: claimAirdropMsgs,
+      content: { type: "cosmos", val: claimAirdropMsgs },
       tagPayloads: [
         invalidateJunoTags([
           { type: "gov", id: govTags.staker },

--- a/src/helpers/tx/index.ts
+++ b/src/helpers/tx/index.ts
@@ -1,4 +1,3 @@
-export { getWasmAttribute } from "./sendTx/getWasmAttribute";
 export { default as estimateTx } from "./estimateTx/estimateTx";
 
 export { default as sendTx } from "./sendTx/sendTx";

--- a/src/helpers/tx/sendTx/getWasmAttribute.ts
+++ b/src/helpers/tx/sendTx/getWasmAttribute.ts
@@ -1,8 +1,0 @@
-import { parseRawLog } from "@cosmjs/stargate/build/logs";
-
-export function getWasmAttribute(attribute: string, rawLog?: string) {
-  const logs = parseRawLog(rawLog);
-  return logs[0].events
-    .find((e) => e.type === "wasm")
-    ?.attributes.find((a) => a.key === attribute)?.value;
-}

--- a/src/helpers/tx/sendTx/sendCosmosTx.ts
+++ b/src/helpers/tx/sendTx/sendCosmosTx.ts
@@ -1,9 +1,9 @@
 import { TimeoutError, isDeliverTxFailure } from "@cosmjs/stargate";
+import { parseRawLog } from "@cosmjs/stargate/build/logs";
 import { CosmosTx, TxResult } from "types/tx";
 import { WalletState } from "contexts/WalletContext";
 import Contract from "contracts/Contract";
 import { logger } from "../../logger";
-import { getWasmAttribute } from "./getWasmAttribute";
 
 export async function sendCosmosTx(
   wallet: WalletState,
@@ -39,4 +39,11 @@ export async function sendCosmosTx(
     }
     return { error: "Error encountered while sending transaction" };
   }
+}
+
+function getWasmAttribute(attribute: string, rawLog?: string) {
+  const logs = parseRawLog(rawLog);
+  return logs[0].events
+    .find((e) => e.type === "wasm")
+    ?.attributes.find((a) => a.key === attribute)?.value;
 }

--- a/src/hooks/useTxSender.ts
+++ b/src/hooks/useTxSender.ts
@@ -21,6 +21,7 @@ export default function useTxSender<T extends boolean = false>(
   const dispatch = useSetter();
 
   const sendTx: Sender = async ({
+    attribute,
     content,
     tagPayloads,
     onSuccess,
@@ -77,7 +78,7 @@ export default function useTxSender<T extends boolean = false>(
       }
 
       // //////////////// SEND TX  ////////////////////
-      const result = await signAndBroadCast(wallet, tx);
+      const result = await signAndBroadCast(wallet, tx, attribute);
 
       if (isTxResultError(result)) {
         return showModal(TxPrompt, result);

--- a/src/hooks/useTxSender.ts
+++ b/src/hooks/useTxSender.ts
@@ -6,7 +6,7 @@ import Popup from "components/Popup";
 import { TxPrompt } from "components/Prompt";
 import { useSetter } from "store/accessors";
 import { logger } from "helpers";
-import { estimateTx, sendTx as signAndBroadCast } from "helpers/tx";
+import { estimateTx, sendTx } from "helpers/tx";
 import { GENERIC_ERROR_MESSAGE } from "constants/common";
 
 type Sender = (args: SenderArgs) => Promise<void>;
@@ -20,7 +20,7 @@ export default function useTxSender<T extends boolean = false>(
   const { showModal, setModalOption } = useModalContext();
   const dispatch = useSetter();
 
-  const sendTx: Sender = async ({
+  const sender: Sender = async ({
     attribute,
     content,
     tagPayloads,
@@ -78,7 +78,7 @@ export default function useTxSender<T extends boolean = false>(
       }
 
       // //////////////// SEND TX  ////////////////////
-      const result = await signAndBroadCast(wallet, tx, attribute);
+      const result = await sendTx(wallet, tx, attribute);
 
       if (isTxResultError(result)) {
         return showModal(TxPrompt, result);
@@ -104,5 +104,5 @@ export default function useTxSender<T extends boolean = false>(
     }
   };
 
-  return isSenderInModal ? { sendTx, isSending } : (sendTx as any);
+  return isSenderInModal ? { sendTx: sender, isSending } : (sender as any);
 }

--- a/src/hooks/useTxSender.ts
+++ b/src/hooks/useTxSender.ts
@@ -38,11 +38,6 @@ export default function useTxSender<T extends boolean = false>(
           error: "You are not authorized to make this transaction",
         });
       }
-      if (content.type !== "cosmos") {
-        return showModal(TxPrompt, {
-          error: "Please connect to Juno to make this transaction",
-        });
-      }
 
       /**
        * avoid unmounting sender in modal while tx is still sending to avoid memory leak

--- a/src/hooks/useTxSender.ts
+++ b/src/hooks/useTxSender.ts
@@ -11,7 +11,7 @@ import { GENERIC_ERROR_MESSAGE } from "constants/common";
 
 type Sender = (args: SenderArgs) => Promise<void>;
 
-export default function useCosmosTxSender<T extends boolean = false>(
+export default function useTxSender<T extends boolean = false>(
   isSenderInModal: T = false as any
 ): T extends true ? { sendTx: Sender; isSending: boolean } : Sender {
   const { wallet } = useGetWallet();
@@ -21,7 +21,7 @@ export default function useCosmosTxSender<T extends boolean = false>(
   const dispatch = useSetter();
 
   const sendTx: Sender = async ({
-    msgs,
+    content,
     tagPayloads,
     onSuccess,
     isAuthorized,
@@ -35,6 +35,11 @@ export default function useCosmosTxSender<T extends boolean = false>(
       if (!isAuthorized /** should be explicitly set to true to pass */) {
         return showModal(TxPrompt, {
           error: "You are not authorized to make this transaction",
+        });
+      }
+      if (content.type !== "cosmos") {
+        return showModal(TxPrompt, {
+          error: "Please connect to Juno to make this transaction",
         });
       }
 
@@ -57,7 +62,7 @@ export default function useCosmosTxSender<T extends boolean = false>(
       }
 
       // //////////////// ESTIMATE TX  ////////////////////
-      const estimate = await estimateTx({ type: "cosmos", val: msgs }, wallet);
+      const estimate = await estimateTx(content, wallet);
       if (!estimate) {
         return showModal(TxPrompt, {
           error: "Simulation failed. Transaction likely to fail",

--- a/src/pages/Admin/Charity/EditProfile/useEditProfile.ts
+++ b/src/pages/Admin/Charity/EditProfile/useEditProfile.ts
@@ -38,7 +38,7 @@ export default function useEditProfile() {
   }) => {
     try {
       /** special case for edit profile: since upload happens prior
-       * to tx submission. Other users of useCosmosTxSender
+       * to tx submission. Other users of useTxSender
        */
       if (!wallet) {
         return showModal(TxPrompt, {

--- a/src/pages/Admin/Charity/Invest/Investor/useSubmit.ts
+++ b/src/pages/Admin/Charity/Invest/Investor/useSubmit.ts
@@ -5,14 +5,14 @@ import { useAdminResources } from "pages/Admin/Guard";
 import { useGetWallet } from "contexts/WalletContext/WalletContext";
 import Account from "contracts/Account";
 import CW3 from "contracts/CW3";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { scaleToStr } from "helpers";
 import { getTagPayloads } from "helpers/admin";
 
 export default function useSubmit(vault: string, type: AccountType) {
   const { cw3, id, propMeta } = useAdminResources();
   const { wallet } = useGetWallet();
-  const { sendTx, isSending } = useCosmosTxSender(true);
+  const { sendTx, isSending } = useTxSender(true);
 
   async function submit({ token }: FormValues) {
     const account = new Account(wallet);
@@ -42,7 +42,7 @@ export default function useSubmit(vault: string, type: AccountType) {
     );
 
     await sendTx({
-      msgs: [proposal],
+      content: { type: "cosmos", val: [proposal] },
       ...propMeta,
       tagPayloads: getTagPayloads(propMeta.willExecute && "acc_invest"),
     });

--- a/src/pages/Admin/Charity/Templates/account/EndowmentStatus/useUpdateStatus.ts
+++ b/src/pages/Admin/Charity/Templates/account/EndowmentStatus/useUpdateStatus.ts
@@ -12,7 +12,7 @@ import { useGetWallet } from "contexts/WalletContext";
 import Popup from "components/Popup";
 import Account from "contracts/Account";
 import CW3 from "contracts/CW3";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { getTagPayloads } from "helpers/admin";
 import { cleanObject } from "helpers/cleanObject";
 
@@ -20,7 +20,7 @@ export default function useUpdateStatus() {
   const { handleSubmit } = useFormContext<EndowmentUpdateValues>();
   const { cw3, propMeta } = useAdminResources();
   const { wallet } = useGetWallet();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
   const { showModal } = useModalContext();
 
   async function updateStatus(data: EndowmentUpdateValues) {
@@ -90,7 +90,7 @@ export default function useUpdateStatus() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
       tagPayloads: getTagPayloads(propMeta.willExecute && "acc_endow_status"),
     });

--- a/src/pages/Admin/Charity/Withdraws/Withdrawer/WithdrawForm/useLogWithdrawProposal.ts
+++ b/src/pages/Admin/Charity/Withdraws/Withdrawer/WithdrawForm/useLogWithdrawProposal.ts
@@ -5,7 +5,6 @@ import { useModalContext } from "contexts/ModalContext";
 import { TxPrompt } from "components/Prompt";
 import { useSetter } from "store/accessors";
 import { createAuthToken, idParamToNum, logger } from "helpers";
-import { getWasmAttribute } from "helpers/tx";
 import { EMAIL_SUPPORT } from "constants/common";
 import { APIs } from "constants/urls";
 
@@ -32,8 +31,7 @@ export default function useLogWithdrawProposal(successMeta?: TxSuccessMeta) {
         { isDismissible: false }
       );
 
-      const parsedId = getWasmAttribute("proposal_id", res.rawLog);
-      const numId = idParamToNum(parsedId);
+      const numId = idParamToNum(res.attrValue);
 
       if (numId === 0) throw new Error("Failed to get proposal id");
       const generatedToken = createAuthToken("angelprotocol-web-app");

--- a/src/pages/Admin/Charity/Withdraws/Withdrawer/WithdrawForm/useLogWithdrawProposal.ts
+++ b/src/pages/Admin/Charity/Withdraws/Withdrawer/WithdrawForm/useLogWithdrawProposal.ts
@@ -31,14 +31,14 @@ export default function useLogWithdrawProposal(successMeta?: TxSuccessMeta) {
         { isDismissible: false }
       );
 
-      const numId = idParamToNum(res.attrValue);
+      const proposal_id = idParamToNum(res.attrValue);
 
-      if (numId === 0) throw new Error("Failed to get proposal id");
+      if (proposal_id === 0) throw new Error("Failed to get proposal id");
       const generatedToken = createAuthToken("angelprotocol-web-app");
       const response = await fetch(APIs.apes + "/v1/withdraw", {
         method: "POST",
         headers: { authorization: generatedToken },
-        body: JSON.stringify({ ...info, proposal_id: numId }),
+        body: JSON.stringify({ ...info, proposal_id }),
       });
 
       if (!response.ok) {

--- a/src/pages/Admin/Charity/Withdraws/Withdrawer/WithdrawForm/useWithdraw.ts
+++ b/src/pages/Admin/Charity/Withdraws/Withdrawer/WithdrawForm/useWithdraw.ts
@@ -6,7 +6,7 @@ import { useAdminResources } from "pages/Admin/Guard";
 import { useGetWallet } from "contexts/WalletContext/WalletContext";
 import Account from "contracts/Account";
 import CW3Endowment from "contracts/CW3/CW3Endowment";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { scaleToStr } from "helpers";
 import { ap_wallets } from "constants/ap_wallets";
 import { chainIds } from "constants/chainIds";
@@ -18,7 +18,7 @@ export default function useWithdraw() {
   const { cw3, id, endow_type, propMeta } = useAdminResources<"charity">();
   const { wallet } = useGetWallet();
 
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
   const logProposal = useLogWithdrawProposal(propMeta.successMeta);
   const type = getValues("type");
 
@@ -70,7 +70,7 @@ export default function useWithdraw() {
         );
 
     await sendTx({
-      msgs: [proposal],
+      content: { type: "cosmos", val: [proposal] },
       //Juno withdrawal
       ...propMeta,
       onSuccess: isJuno

--- a/src/pages/Admin/Charity/Withdraws/Withdrawer/WithdrawForm/useWithdraw.ts
+++ b/src/pages/Admin/Charity/Withdraws/Withdrawer/WithdrawForm/useWithdraw.ts
@@ -73,6 +73,7 @@ export default function useWithdraw() {
       content: { type: "cosmos", val: [proposal] },
       //Juno withdrawal
       ...propMeta,
+      attribute: "proposal_id",
       onSuccess: isJuno
         ? undefined //no need to POST to AWS if destination is juno
         : async (response, chain) =>

--- a/src/pages/Admin/Charity/common/Investment/Investor/useSubmit.ts
+++ b/src/pages/Admin/Charity/common/Investment/Investor/useSubmit.ts
@@ -4,14 +4,14 @@ import { useAdminResources } from "pages/Admin/Guard";
 import { useGetWallet } from "contexts/WalletContext/WalletContext";
 import Account from "contracts/Account";
 import CW3 from "contracts/CW3";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { scaleToStr } from "helpers";
 import { getTagPayloads } from "helpers/admin";
 
 export default function useSubmit(vault: string, type: AccountType) {
   const { cw3, id, propMeta } = useAdminResources();
   const { wallet } = useGetWallet();
-  const { sendTx, isSending } = useCosmosTxSender(true);
+  const { sendTx, isSending } = useTxSender(true);
 
   async function submit({ token }: FormValues) {
     const account = new Account(wallet);
@@ -39,7 +39,7 @@ export default function useSubmit(vault: string, type: AccountType) {
     );
 
     await sendTx({
-      msgs: [proposal],
+      content: { type: "cosmos", val: [proposal] },
       ...propMeta,
       tagPayloads: getTagPayloads(propMeta.willExecute && "acc_invest"),
     });

--- a/src/pages/Admin/Charity/common/Investment/Redeemer/useSubmit.ts
+++ b/src/pages/Admin/Charity/common/Investment/Redeemer/useSubmit.ts
@@ -4,14 +4,14 @@ import { useAdminResources } from "pages/Admin/Guard";
 import { useGetWallet } from "contexts/WalletContext/WalletContext";
 import Account from "contracts/Account";
 import CW3 from "contracts/CW3";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { scaleToStr } from "helpers";
 import { getTagPayloads } from "helpers/admin";
 
 export default function useSubmit(vault: string, type: AccountType) {
   const { cw3, id, propMeta } = useAdminResources();
   const { wallet } = useGetWallet();
-  const { sendTx, isSending } = useCosmosTxSender(true);
+  const { sendTx, isSending } = useTxSender(true);
 
   async function submit({ token }: FormValues) {
     const account = new Account(wallet);
@@ -31,7 +31,7 @@ export default function useSubmit(vault: string, type: AccountType) {
     );
 
     await sendTx({
-      msgs: [proposal],
+      content: { type: "cosmos", val: [proposal] },
       ...propMeta,
       tagPayloads: getTagPayloads(propMeta.willExecute && "acc_redeem"),
     });

--- a/src/pages/Admin/Core/Templates/index-fund/Alliance/useEditAlliance.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/Alliance/useEditAlliance.ts
@@ -8,7 +8,7 @@ import Popup from "components/Popup";
 import { useGetter } from "store/accessors";
 import CW3 from "contracts/CW3";
 import IndexFund from "contracts/IndexFund";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 
 export default function useEditAlliance() {
   const { trigger, reset, getValues } = useFormContext<AllianceEditValues>();
@@ -18,7 +18,7 @@ export default function useEditAlliance() {
     (state) => state.admin.allianceMembers
   );
   const { showModal } = useModalContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
 
   async function editAlliance() {
     const isValid = await trigger(["description", "title"], {
@@ -84,7 +84,7 @@ export default function useEditAlliance() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
     });
     reset();

--- a/src/pages/Admin/Core/Templates/index-fund/Config/useConfigureFund.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/Config/useConfigureFund.ts
@@ -7,7 +7,7 @@ import { useGetWallet } from "contexts/WalletContext";
 import Popup from "components/Popup";
 import CW3 from "contracts/CW3";
 import IndexFund from "contracts/IndexFund";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { scaleToStr } from "helpers";
 import { genDiffMeta, getPayloadDiff } from "helpers/admin";
 import { cleanObject } from "helpers/cleanObject";
@@ -22,7 +22,7 @@ export default function useConfigureFund() {
     formState: { isSubmitting, isDirty, isValid },
   } = useFormContext<FundConfigValues>();
   const { showModal } = useModalContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
 
   async function configureFund({
     title,
@@ -62,7 +62,7 @@ export default function useConfigureFund() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
     });
   }

--- a/src/pages/Admin/Core/Templates/index-fund/CreateFund/useCreateFund.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/CreateFund/useCreateFund.ts
@@ -7,7 +7,7 @@ import { useGetWallet } from "contexts/WalletContext";
 import { useGetter } from "store/accessors";
 import CW3 from "contracts/CW3";
 import IndexFund from "contracts/IndexFund";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { condense, roundDown } from "helpers";
 import { cleanObject } from "helpers/cleanObject";
 import { INIT_SPLIT } from ".";
@@ -15,7 +15,7 @@ import { INIT_SPLIT } from ".";
 export default function useCreateFund() {
   const { cw3, propMeta } = useAdminResources();
   const { wallet } = useGetWallet();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
   const { trigger, getValues } = useFormContext<FundCreatorValues>();
   const newFundMembers = useGetter((state) => state.admin.newFundMembers);
 
@@ -83,7 +83,7 @@ export default function useCreateFund() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
     });
 

--- a/src/pages/Admin/Core/Templates/index-fund/IndexFundOwner/useUpdateOwner.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/IndexFundOwner/useUpdateOwner.ts
@@ -7,7 +7,7 @@ import { useGetWallet } from "contexts/WalletContext";
 import Popup from "components/Popup";
 import CW3 from "contracts/CW3";
 import IndexFund from "contracts/IndexFund";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 
 export default function useUpdateOwner() {
   const { cw3, propMeta } = useAdminResources();
@@ -18,7 +18,7 @@ export default function useUpdateOwner() {
   } = useFormContext<IndexFundOwnerValues>();
 
   const { showModal } = useModalContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
 
   async function updateOwner(data: IndexFundOwnerValues) {
     //check for changes
@@ -46,7 +46,7 @@ export default function useUpdateOwner() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
     });
   }

--- a/src/pages/Admin/Core/Templates/index-fund/Members/useUpdateFund.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/Members/useUpdateFund.ts
@@ -8,7 +8,7 @@ import { useGetWallet } from "contexts/WalletContext";
 import { useGetter } from "store/accessors";
 import CW3 from "contracts/CW3";
 import IndexFund from "contracts/IndexFund";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 
 export default function useUpdateFund() {
   const { trigger, reset, getValues } = useFormContext<FundUpdateValues>();
@@ -17,7 +17,7 @@ export default function useUpdateFund() {
   const [isLoading, setIsLoading] = useState(false);
   const fundMembers = useGetter((state) => state.admin.fundMembers);
   const { handleError } = useErrorContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
 
   async function updateFund() {
     try {
@@ -76,7 +76,7 @@ export default function useUpdateFund() {
       );
 
       await sendTx({
-        msgs: [proposalMsg],
+        content: { type: "cosmos", val: [proposalMsg] },
         ...propMeta,
       });
       setIsLoading(false);

--- a/src/pages/Admin/Core/Templates/index-fund/RemoveFund/useDestroyFund.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/RemoveFund/useDestroyFund.ts
@@ -6,7 +6,7 @@ import { useGetWallet } from "contexts/WalletContext";
 import Popup from "components/Popup";
 import CW3 from "contracts/CW3";
 import IndexFund from "contracts/IndexFund";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 
 export default function useDestroyFund() {
   const {
@@ -14,7 +14,7 @@ export default function useDestroyFund() {
     formState: { isSubmitting },
   } = useFormContext<FundDestroyValues>();
   const { showModal } = useModalContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
   const { cw3, propMeta } = useAdminResources();
   const { wallet } = useGetWallet();
 
@@ -44,7 +44,7 @@ export default function useDestroyFund() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
     });
   }

--- a/src/pages/Admin/Core/Templates/registrar/ConfigExtension/useConfigureRegistrar.ts
+++ b/src/pages/Admin/Core/Templates/registrar/ConfigExtension/useConfigureRegistrar.ts
@@ -10,7 +10,7 @@ import { useGetWallet } from "contexts/WalletContext";
 import Popup from "components/Popup";
 import CW3 from "contracts/CW3";
 import Registrar from "contracts/Registrar";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { genDiffMeta, getPayloadDiff } from "helpers/admin";
 import { cleanObject } from "helpers/cleanObject";
 
@@ -24,7 +24,7 @@ export default function useConfigureRegistrar() {
     formState: { isDirty, isSubmitting },
   } = useFormContext<RV>();
   const { showModal } = useModalContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
 
   async function configureRegistrar({
     title,
@@ -60,7 +60,7 @@ export default function useConfigureRegistrar() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
     });
   }

--- a/src/pages/Admin/Core/Templates/registrar/Owner/useUpdateOwner.ts
+++ b/src/pages/Admin/Core/Templates/registrar/Owner/useUpdateOwner.ts
@@ -6,7 +6,7 @@ import { useGetWallet } from "contexts/WalletContext";
 import Popup from "components/Popup";
 import CW3 from "contracts/CW3";
 import Registrar from "contracts/Registrar";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 
 export default function useUpdateOwner() {
   const { cw3, propMeta } = useAdminResources();
@@ -17,7 +17,7 @@ export default function useUpdateOwner() {
   } = useFormContext<RegistrarOwnerValues>();
 
   const { showModal } = useModalContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
 
   async function updateOwner(data: RegistrarOwnerValues) {
     //check for changes
@@ -45,7 +45,7 @@ export default function useUpdateOwner() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
     });
   }

--- a/src/pages/Admin/Proposal/PollAction.tsx
+++ b/src/pages/Admin/Proposal/PollAction.tsx
@@ -7,7 +7,7 @@ import { defaultProposalTags } from "services/juno/tags";
 import { useModalContext } from "contexts/ModalContext";
 import { useGetWallet } from "contexts/WalletContext";
 import CW3 from "contracts/CW3";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { getTagPayloads } from "helpers/admin";
 import { useAdminResources } from "../Guard";
 import Voter from "./Voter";
@@ -15,7 +15,7 @@ import Voter from "./Voter";
 export default function PollAction(props: ProposalDetails) {
   const { data: latestBlock = "0" } = useLatestBlockQuery(null);
   const { wallet } = useGetWallet();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
   const { cw3, propMeta } = useAdminResources();
   const { showModal } = useModalContext();
 
@@ -24,7 +24,7 @@ export default function PollAction(props: ProposalDetails) {
     const execMsg = contract.createExecProposalMsg(props.id);
 
     await sendTx({
-      msgs: [execMsg],
+      content: { type: "cosmos", val: [execMsg] },
       isAuthorized: propMeta.isAuthorized,
       tagPayloads: extractTagFromMeta(props.meta),
     });

--- a/src/pages/Admin/Proposal/Voter/useVote.ts
+++ b/src/pages/Admin/Proposal/Voter/useVote.ts
@@ -7,7 +7,7 @@ import { adminTags } from "services/juno/tags";
 import { useGetWallet } from "contexts/WalletContext";
 import CW3 from "contracts/CW3";
 import CW3Review from "contracts/CW3/CW3Review";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 
 export default function useVote() {
   const {
@@ -16,7 +16,7 @@ export default function useVote() {
   } = useFormContext<VV>();
   const { wallet } = useGetWallet();
   const { cw3 } = useAdminResources();
-  const { sendTx, isSending } = useCosmosTxSender(true);
+  const { sendTx, isSending } = useTxSender(true);
 
   async function vote({ type, proposalId, vote, reason }: VV) {
     let voteMsg: MsgExecuteContractEncodeObject;
@@ -34,7 +34,7 @@ export default function useVote() {
     }
 
     await sendTx({
-      msgs: [voteMsg],
+      content: { type: "cosmos", val: [voteMsg] },
       tagPayloads: [
         invalidateJunoTags([{ type: "admin", id: adminTags.proposals }]),
       ],

--- a/src/pages/Admin/Review/Templates/ReviewCW3Configurer/useCreateProposal.ts
+++ b/src/pages/Admin/Review/Templates/ReviewCW3Configurer/useCreateProposal.ts
@@ -9,7 +9,7 @@ import { useModalContext } from "contexts/ModalContext";
 import { useGetWallet } from "contexts/WalletContext/WalletContext";
 import Popup from "components/Popup";
 import CW3Review from "contracts/CW3/CW3Review";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { genDiffMeta, getPayloadDiff, getTagPayloads } from "helpers/admin";
 
 type Key = keyof FormReviewCW3Config;
@@ -24,7 +24,7 @@ export default function useCreateProposal() {
     formState: { isSubmitting, isDirty, isValid },
   } = useFormContext<CW3ConfigValues<FormReviewCW3Config>>();
   const { showModal } = useModalContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
 
   async function createProposal({
     title,
@@ -74,7 +74,7 @@ export default function useCreateProposal() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
       tagPayloads: getTagPayloads(propMeta.willExecute && "review_cw3_config"),
     });

--- a/src/pages/Admin/templates/cw3/Config/useCreateProposal.ts
+++ b/src/pages/Admin/templates/cw3/Config/useCreateProposal.ts
@@ -9,7 +9,7 @@ import { useModalContext } from "contexts/ModalContext";
 import { useGetWallet } from "contexts/WalletContext";
 import Popup from "components/Popup";
 import CW3 from "contracts/CW3";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { genDiffMeta, getPayloadDiff, getTagPayloads } from "helpers/admin";
 
 type Key = keyof FormCW3Config;
@@ -24,7 +24,7 @@ export default function usePropose() {
     formState: { isSubmitting, isDirty, isValid },
   } = useFormContext<CW3ConfigValues<FormCW3Config>>();
   const { showModal } = useModalContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
 
   async function createProposal({
     title,
@@ -69,7 +69,7 @@ export default function usePropose() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
       tagPayloads: getTagPayloads(propMeta.willExecute && "cw3_config"),
     });

--- a/src/pages/Admin/templates/cw3/FundSender/Form/useTransferFunds.ts
+++ b/src/pages/Admin/templates/cw3/FundSender/Form/useTransferFunds.ts
@@ -8,7 +8,7 @@ import { useGetWallet } from "contexts/WalletContext";
 import Popup from "components/Popup";
 import CW3 from "contracts/CW3";
 import CW20 from "contracts/CW20";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { scaleToStr } from "helpers";
 import { getTagPayloads } from "helpers/admin";
 import { contracts } from "constants/contracts";
@@ -23,7 +23,7 @@ export default function useTransferFunds() {
   //TODO: use wallet token[] to list amounts to transfer
   const { wallet } = useGetWallet();
   const { showModal } = useModalContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
 
   async function transferFunds(data: FundSendValues) {
     const balance =
@@ -72,7 +72,7 @@ export default function useTransferFunds() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
       tagPayloads: getTagPayloads(propMeta.willExecute && "cw3_transfer"),
     });

--- a/src/pages/Admin/templates/cw4/Members/useUpdateMembers.ts
+++ b/src/pages/Admin/templates/cw4/Members/useUpdateMembers.ts
@@ -8,7 +8,7 @@ import Popup from "components/Popup";
 import { useGetter } from "store/accessors";
 import CW3 from "contracts/CW3";
 import CW4 from "contracts/CW4";
-import useCosmosTxSender from "hooks/useCosmosTxSender";
+import useTxSender from "hooks/useTxSender";
 import { getTagPayloads } from "helpers/admin";
 
 export default function useUpdateMembers() {
@@ -17,7 +17,7 @@ export default function useUpdateMembers() {
   const apCW4Members = useGetter((state) => state.admin.apCW4Members);
   const { wallet } = useGetWallet();
   const { showModal } = useModalContext();
-  const sendTx = useCosmosTxSender();
+  const sendTx = useTxSender();
 
   async function updateMembers() {
     const isValid = await trigger(["description", "title"], {
@@ -75,7 +75,7 @@ export default function useUpdateMembers() {
     );
 
     await sendTx({
-      msgs: [proposalMsg],
+      content: { type: "cosmos", val: [proposalMsg] },
       ...propMeta,
       tagPayloads: getTagPayloads(propMeta.willExecute && "cw4_members"),
     });

--- a/src/types/tx.ts
+++ b/src/types/tx.ts
@@ -25,10 +25,7 @@ export type SubmittedTx = { hash: string; chainID: string };
 
 export type TxLoading = { loading: string };
 export type TxError = { error: string; tx?: SubmittedTx };
-export type TxSuccess = SubmittedTx & {
-  attrValue?: string;
-  rawLog?: string /**TODO: remove once useCosmosTxSender is repurposed to a general useTxSender */;
-};
+export type TxSuccess = SubmittedTx & { attrValue?: string };
 
 export type TxResult = TxError | TxSuccess;
 
@@ -53,6 +50,7 @@ export type TxState = TxLoading | TxError | SuccessState;
 export type TxOnSuccess = (result: TxSuccess, chain: Chain) => void;
 
 export type SenderArgs = {
+  attribute?: string; // left as 'attribute' for consistency, but maybe rename this to 'readAttribute` to better indicate the purpose?
   tagPayloads?: TagPayload[];
   successMeta?: TxSuccessMeta;
   isAuthorized?: boolean;

--- a/src/types/tx.ts
+++ b/src/types/tx.ts
@@ -56,7 +56,7 @@ export type SenderArgs = {
   tagPayloads?: TagPayload[];
   successMeta?: TxSuccessMeta;
   isAuthorized?: boolean;
-  msgs: EncodeObject[];
+  content: TxContent;
   onSuccess?(result: TxSuccess, chain: Chain): void;
 };
 


### PR DESCRIPTION
## Explanation of the solution
Converted `useCosmosTxSender` into a generic `useTxSender` that can be used to send any type of transaction on any of the supported chains.

Most of the changes are related to how Juno transactions are sent. Only changes worth testing are **withdrawals and launchpad creations**.
Maybe some other existing pieces of code can also be updated to use this generic hook @ap-justin ?

- [x] launchpad create on Juno 
- [x] launchpad create on Polygon (**note: tx gets submitted, but error "Endowment was created but failed to save to AWS" appears since logic for getting EVM Tx attributes is not configured in the webapp**)
- [x] withdrawal to Juno 

Need this to send appropriate transactions for https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1911 and potentially for https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1909 (both of those could be merged into [ast-polygon](https://github.com/AngelProtocolFinance/angelprotocol-web-app/tree/ast-polygon) branch, since they're closely related @SovereignAndrey?)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- open `.env` file and set `REACT_APP_APP_TYPE=AST` 
- run `yarn start` to start the webapp
- go to http://localhost:4200/register
- verify endowment registration can be submitted
- go to http://localhost:4200/admin/1/withdraws
- verify withdrawals can be submitted
