### PR TITLE
catch file upload API failures to avoid update profile crash

### DIFF
--- a/src/helpers/uploadFiles.ts
+++ b/src/helpers/uploadFiles.ts
@@ -26,7 +26,7 @@ export async function uploadFiles(
           fileName: `${timeStamp}-${f.name.replace(SPACES, "_")}`,
         }),
         headers: { authorization },
-      })
+      }).catch((e: any) => console.log(e))
     )
   );
 


### PR DESCRIPTION
Ticket(s):
- [Bug: Content clears on edit profile if the update fails (should not happen)#2031](https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/2031)

## Explanation of the solution
The upload API failure leads to abrupt crash of the update function
Adding a catch clause avoids that crash (The issue is intermittent and only occurs cause of network issues )
 
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes