### PR TITLE
Adds outline to bookmark icon in light mode

### DIFF
--- a/src/components/BookmarkBtn.tsx
+++ b/src/components/BookmarkBtn.tsx
@@ -60,7 +60,7 @@ export default function BookmarkBtn({ endowId, children }: Props) {
         onClick={toogleBookmark}
         disabled={isLoading}
         className={`flex items-center gap-1 ${
-          isBookmarked || isHovered ? "text-red" : "text-white"
+          isBookmarked || isHovered ? "text-red" : ""
         }`}
         onMouseOver={(e) => {
           e.preventDefault();


### PR DESCRIPTION
Ticket(s):
- [Add light red border to the bookmark heart on light mode as we can't see it in LIGHT mode#2096](https://github.com/AngelProtocolFinance/angelprotocol-web-app/issues/2096)

## Explanation of the solution
![image](https://user-images.githubusercontent.com/23124046/234051102-3833b459-5a47-4a0f-ab4b-f01b62e7184d.png)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes