### PR TITLE
Update URL scheme to accept any valid http(s) URL

### DIFF
--- a/src/schemas/__tests__/string.test.ts
+++ b/src/schemas/__tests__/string.test.ts
@@ -4,6 +4,8 @@ import { isValidUrl } from "../string";
 describe("string schemas tests", () => {
   describe("isValidUrl", () => {
     const cases = [
+      { input: null, expected: false },
+      { input: undefined, expected: false },
       { input: "", expected: false },
       { input: ".", expected: false },
       { input: "ftp://www.example.com", expected: false },
@@ -11,6 +13,7 @@ describe("string schemas tests", () => {
       // special case, domain name can contain only top-level domain
       // see https://stackoverflow.com/questions/69614892/can-a-domain-consist-of-only-tld-top-level-domain#:~:text=D%20in%20TLD%20means%20domain,so%20yes%20it%20is%20valid.
       { input: "fdasfasda", expected: true },
+      { input: "1", expected: true },
       { input: "example.com", expected: true },
       { input: "example.org", expected: true },
       { input: "www.example.com", expected: true },

--- a/src/schemas/__tests__/string.test.ts
+++ b/src/schemas/__tests__/string.test.ts
@@ -1,0 +1,28 @@
+import { isValidUrl } from "../string";
+
+//NOTE: intended for shallow form objects only atm
+describe("string schemas tests", () => {
+  describe("isValidUrl", () => {
+    const cases = [
+      { input: "", expected: false },
+      { input: ".", expected: false },
+      { input: "ftp://www.example.com", expected: false },
+      { input: "mailto://www.example.com", expected: false },
+      // special case, domain name can contain only top-level domain
+      // see https://stackoverflow.com/questions/69614892/can-a-domain-consist-of-only-tld-top-level-domain#:~:text=D%20in%20TLD%20means%20domain,so%20yes%20it%20is%20valid.
+      { input: "fdasfasda", expected: true },
+      { input: "example.com", expected: true },
+      { input: "example.org", expected: true },
+      { input: "www.example.com", expected: true },
+      { input: "http://www.example.com", expected: true },
+      { input: "https://www.example.com", expected: true },
+      { input: "tiktok.com/@betterme.org", expected: true },
+      { input: "www.tiktok.com/@betterme.org", expected: true },
+      { input: "https://www.tiktok.com/@betterme.org", expected: true },
+    ];
+    test.each(cases)(
+      'isValidUrl("$input") === $expected',
+      ({ input, expected }) => expect(isValidUrl(input)).toBe(expected)
+    );
+  });
+});

--- a/src/schemas/string.ts
+++ b/src/schemas/string.ts
@@ -1,4 +1,5 @@
 import * as Yup from "yup";
+import { logger } from "helpers";
 import { chainIds } from "constants/chainIds";
 
 export const junoAddrPattern = /^juno1[a-z0-9]{38,58}$/i;
@@ -40,22 +41,26 @@ export const url = Yup.string().nullable().test({
   test: isValidUrl,
 });
 
-function isValidUrl(str: string | null | undefined) {
-  if (!str) {
-    return true;
+export function isValidUrl(str: string | null | undefined) {
+  if (!str || str === ".") {
+    return false;
   }
 
-  // https://www.freecodecamp.org/news/how-to-validate-urls-in-javascript/
-  const pattern = new RegExp(
-    "^([a-zA-Z]+:\\/\\/)?" + // protocol
-      "((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|" + // domain name
-      "((\\d{1,3}\\.){3}\\d{1,3}))" + // OR IP (v4) address
-      "(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*" + // port and path
-      "(\\?[;&a-z\\d%_.~+=-]*)?" + // query string
-      "(\\#[-a-z\\d_]*)?$", // fragment locator
-    "i"
-  );
-  return pattern.test(str);
+  let givenURL;
+  try {
+    // first check if this is a valid URL at all using any schema
+    givenURL = new URL(str);
+  } catch (error) {
+    logger.info("Original URL is ", str);
+    try {
+      // check if prepending http would result in a valid URL
+      givenURL = new URL(`http://${str}`);
+    } catch (error) {
+      logger.error("Error is", error);
+      return false;
+    }
+  }
+  return givenURL.protocol === "http:" || givenURL.protocol === "https:";
 }
 
 export const stringByteSchema = (minBytes: number, maxBytes: number) =>


### PR DESCRIPTION
Ticket(s):
- https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/1973

## Explanation of the solution
It was agreed to accept any valid HTTP(S) URL, but not other schemas, see [this comment](https://app.clickup.com/t/862jg6t1j?comment=90040006961312&threadedComment=90080018792974).

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify only a valid HTTP(S) URL is allowed to pass the validation