### PR TITLE
Follow-up fixes: AST maturity optional

### DIFF
--- a/src/components/form/constants.ts
+++ b/src/components/form/constants.ts
@@ -1,1 +1,0 @@
-export const hookFormInitialDateString = "NaN-NaN-NaN";

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -2,4 +2,3 @@ export * from "./Label";
 export * from "./Field";
 export { CheckField } from "./CheckField";
 export { dateToFormFormat } from "./helpers";
-export * from "./constants";

--- a/src/pages/Launchpad/Maturity/Form/index.tsx
+++ b/src/pages/Launchpad/Maturity/Form/index.tsx
@@ -1,29 +1,43 @@
+import { useFormContext } from "react-hook-form";
 import { FV } from "../types";
+import Toggle from "components/Toggle";
 import { Field } from "components/form";
 import Form, { Desc, FormProps, Title } from "../../common/Form";
 import NavButtons from "../../common/NavButtons";
 import Beneficiaries from "./Beneficiaries";
 
 export default function MaturityForm(props: FormProps) {
+  const { watch } = useFormContext<FV>();
+  const willMature = watch("willMature");
   return (
-    <Form {...props}>
+    <Form {...props} className="grid content-start">
       <Title className="mb-2">Maturity</Title>
       <Desc className="mb-8">
         You can set the maturity date of your AST. Upon reaching maturity, all
         funds from both Liquid account and Locked account can be withdrawn by a
         list of addresses set in advance.
       </Desc>
-      <Field<FV, "date">
-        type="date"
-        name="date"
-        label="Maturity date"
-        placeholder="DD/MM/YYYY"
-        required
-        classes={{ container: "mb-8", input: "date-input uppercase" }}
-      />
+      <Toggle<FV>
+        name="willMature"
+        classes={{ label: "text-sm", container: "mb-6" }}
+      >
+        Set maturity
+      </Toggle>
+      {willMature ? (
+        <>
+          <Field<FV, "date">
+            type="date"
+            name="date"
+            label="Maturity date"
+            placeholder="DD/MM/YYYY"
+            required
+            classes={{ container: "mb-8", input: "date-input uppercase" }}
+          />
 
-      <Beneficiaries classes="mb-8" />
-      <NavButtons curr={4} classes="mt-8" />
+          <Beneficiaries classes="mb-8" />
+        </>
+      ) : null}
+      <NavButtons curr={4} classes="self-end" />
     </Form>
   );
 }

--- a/src/pages/Launchpad/Summary/Maturity.tsx
+++ b/src/pages/Launchpad/Summary/Maturity.tsx
@@ -5,6 +5,7 @@ import Info from "../common/Info";
 import Section, { SectionProps } from "./Section";
 
 export default function Maturity({
+  willMature,
   date,
   beneficiaries,
   ...props
@@ -18,25 +19,31 @@ export default function Maturity({
 
   return (
     <Section {...props}>
-      <div className="mb-6">
-        <span className="font-semibold">Maturity date: </span>
-        <span>{new Date(date).toLocaleDateString()}</span>
-      </div>
-      <p className="font-semibold mb-2">Maturity Whitelist:</p>
-      {isEmpty(_beneficiaries) ? (
-        <Info>
-          No whitelist has been set - the Admin wallet will be the only
-          beneficiary at maturity
-        </Info>
+      {willMature ? (
+        <>
+          <div className="mb-6">
+            <span className="font-semibold">Maturity date: </span>
+            <span>{new Date(date).toLocaleDateString()}</span>
+          </div>
+          <p className="font-semibold mb-2">Maturity Whitelist:</p>
+          {isEmpty(_beneficiaries) ? (
+            <Info>
+              No whitelist has been set - the Admin wallet will be the only
+              beneficiary at maturity
+            </Info>
+          ) : (
+            <ul className="grid gap-y-2 list-disc list-inside">
+              {beneficiaries.map(({ addr, share }) => (
+                <li key={addr} className="">
+                  <span className="mr-10">{addr}</span>
+                  <span className="font-semibold">{share} %</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       ) : (
-        <ul className="grid gap-y-2 list-disc list-inside">
-          {beneficiaries.map(({ addr, share }) => (
-            <li key={addr} className="">
-              <span className="mr-10">{addr}</span>
-              <span className="font-semibold">{share} %</span>
-            </li>
-          ))}
-        </ul>
+        <Info>Maturity is not set</Info>
       )}
     </Section>
   );

--- a/src/pages/Launchpad/Summary/useSubmit/toEVMAST.ts
+++ b/src/pages/Launchpad/Summary/useSubmit/toEVMAST.ts
@@ -20,7 +20,7 @@ export default function toEVMAST(
   return {
     owner: creator,
     withdrawBeforeMaturity: true, //not specified in launchpad design
-    maturityTime: maturity.date ? blockTime(maturity.date) : 0,
+    maturityTime: maturity.willMature ? blockTime(maturity.date) : 0,
     // maturityHeight: 0; //not specified in launchpad design
     maturityHeight: 0,
     name: about.name,

--- a/src/slices/launchpad/types.ts
+++ b/src/slices/launchpad/types.ts
@@ -21,6 +21,7 @@ export type Beneficiary = {
   share: string; // "1" - "100"
 };
 export type TMaturity = {
+  willMature: boolean;
   date: string;
   beneficiaries: Beneficiary[];
 };


### PR DESCRIPTION
Ticket(s): https://app.clickup.com/t/862jnnktv

since maturity date is to be set as `optional`, maturity whitelist should not be inputted anymore (hidden when no maturity is set)

## Explanation of the solution
* add `maturity` toggle 
<img width="408" alt="image" src="https://user-images.githubusercontent.com/89639563/234278801-8115ff86-5946-4a62-9799-39890cf56bd2.png">

where toggling shows maturity related fields
<img width="715" alt="image" src="https://user-images.githubusercontent.com/89639563/234279054-1cda3cca-fc1c-43fe-a984-fef32423742d.png">

* if user didn't set maturity - show info in summary
<img width="744" alt="image" src="https://user-images.githubusercontent.com/89639563/234279348-1eaa7649-3541-4063-b97c-03e19c715d12.png">


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes