### PR TITLE
Add margin to privacy note

### DIFF
--- a/src/pages/Registration/Signup/Form.tsx
+++ b/src/pages/Registration/Signup/Form.tsx
@@ -36,7 +36,7 @@ export default function Form({ classes = "" }: { classes?: string }) {
         required
         name="hasAgreedToPrivacyPolicy"
         classes={{
-          container: "check-field-reg justify-self-center -mt-4 text-xs",
+          container: "check-field-reg justify-self-center -mt-2 text-xs",
           error: "mt-2",
         }}
       >


### PR DESCRIPTION
Ticket(s):
- [Prod: Registration signup form error message is too close to text below it#2044](https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/2044)

## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes