### PR TITLE
Update website url schema validation

### DIFF
--- a/src/pages/Admin/Core/Templates/index-fund/Alliance/schema.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/Alliance/schema.ts
@@ -1,7 +1,7 @@
 import * as Yup from "yup";
 import { AllianceEditValues } from "pages/Admin/types";
 import { SchemaShape } from "schemas/types";
-import { requiredWalletAddr } from "schemas/string";
+import { requiredWalletAddr, url } from "schemas/string";
 import { proposalShape } from "../../../../constants";
 
 const shape: SchemaShape<AllianceEditValues> = {
@@ -12,10 +12,7 @@ const shape: SchemaShape<AllianceEditValues> = {
     .nullable()
     .required("logo is required")
     .url("url is invalid"),
-  website: Yup.string()
-    .nullable()
-    .required("website is required")
-    .url("url is invalid"),
+  website: url,
 };
 
 export const schema = Yup.object(shape);

--- a/src/pages/Registration/Steps/Documentation/schema.ts
+++ b/src/pages/Registration/Steps/Documentation/schema.ts
@@ -6,7 +6,7 @@ import { Country } from "types/countries";
 import { OptionType } from "components/Selector";
 import { Asset } from "components/registration";
 import { genFileSchema } from "schemas/file";
-import { requiredString } from "schemas/string";
+import { requiredString, url } from "schemas/string";
 import { MAX_SDGS } from "constants/unsdgs";
 
 export const MB_LIMIT = 25;
@@ -34,7 +34,7 @@ function genAssetShape(isRequired: boolean = false): SchemaShape<Asset> {
 export const schema = Yup.object().shape<SchemaShape<FormValues>>({
   proofOfIdentity: Yup.object().shape(genAssetShape(true)),
   proofOfRegistration: Yup.object().shape(genAssetShape(true)),
-  website: Yup.string().required("required").url("invalid url"),
+  website: url,
   sdgs: Yup.array()
     .min(1, "required")
     .max(MAX_SDGS, `maximum ${MAX_SDGS} selections allowed`),


### PR DESCRIPTION
Ticket(s):
- [Use common URL schema found in src/schemas/string.ts > url to validate "website" on Registration > Documentation step#2069](https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/2069)

## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes