### PR TITLE
Adjust permissions rules

### DIFF
--- a/src/pages/Admin/Charity/Permissions/Form.tsx
+++ b/src/pages/Admin/Charity/Permissions/Form.tsx
@@ -1,7 +1,7 @@
 import { ErrorMessage } from "@hookform/error-message";
 import MobileTable from "./MobileTable";
 import Table from "./Table";
-import { getFieldErrorName } from "./helpers/getFieldErrorName";
+import { getFieldErrorName } from "./helpers";
 import useSubmit from "./useSubmit";
 
 export default function Form() {

--- a/src/pages/Admin/Charity/Permissions/Form.tsx
+++ b/src/pages/Admin/Charity/Permissions/Form.tsx
@@ -1,13 +1,13 @@
 import { ErrorMessage } from "@hookform/error-message";
-import { getTypedKeys } from "helpers";
 import MobileTable from "./MobileTable";
 import Table from "./Table";
+import { getFieldErrorName } from "./helpers/getFieldErrorName";
 import useSubmit from "./useSubmit";
 
 export default function Form() {
   const { isSubmitting, errors, reset, submit } = useSubmit();
 
-  const errorName = getTypedKeys(errors).find((errKey) => !!errors[errKey]);
+  const errorName = getFieldErrorName(errors);
 
   return (
     <form className="grid gap-6 w-full" onSubmit={submit}>
@@ -33,7 +33,7 @@ export default function Form() {
         {errorName && (
           <ErrorMessage
             errors={errors}
-            name={`${errorName}.delegate_address`}
+            name={errorName}
             as="span"
             className="field-error static text-sm"
           />

--- a/src/pages/Admin/Charity/Permissions/MobileTable.tsx
+++ b/src/pages/Admin/Charity/Permissions/MobileTable.tsx
@@ -72,6 +72,7 @@ export default function MobileTable({ className = "" }) {
                       classes={{
                         label: "uppercase text-xs font-bold",
                         input: "checkbox-orange",
+                        error: "hidden",
                       }}
                       disabled={checkboxDisabled}
                     >
@@ -83,6 +84,7 @@ export default function MobileTable({ className = "" }) {
                         classes={{
                           label: "uppercase text-xs font-bold",
                           input: "checkbox-orange",
+                          error: "hidden",
                         }}
                         disabled={checkboxDisabled}
                       >
@@ -94,6 +96,7 @@ export default function MobileTable({ className = "" }) {
                       classes={{
                         label: "uppercase text-xs font-bold",
                         input: "checkbox-orange",
+                        error: "hidden",
                       }}
                       disabled={checkboxDisabled}
                     >

--- a/src/pages/Admin/Charity/Permissions/MobileTable.tsx
+++ b/src/pages/Admin/Charity/Permissions/MobileTable.tsx
@@ -115,7 +115,7 @@ export default function MobileTable({ className = "" }) {
                       id={`del-addr-input-${fieldName}`}
                       disabled={delegateAddressDisabled}
                       className={`field-input truncate h-8 ${
-                        !errors[fieldName]
+                        !errors[fieldName]?.delegate_address
                           ? ""
                           : "border-red dark:border-red-l2 focus:border-red focus:dark:border-red-l2"
                       }`}

--- a/src/pages/Admin/Charity/Permissions/Table.tsx
+++ b/src/pages/Admin/Charity/Permissions/Table.tsx
@@ -102,7 +102,7 @@ export default function Table({ className = "" }) {
               <input
                 type="text"
                 className={`field-input min-w-[9rem] w-full truncate py-1.5 ${
-                  !errors[fieldName]
+                  !errors[fieldName]?.delegate_address
                     ? ""
                     : "border-red dark:border-red-l2 focus:border-red focus:dark:border-red-l2"
                 }`}

--- a/src/pages/Admin/Charity/Permissions/Table.tsx
+++ b/src/pages/Admin/Charity/Permissions/Table.tsx
@@ -74,6 +74,7 @@ export default function Table({ className = "" }) {
                 classes={{
                   label: "uppercase text-xs font-bold",
                   input: "checkbox-orange",
+                  error: "hidden",
                 }}
                 disabled={checkboxDisabled}
               />
@@ -83,6 +84,7 @@ export default function Table({ className = "" }) {
                   classes={{
                     label: "uppercase text-xs font-bold",
                     input: "checkbox-orange",
+                    error: "hidden",
                   }}
                   disabled={checkboxDisabled}
                 />
@@ -92,6 +94,7 @@ export default function Table({ className = "" }) {
                 classes={{
                   label: "uppercase text-xs font-bold",
                   input: "checkbox-orange",
+                  error: "hidden",
                 }}
                 disabled={checkboxDisabled}
               />

--- a/src/pages/Admin/Charity/Permissions/helpers/createUpdateEndowmentControllerMsg.ts
+++ b/src/pages/Admin/Charity/Permissions/helpers/createUpdateEndowmentControllerMsg.ts
@@ -4,9 +4,9 @@ import {
   SettingsPermission,
 } from "types/contracts";
 import { ADDRESS_ZERO } from "constants/evm";
-import { UpdateableFormValues } from "./schema";
+import { UpdateableFormValues } from "../schema";
 
-export default function createUpdateEndowmentControllerMsg(
+export function createUpdateEndowmentControllerMsg(
   endowId: number,
   changes: Partial<UpdateableFormValues>,
   initial: SettingsController

--- a/src/pages/Admin/Charity/Permissions/helpers/getFieldErrorName.ts
+++ b/src/pages/Admin/Charity/Permissions/helpers/getFieldErrorName.ts
@@ -1,0 +1,38 @@
+import { FieldErrors } from "react-hook-form";
+import { getTypedKeys } from "helpers";
+import { FormField, FormValues } from "../schema";
+
+// this object is created only to be able to iterate over `FormField` keys
+const formFieldSample: FormField = {
+  delegate_address: "",
+  delegated: false,
+  govControlled: false,
+  modifiableAfterInit: false,
+  name: "",
+  ownerControlled: false,
+};
+
+export function getFieldErrorName(
+  errors: FieldErrors<FormValues>
+): string | undefined {
+  const errorKey = getTypedKeys(errors).find((errKey) => !!errors[errKey]);
+
+  // shouldn't be any of the below, but have the check to narrow down the key type
+  if (
+    !errorKey ||
+    errorKey === "endowment_controller" ||
+    errorKey === "initialValues" ||
+    errorKey === "root"
+  ) {
+    return errorKey;
+  }
+
+  // `errors[errorKey]` is defined due to check above
+  const errorSubKey = getTypedKeys(formFieldSample).find(
+    (errKey) => !!errors[errorKey]![errKey]
+  );
+
+  if (errorSubKey) {
+    return `${errorKey}.${errorSubKey}`;
+  }
+}

--- a/src/pages/Admin/Charity/Permissions/helpers/index.ts
+++ b/src/pages/Admin/Charity/Permissions/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from "./createUpdateEndowmentControllerMsg";
+export * from "./getFieldErrorName";

--- a/src/pages/Admin/Charity/Permissions/helpers/index.ts
+++ b/src/pages/Admin/Charity/Permissions/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from "./createUpdateEndowmentControllerMsg";

--- a/src/pages/Admin/Charity/Permissions/schema.ts
+++ b/src/pages/Admin/Charity/Permissions/schema.ts
@@ -23,14 +23,42 @@ export type FormValues = UpdateableFormValues & {
 };
 
 const deledatedKey: keyof FormField = "delegated";
+const ownerControlledKey: keyof FormField = "ownerControlled";
+const govControlledKey: keyof FormField = "govControlled";
 
 const fieldShape: SchemaShape<FormField> = {
-  delegate_address: Yup.string().when(
-    deledatedKey,
-    (delegate: FormField["delegated"], schema) =>
-      delegate ? requiredWalletAddr() : schema.optional()
-  ),
+  delegated: Yup.boolean().when([ownerControlledKey, govControlledKey], {
+    is: (
+      ownerControlled: FormField["ownerControlled"],
+      govControlled: FormField["govControlled"]
+    ) => !ownerControlled && !govControlled,
+    then: (schema) =>
+      schema.isFalse("Cannot give permissions only to Delegate wallet"),
+    otherwise: (schema) => schema.optional(),
+  }),
+  delegate_address: Yup.string().when(deledatedKey, {
+    is: true,
+    then: requiredWalletAddr(),
+    otherwise: (schema) => schema.optional(),
+  }),
+  govControlled: Yup.boolean().when(ownerControlledKey, {
+    is: true,
+    then: (schema) =>
+      schema.isFalse(
+        "Cannot give permissions to both Admin Wallet and Governance"
+      ),
+    otherwise: (schema) => schema.optional(),
+  }),
+  ownerControlled: Yup.boolean().when(govControlledKey, {
+    is: true,
+    then: (schema) =>
+      schema.isFalse(
+        "Cannot give permissions to both Admin Wallet and Governance"
+      ),
+    otherwise: (schema) => schema.optional(),
+  }),
 };
+
 const shape: SchemaShape<FormValues> = {
   accountFees: Yup.object().shape(fieldShape),
   beneficiaries_allowlist: Yup.object().shape(fieldShape),

--- a/src/pages/Admin/Charity/Permissions/schema.ts
+++ b/src/pages/Admin/Charity/Permissions/schema.ts
@@ -56,22 +56,18 @@ const fieldShape: SchemaShape<FormField> = {
   }),
 };
 
+/**
+ * Defined fields that have cyclical validation dependency to pass.
+ * For more details see https://github.com/jquense/yup/issues/176#issuecomment-367352042
+ */
+const excludes: [string, string][] = [[govControlledKey, ownerControlledKey]];
+
 const shape: SchemaShape<FormValues> = {
-  accountFees: Yup.object().shape(fieldShape, [
-    [govControlledKey, ownerControlledKey],
-  ]),
-  beneficiaries_allowlist: Yup.object().shape(fieldShape, [
-    [govControlledKey, ownerControlledKey],
-  ]),
-  contributors_allowlist: Yup.object().shape(fieldShape, [
-    [govControlledKey, ownerControlledKey],
-  ]),
-  donationSplitParams: Yup.object().shape(fieldShape, [
-    [govControlledKey, ownerControlledKey],
-  ]),
-  profile: Yup.object().shape(fieldShape, [
-    [govControlledKey, ownerControlledKey],
-  ]),
+  accountFees: Yup.object().shape(fieldShape, excludes),
+  beneficiaries_allowlist: Yup.object().shape(fieldShape, excludes),
+  contributors_allowlist: Yup.object().shape(fieldShape, excludes),
+  donationSplitParams: Yup.object().shape(fieldShape, excludes),
+  profile: Yup.object().shape(fieldShape, excludes),
 };
 
 export const schema = Yup.object(shape);

--- a/src/pages/Admin/Charity/Permissions/schema.ts
+++ b/src/pages/Admin/Charity/Permissions/schema.ts
@@ -60,11 +60,21 @@ const fieldShape: SchemaShape<FormField> = {
 };
 
 const shape: SchemaShape<FormValues> = {
-  accountFees: Yup.object().shape(fieldShape),
-  beneficiaries_allowlist: Yup.object().shape(fieldShape),
-  contributors_allowlist: Yup.object().shape(fieldShape),
-  donationSplitParams: Yup.object().shape(fieldShape),
-  profile: Yup.object().shape(fieldShape),
+  accountFees: Yup.object().shape(fieldShape, [
+    [govControlledKey, ownerControlledKey],
+  ]),
+  beneficiaries_allowlist: Yup.object().shape(fieldShape, [
+    [govControlledKey, ownerControlledKey],
+  ]),
+  contributors_allowlist: Yup.object().shape(fieldShape, [
+    [govControlledKey, ownerControlledKey],
+  ]),
+  donationSplitParams: Yup.object().shape(fieldShape, [
+    [govControlledKey, ownerControlledKey],
+  ]),
+  profile: Yup.object().shape(fieldShape, [
+    [govControlledKey, ownerControlledKey],
+  ]),
 };
 
 export const schema = Yup.object(shape);

--- a/src/pages/Admin/Charity/Permissions/schema.ts
+++ b/src/pages/Admin/Charity/Permissions/schema.ts
@@ -23,7 +23,6 @@ export type FormValues = UpdateableFormValues & {
 };
 
 const delegatedKey: keyof FormField = "delegated";
-const ownerControlledKey: keyof FormField = "ownerControlled";
 const govControlledKey: keyof FormField = "govControlled";
 
 const fieldShape: SchemaShape<FormField> = {
@@ -32,17 +31,8 @@ const fieldShape: SchemaShape<FormField> = {
     then: requiredWalletAddr(),
     otherwise: (schema) => schema.optional(),
   }),
-  govControlled: Yup.boolean().when(ownerControlledKey, {
-    is: true,
-    then: (schema) =>
-      schema.isFalse(
-        "Cannot give permissions to both Admin Wallet and Governance"
-      ),
-    otherwise: (schema) =>
-      schema.isTrue(
-        "Please give permissions to either Admin Wallet or Governance"
-      ),
-  }),
+  // it is sufficient to validate only `ownerControlled` field, since the way the validation is defined
+  // makes it necessary for the user to check either `govControlled` or `ownerControlled` to make the form valid.
   ownerControlled: Yup.boolean().when(govControlledKey, {
     is: true,
     then: (schema) =>
@@ -56,18 +46,12 @@ const fieldShape: SchemaShape<FormField> = {
   }),
 };
 
-/**
- * Defined fields that have cyclical validation dependency to pass.
- * For more details see https://github.com/jquense/yup/issues/176#issuecomment-367352042
- */
-const excludes: [string, string][] = [[govControlledKey, ownerControlledKey]];
-
 const shape: SchemaShape<FormValues> = {
-  accountFees: Yup.object().shape(fieldShape, excludes),
-  beneficiaries_allowlist: Yup.object().shape(fieldShape, excludes),
-  contributors_allowlist: Yup.object().shape(fieldShape, excludes),
-  donationSplitParams: Yup.object().shape(fieldShape, excludes),
-  profile: Yup.object().shape(fieldShape, excludes),
+  accountFees: Yup.object().shape(fieldShape),
+  beneficiaries_allowlist: Yup.object().shape(fieldShape),
+  contributors_allowlist: Yup.object().shape(fieldShape),
+  donationSplitParams: Yup.object().shape(fieldShape),
+  profile: Yup.object().shape(fieldShape),
 };
 
 export const schema = Yup.object(shape);

--- a/src/pages/Admin/Charity/Permissions/schema.ts
+++ b/src/pages/Admin/Charity/Permissions/schema.ts
@@ -27,15 +27,6 @@ const ownerControlledKey: keyof FormField = "ownerControlled";
 const govControlledKey: keyof FormField = "govControlled";
 
 const fieldShape: SchemaShape<FormField> = {
-  delegated: Yup.boolean().when([ownerControlledKey, govControlledKey], {
-    is: (
-      ownerControlled: FormField["ownerControlled"],
-      govControlled: FormField["govControlled"]
-    ) => !ownerControlled && !govControlled,
-    then: (schema) =>
-      schema.isFalse("Cannot give permissions only to Delegate wallet"),
-    otherwise: (schema) => schema.optional(),
-  }),
   delegate_address: Yup.string().when(deledatedKey, {
     is: true,
     then: requiredWalletAddr(),
@@ -47,7 +38,10 @@ const fieldShape: SchemaShape<FormField> = {
       schema.isFalse(
         "Cannot give permissions to both Admin Wallet and Governance"
       ),
-    otherwise: (schema) => schema.optional(),
+    otherwise: (schema) =>
+      schema.isTrue(
+        "Please give permissions to either Admin Wallet or Governance"
+      ),
   }),
   ownerControlled: Yup.boolean().when(govControlledKey, {
     is: true,
@@ -55,7 +49,10 @@ const fieldShape: SchemaShape<FormField> = {
       schema.isFalse(
         "Cannot give permissions to both Admin Wallet and Governance"
       ),
-    otherwise: (schema) => schema.optional(),
+    otherwise: (schema) =>
+      schema.isTrue(
+        "Please give permissions to either Admin Wallet or Governance"
+      ),
   }),
 };
 

--- a/src/pages/Admin/Charity/Permissions/schema.ts
+++ b/src/pages/Admin/Charity/Permissions/schema.ts
@@ -22,12 +22,12 @@ export type FormValues = UpdateableFormValues & {
   endowment_controller: FormField;
 };
 
-const deledatedKey: keyof FormField = "delegated";
+const delegatedKey: keyof FormField = "delegated";
 const ownerControlledKey: keyof FormField = "ownerControlled";
 const govControlledKey: keyof FormField = "govControlled";
 
 const fieldShape: SchemaShape<FormField> = {
-  delegate_address: Yup.string().when(deledatedKey, {
+  delegate_address: Yup.string().when(delegatedKey, {
     is: true,
     then: requiredWalletAddr(),
     otherwise: (schema) => schema.optional(),

--- a/src/pages/Admin/Charity/Permissions/useSubmit.ts
+++ b/src/pages/Admin/Charity/Permissions/useSubmit.ts
@@ -37,7 +37,7 @@ export default function useSubmit() {
     if (isValid) {
       trigger();
     }
-  }, [isValid]);
+  }, [isValid, trigger]);
 
   async function onSubmit({
     initialValues,

--- a/src/pages/Admin/Charity/Permissions/useSubmit.ts
+++ b/src/pages/Admin/Charity/Permissions/useSubmit.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 import { SimulContractTx } from "types/evm";
 import { useAdminResources } from "pages/Admin/Guard";
@@ -21,13 +22,22 @@ export default function useSubmit() {
   } = useAdminResources<"charity">();
   const { handleError } = useErrorContext();
   const {
-    formState: { isSubmitting, errors },
+    formState: { isSubmitting, errors, isValid },
     handleSubmit,
     reset,
+    trigger,
   } = useFormContext<FormValues>();
   const { wallet } = useGetWallet();
   const sendTx = useTxSender();
   const { isUserOwner, userDelegated } = useUserAuthorization();
+
+  // if this effect is omitted and there are any errors,
+  // once form is changed to a valid state the error messages do not disappear
+  useEffect(() => {
+    if (isValid) {
+      trigger();
+    }
+  }, [isValid]);
 
   async function onSubmit({
     initialValues,

--- a/src/pages/Admin/Charity/Permissions/useSubmit.ts
+++ b/src/pages/Admin/Charity/Permissions/useSubmit.ts
@@ -8,7 +8,7 @@ import useTxSender from "hooks/useTxSender";
 import { isEmpty } from "helpers";
 import { getPayloadDiff, getTagPayloads } from "helpers/admin";
 import { UnexpectedStateError } from "errors/errors";
-import createUpdateEndowmentControllerMsg from "./createUpdateEndowmentControllerMsg";
+import { createUpdateEndowmentControllerMsg } from "./helpers";
 import { FormValues } from "./schema";
 import useUserAuthorization from "./useUserAuthorization";
 


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/865c65xrw
  - https://app.clickup.com/t/865c6572n

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- open `src/pages/Admin/Guard.tsx`, comment out admin resource fetching logic and use the below `data` placeholder:
```ts
const data: AdminResources = {
  type: "charity",
  propMeta: { isAuthorized: true },
  endow_type: "normal",
  settingsController: {
    endowmentController: {
      ownerControlled: true,
      govControlled: false,
      modifiableAfterInit: true,
      delegate: { expires: 1000000, Addr: ADDRESS_ZERO },
    },
    name: {
      ownerControlled: true,
      govControlled: false,
      modifiableAfterInit: true,
      delegate: { expires: 1000000, Addr: ADDRESS_ZERO },
    },
    aumFee: {
      ownerControlled: true,
      govControlled: false,
      modifiableAfterInit: true,
      delegate: { expires: 1000000, Addr: ADDRESS_ZERO },
    },
    whitelistedBeneficiaries: {
      ownerControlled: true,
      govControlled: false,
      modifiableAfterInit: true,
      delegate: { expires: 1000000, Addr: ADDRESS_ZERO },
    },
    whitelistedContributors: {
      ownerControlled: true,
      govControlled: false,
      modifiableAfterInit: true,
      delegate: { expires: 1000000, Addr: ADDRESS_ZERO },
    },
    splitToLiquid: {
      ownerControlled: true,
      govControlled: false,
      modifiableAfterInit: true,
      delegate: { expires: 1000000, Addr: ADDRESS_ZERO },
    },
  } as SettingsController,
} as AdminResources;
```
This will ensure you can open the permissions page and play around.
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to http://localhost:4200/admin/27/permissions
- verify user is able to select only the options outlined in the [CU task](https://app.clickup.com/t/865c6572n)
- verify correct error messages appear when expected

## UI changes for review

![image](https://user-images.githubusercontent.com/19427053/233937210-f15a5d57-34c3-4536-aadf-3b0d1a93512f.png)
