### PR TITLE
Admin fixes

### DIFF
--- a/src/pages/Admin/Core/Nav.tsx
+++ b/src/pages/Admin/Core/Nav.tsx
@@ -13,6 +13,6 @@ export default function Nav() {
 }
 
 const styler = createNavLinkStyler(
-  "px-2 uppercase text-sm text-center font-semibold font-heading text-white",
+  "px-2 uppercase text-sm text-center font-semibold font-heading text-gray-d2 dark:text-white",
   "text-orange"
 );

--- a/src/pages/Admin/Proposal/Voter/useVote.ts
+++ b/src/pages/Admin/Proposal/Voter/useVote.ts
@@ -2,8 +2,6 @@ import { MsgExecuteContractEncodeObject } from "@cosmjs/cosmwasm-stargate";
 import { useFormContext } from "react-hook-form";
 import { VoteValues as VV } from "./types";
 import { useAdminResources } from "pages/Admin/Guard";
-import { invalidateJunoTags } from "services/juno";
-import { adminTags } from "services/juno/tags";
 import { useGetWallet } from "contexts/WalletContext";
 import CW3 from "contracts/CW3";
 import CW3Review from "contracts/CW3/CW3Review";
@@ -15,7 +13,7 @@ export default function useVote() {
     formState: { isValid },
   } = useFormContext<VV>();
   const { wallet } = useGetWallet();
-  const { cw3 } = useAdminResources();
+  const { cw3, propMeta } = useAdminResources();
   const { sendTx, isSending } = useCosmosTxSender(true);
 
   async function vote({ type, proposalId, vote, reason }: VV) {
@@ -35,9 +33,7 @@ export default function useVote() {
 
     await sendTx({
       msgs: [voteMsg],
-      tagPayloads: [
-        invalidateJunoTags([{ type: "admin", id: adminTags.proposals }]),
-      ],
+      ...propMeta,
     });
   }
 


### PR DESCRIPTION
Ticket(s): n/a
1. AP admin text is hidden on lightmode
2. After voting user vote is not reflected ( was able to repro in testnet, but due to cache invalidation only - vote is still reflected on page refresh )

## Explanation of the solution
1. AP admin nav light text color
2. invalidate `proposal` tag on vote

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes