### PR TITLE
Web3 auth dyanmically setup provider (allows torus wallet connect)

### DIFF
--- a/src/helpers/evm/evm.ts
+++ b/src/helpers/evm/evm.ts
@@ -2,6 +2,7 @@ import WalletConnect from "@walletconnect/client";
 import { InjectedProvider, RequestArguments } from "types/evm";
 import { ProviderId } from "types/lists";
 import { Dwindow } from "types/window";
+import web3Auth from "contexts/WalletContext/useWeb3Auth/web3AuthSetup";
 import { WC_BRIDGE } from "constants/urls";
 
 export const connector = new WalletConnect({
@@ -26,7 +27,7 @@ export function getProvider(
     case "metamask":
       return dwindow.ethereum;
     case "web3auth-metamask":
-      return dwindow.ethereum;
+      return web3Auth.provider as InjectedProvider;
     /** only used in sendTx */
     case "evm-wc":
       return wcProvider as InjectedProvider;

--- a/src/types/evm.ts
+++ b/src/types/evm.ts
@@ -43,7 +43,7 @@ export type AccountChangeHandler = (accounts: string[]) => void;
 export type ChainChangeHandler = (chainId: string) => void;
 
 export type InjectedProvider = {
-  chainId: string;
+  chainId?: string;
   request: <T>(args: RequestArguments) => Promise<T>;
   on(ev: "chainChanged", listener: ChainChangeHandler): any;
   on(ev: "accountsChanged", listener: AccountChangeHandler): any;


### PR DESCRIPTION
Ticket(s):
-https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/2036

## Explanation of the solution
**Issue:**
![image](https://user-images.githubusercontent.com/23124046/230058924-4a2551d3-6584-462c-bf61-d0abbe15e5fd.png)

web3auth would not connect to injectedprovider unless connected through metamask, So earlier even though web3Auth was connecting using torus or social login the wallet wasn't getting connected and no txn were possible

**Solution**
Now provider get determined dynamically and connected irrespective of type of login

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes