### PR TITLE
Remove unused `appRoutes.index`

### DIFF
--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,5 +1,4 @@
 export enum appRoutes {
-  index = "/",
   dashboard = "/dashboard",
   marketplace = "/marketplace",
   leaderboard = "/leaderboard",


### PR DESCRIPTION
## Explanation of the solution
This route is no longer used as of https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/2056.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes