### PR TITLE
Add back ChainQueryArgs to services/types

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -23,3 +23,8 @@ jobs:
         env:
           REACT_APP_JUNO_LCD_NODE: ${{ secrets.REACT_APP_JUNO_LCD_NODE }}
           REACT_APP_INFURA_ID: ${{ secrets.REACT_APP_INFURA_ID }}
+      - name: Build codebase
+        run: yarn build
+        env:
+          REACT_APP_JUNO_LCD_NODE: ${{ secrets.REACT_APP_JUNO_LCD_NODE }}
+          REACT_APP_INFURA_ID: ${{ secrets.REACT_APP_INFURA_ID }}

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -94,6 +94,11 @@ export default function ImgEditor<T extends FieldValues, K extends keyof T>(
                 </IconButton>
               )
             }
+            {!isInitial && (
+              <IconButton onClick={handleOpenCropper} disabled={isSubmitting}>
+                <Icon type="Crop" />
+              </IconButton>
+            )}
           </div>
         )}
       </div>

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -5,6 +5,7 @@ import {
   Proposal,
   ReviewCW3Config,
 } from "types/contracts";
+import { ProviderId } from "types/lists";
 import { SenderArgs } from "types/tx";
 
 export type ContractQueryArgs<T = object> = {
@@ -58,3 +59,9 @@ export type JunoTags =
   | "account"
   | "registrar"
   | "custom";
+
+export type ChainQueryArgs = {
+  address: string;
+  chainId: string;
+  providerId: ProviderId;
+};


### PR DESCRIPTION
## Explanation of the solution
- added back the required type removed in https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/2004.
![image](https://user-images.githubusercontent.com/19427053/228195343-ffb326c2-8487-4c51-9ca0-394e5fafd42b.png)
- added back the 'Crop' btn to `ImgEditor` removed in https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/2004.

Seems our "Build" action missed this compilation error that was immediately caught in local build, it's becoming unreliable @SovereignAndrey 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
