### PR TITLE
Charity application proposal save to AWS

### DIFF
--- a/src/contracts/evm/multisig/events.json
+++ b/src/contracts/evm/multisig/events.json
@@ -1,0 +1,3 @@
+[
+  "event Submission(uint256 indexed,tuple(string,string,address,uint256,bytes,bool))"
+]

--- a/src/contracts/evm/multisig/index.ts
+++ b/src/contracts/evm/multisig/index.ts
@@ -1,5 +1,6 @@
 import { Interface } from "@ethersproject/abi";
+import events from "./events.json";
 import queries from "./queries.json";
 import txs from "./txs.json";
 
-export const multisig = new Interface([...txs, ...queries]);
+export const multisig = new Interface([...txs, ...queries, ...events]);

--- a/src/pages/Admin/Review/Application/Summary/Proposer.tsx
+++ b/src/pages/Admin/Review/Application/Summary/Proposer.tsx
@@ -21,10 +21,11 @@ import { proposalShape } from "../../../constants";
 type Props = {
   type: TxType;
   appId: number;
+  reference: string;
 };
 
 type FV = ProposalBase & /** meta */ Props;
-export default function Proposer({ type, appId }: Props) {
+export default function Proposer({ type, appId, reference }: Props) {
   const methods = useForm<FV>({
     resolver: yupResolver(object().shape<SchemaShape<FV>>(proposalShape)),
     defaultValues: {
@@ -70,7 +71,7 @@ export default function Proposer({ type, appId }: Props) {
 
       const res = await updateReg({
         type: "application",
-        reference: "",
+        reference,
         approve_tx_id: +txId,
       });
 

--- a/src/pages/Admin/Review/Application/Summary/Proposer.tsx
+++ b/src/pages/Admin/Review/Application/Summary/Proposer.tsx
@@ -61,7 +61,14 @@ export default function Proposer({ type, appId, reference }: Props) {
 
     const onSuccess: TxOnSuccess = async (result) => {
       const { data, ...okTx } = result;
-      const txId = data as string;
+      const txId = data as string | null;
+
+      if (!txId) {
+        return showModal(TxPrompt, {
+          error: "Failed to retrieve transaction id",
+          tx: okTx,
+        });
+      }
 
       showModal(
         TxPrompt,

--- a/src/pages/Admin/Review/Application/Summary/Summary.tsx
+++ b/src/pages/Admin/Review/Application/Summary/Summary.tsx
@@ -43,11 +43,18 @@ export default function Summary({
         docs={r.AuditedFinancialReports || []}
       />
       {txId ? (
-        <Link to={`../${adminRoutes.proposal}/${txId}`}>
-          Sign {txType} transaction
+        <Link
+          to={`../${adminRoutes.proposal}/${txId}`}
+          className="text-sm text-blue hover:text-orange"
+        >
+          <span> Sign {txType} transaction</span>
+          <Icon
+            type="ArrowRight"
+            className="text-lg relative inline bottom-px"
+          />
         </Link>
       ) : (
-        <ReviewOptions appId={+appId} />
+        <ReviewOptions appId={+appId} reference={r.PK} />
       )}
     </div>
   );
@@ -55,11 +62,13 @@ export default function Summary({
 
 type Props = {
   appId: number;
+  reference: string;
 };
-function ReviewOptions({ appId }: Props) {
+function ReviewOptions({ appId, reference }: Props) {
   const { showModal } = useModalContext();
 
-  const review = (type: TxType) => () => showModal(Proposer, { appId, type });
+  const review = (type: TxType) => () =>
+    showModal(Proposer, { appId, type, reference });
 
   return (
     <div className="flex items-center gap-2 justify-start mt-6">

--- a/src/types/aws/ap/registration.ts
+++ b/src/types/aws/ap/registration.ts
@@ -112,8 +112,8 @@ Inactive | Rejected | {id: number}
 export type DoneWallet = Append<DoneDocs, {}, {}, WalletData & NewEndow>;
 
 type ApplicationIDs = {
-  approve_tx_id?: string;
-  reject_tx_id?: string;
+  approve_tx_id?: number;
+  reject_tx_id?: number;
 };
 export type InReview = Append<DoneWallet, ApplicationIDs, {}, {}>;
 


### PR DESCRIPTION
Ticket(s):
* https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/2072

## Explanation of the solution
* after `approving` or `rejecting` an application, corersponding `approve_tx_id` or `reject_tx_id` is saved to AWS
* link is shown to created proposal
<img width="322" alt="image" src="https://user-images.githubusercontent.com/89639563/233875250-766d5869-2c44-4aad-ab40-89689710ab1e.png">

NOTE: executing transaction still has some errors may be related to 
* https://github.com/pedalsup/Angel-protocol/issues/38

[failed tx execution](https://mumbai.polygonscan.com/tx/0xba3a3ff74d0e0c028909f7635220448a6dac301d07989ddee59a8790aa0eca39)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes