### PR TITLE
Add Polygon to Kado modal buy options

### DIFF
--- a/src/components/KadoModal.tsx
+++ b/src/components/KadoModal.tsx
@@ -10,7 +10,10 @@ import { KADO_API_KEY } from "constants/env";
 import IFrame from "./IFrame";
 import Modal from "./Modal";
 
-type KADO_NETWORK_VALUES = "ethereum" | "juno" | "terra";
+const KADO_NETWORKS = ["ethereum", "juno", "terra", "polygon"] as const;
+type KADO_NETWORK_VALUES = typeof KADO_NETWORKS[number];
+
+const NETWORK_LIST = KADO_NETWORKS.join(",");
 
 export default function KadoModal() {
   const dispatch = useSetter();
@@ -46,7 +49,7 @@ export default function KadoModal() {
         </button>
       </Modal.Title>
       <IFrame
-        src={`https://app.kado.money?apiKey=${KADO_API_KEY}&onPayCurrency=USD&onRevCurrency=USDC&onPayAmount=100${onToAddress}&cryptoList=USDC${network}&product=BUY&networkList=ethereum,juno,terra`}
+        src={`https://app.kado.money?apiKey=${KADO_API_KEY}&onPayCurrency=USD&onRevCurrency=USDC&onPayAmount=100${onToAddress}&cryptoList=USDC${network}&product=BUY&networkList=${NETWORK_LIST}`}
         className="w-full h-full border-none rounded-b"
         title="Buy with Kado"
         onLoad={handleOnLoad}
@@ -57,6 +60,9 @@ export default function KadoModal() {
 
 function getKadoNetworkValue(chainId: string): KADO_NETWORK_VALUES {
   switch (chainId) {
+    case chainIDs.polygonMain:
+    case chainIDs.polygonTest:
+      return "polygon";
     // if Binance, just default to ethereum
     case chainIDs.binanceMain:
     case chainIDs.binanceTest:
@@ -71,6 +77,6 @@ function getKadoNetworkValue(chainId: string): KADO_NETWORK_VALUES {
       return "terra";
     default:
       logger.error(`${chainId} is not supported`);
-      return "ethereum";
+      return "polygon";
   }
 }


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/865c6crj2

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- connect wallet with no asset balances (to force "buy some crypto" link to appear)
- open Kado modal
- verify Polygon is an available network to buy on

## UI changes for review

![image](https://user-images.githubusercontent.com/19427053/233955542-2563aa1c-afdf-43d5-bad6-0504c2b80b50.png)
