### PR TITLE
Removed the duplicate "Crop" button

### DIFF
--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -94,7 +94,6 @@ export default function ImgEditor<T extends FieldValues, K extends keyof T>(
                 </IconButton>
               )
             }
-            
           </div>
         )}
         {

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -94,11 +94,7 @@ export default function ImgEditor<T extends FieldValues, K extends keyof T>(
                 </IconButton>
               )
             }
-            {!isInitial && (
-              <IconButton onClick={handleOpenCropper} disabled={isSubmitting}>
-                <Icon type="Crop" />
-              </IconButton>
-            )}
+            
           </div>
         )}
         {

--- a/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/MyEndowments.tsx
+++ b/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/MyEndowments.tsx
@@ -10,7 +10,7 @@ export default function MyEndowments({ endowments }: Props) {
       <h3 className="font-heading font-bold text-sm text-gray-d1 dark:text-gray">
         My Endowments
       </h3>
-      <div className="overflow-y-auto max-h-40 scroller grid gap-3">
+      <div className="overflow-y-auto max-h-40 grid gap-3">
         {endowments.map((endowment) => (
           <div
             key={`my-endow-${endowment.endowId}`}

--- a/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/MyEndowments.tsx
+++ b/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/MyEndowments.tsx
@@ -10,7 +10,7 @@ export default function MyEndowments({ endowments }: Props) {
       <h3 className="font-heading font-bold text-sm text-gray-d1 dark:text-gray">
         My Endowments
       </h3>
-      <div className="overflow-y-auto max-h-40 grid gap-3">
+      <div className="overflow-y-auto max-h-40 scroller grid gap-3">
         {endowments.map((endowment) => (
           <div
             key={`my-endow-${endowment.endowId}`}


### PR DESCRIPTION
Ticket(s):
-

## Explanation of the solution
There was a duplicate Crop button being displayed on the image because of copy pasting same button twice in the code. I removed the duplicate one.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes