### PR TITLE
sync footer links with marketing site

### DIFF
--- a/src/App/Footer/Links.tsx
+++ b/src/App/Footer/Links.tsx
@@ -4,7 +4,7 @@ const linkStyles = "font-body font-semibold text-xs";
 
 export default function Links() {
   return (
-    <div className="grid grid-rows-2 grid-cols-2 gap-4 w-4/5 max-w-[38rem] md:grid-rows-1 md:grid-cols-4 lg:w-full">
+    <div className="grid grid-rows-2 grid-cols-2 gap-4 w-4/5 max-w-[45rem] md:grid-rows-1 md:grid-cols-4 lg:w-full">
       {SECTIONS_DATA.map(({ title, links }) => (
         <div key={title} className="flex flex-col items-start gap-4">
           <p className="font-heading text-sm font-bold uppercase leading-6">

--- a/src/App/Footer/constants.ts
+++ b/src/App/Footer/constants.ts
@@ -1,6 +1,5 @@
 import { IconType } from "components/Icon";
 import { BASE_DOMAIN, DAPP_DOMAIN } from "constants/common";
-import { LITEPAPER } from "constants/urls";
 
 type SocialMedia =
   | "Twitter"
@@ -61,10 +60,10 @@ type Section = {
 
 export const SECTIONS_DATA: Section[] = [
   {
-    title: "Products",
+    title: "How we can help",
     links: [
       {
-        text: "Non-profits",
+        text: "Nonprofits",
         href: `${BASE_DOMAIN}`,
       },
       {
@@ -79,37 +78,28 @@ export const SECTIONS_DATA: Section[] = [
     ],
   },
   {
-    title: "About",
+    title: "Resources",
     links: [
-      { text: "About us", href: `${BASE_DOMAIN}/about-angel-giving/` },
-      {
-        text: "Meet the team",
-        href: `${BASE_DOMAIN}/about/#:~:text=MEET%20THE%20TEAM-`,
-      },
-      { text: "News", href: `${BASE_DOMAIN}/news/` },
-      { text: "Careers", href: `${BASE_DOMAIN}/careers/` },
-    ],
-  },
-  {
-    title: "Docs",
-    links: [
-      { text: "Litepaper", href: LITEPAPER },
+      { text: "About us", href: `${BASE_DOMAIN}/about/` },
       { text: "FAQs", href: "https://intercom.help/angel-protocol/en" },
-      { text: "Technical doc (coming soon)" },
+      { text: "News", href: `${BASE_DOMAIN}/angel-giving-news/` },
     ],
   },
   {
     title: "Legal",
     links: [
       {
-        text: "Privacy policy",
+        text: "Privacy Policy",
         href: `${BASE_DOMAIN}/privacy-policy/`,
       },
       {
-        text: "Terms of Use",
+        text: "Terms of Use (Platform)",
         href: `${BASE_DOMAIN}/terms-of-use/`,
       },
-      { text: "Terms for NPO", href: `${BASE_DOMAIN}/terms-of-use-npo/` },
+      {
+        text: "Terms of Use (Nonprofits)",
+        href: `${BASE_DOMAIN}/terms-of-use-npo/`,
+      },
     ],
   },
 ];


### PR DESCRIPTION
Ticket(s):
Closes #2014 

## Explanation of the solution
- Modified dapp footer to match the columns and link contents now used on the marketing site.
- grid col width made a little wider

### Existing dapp footer links
![image](https://user-images.githubusercontent.com/85138450/228413295-5161c778-833f-4e95-99e6-f7f55924620f.png)

### Marketing page footer links (expected)
![image](https://user-images.githubusercontent.com/85138450/228410684-8f4409df-7d55-483a-9f1b-ef2d23aaeb29.png)

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## UI changes for review
### New dapp footer links
![image](https://user-images.githubusercontent.com/85138450/228413808-6de96c80-e58a-4a10-8fb0-8c2c0d5ee3e9.png)