### PR TITLE
V1.8 strategies - preliminary work & balances placeholders

### DIFF
--- a/src/pages/Admin/Charity/Invest/Investor/AccountOptions.tsx
+++ b/src/pages/Admin/Charity/Invest/Investor/AccountOptions.tsx
@@ -3,9 +3,13 @@ import { UseFormRegisterReturn, useFormContext } from "react-hook-form";
 import { FormValues } from "./types";
 import { AccountType } from "types/lists";
 import { humanize } from "helpers";
-import { TStrategy } from "../strats";
 
-type Props = Pick<TStrategy, "balances"> & { classes?: string };
+type UserBalances = {
+  locked: number;
+  liquid: number;
+};
+
+type Props = { balances: UserBalances; classes?: string };
 
 export default function AccountOptions({ balances, classes = "" }: Props) {
   const { register, watch, setValue, trigger, getFieldState } =

--- a/src/pages/Admin/Charity/Invest/Investor/Form.tsx
+++ b/src/pages/Admin/Charity/Invest/Investor/Form.tsx
@@ -1,21 +1,16 @@
 import { useFormContext } from "react-hook-form";
 import { FormValues as FV } from "./types";
+import { TStrategy } from "types/aws";
 import { useModalContext } from "contexts/ModalContext";
 import Icon from "components/Icon";
 import Modal from "components/Modal";
 import { LoadingStatus } from "components/Status";
 import TokenField from "components/TokenField";
-import { TStrategy } from "../strats";
 import AccountOptions from "./AccountOptions";
 import LockDuration from "./LockDuration";
 import useSubmit from "./useSubmit";
 
-export default function Form({
-  balances,
-  name,
-  description,
-  rating,
-}: TStrategy) {
+export default function Form({ name, description, rating }: TStrategy) {
   const { getValues, handleSubmit } = useFormContext<FV>();
   const { isSending } = useSubmit("13123", "liquid");
   const { closeModal } = useModalContext();
@@ -50,7 +45,7 @@ export default function Form({
         />
         <KeyValue title="Accepted Currency" value="USDC" />
       </div>
-      <AccountOptions balances={balances} classes="mx-8 mb-6" />
+      <AccountOptions balances={{ locked: 0, liquid: 0 }} classes="mx-8 mb-6" />
       <LockDuration classes="mx-8" />
       <TokenField<FV, "token">
         name="token"

--- a/src/pages/Admin/Charity/Invest/Investor/index.tsx
+++ b/src/pages/Admin/Charity/Invest/Investor/index.tsx
@@ -1,13 +1,16 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import { FormProvider, useForm } from "react-hook-form";
 import { FormValues } from "./types";
+import { TStrategy } from "types/aws";
 import { TokenWithAmount } from "types/slices";
-import { TStrategy } from "../strats";
 import Form from "./Form";
 import { schema } from "./schema";
 
 export default function Investor(props: TStrategy) {
-  const { balances } = props;
+  const balances = {
+    locked: 0,
+    liquid: 0,
+  };
   const token: TokenWithAmount = {
     approved: true,
     decimals: 6,

--- a/src/pages/Admin/Charity/Invest/Strategy.tsx
+++ b/src/pages/Admin/Charity/Invest/Strategy.tsx
@@ -1,13 +1,22 @@
 import { PropsWithChildren } from "react";
+import { TStrategy } from "types/aws";
 import { useModalContext } from "contexts/ModalContext";
 import ExtLink from "components/ExtLink";
 import Icon from "components/Icon";
 import { humanize } from "helpers";
 import Investor from "./Investor";
-import { TStrategy } from "./strats";
 
 export default function Strategy(props: TStrategy) {
-  const { name, invested, description, provider, type, rating, apy } = props;
+  const {
+    name,
+    market_cap,
+    description,
+    provider,
+    type,
+    rating,
+    apy,
+    website,
+  } = props;
   const { showModal } = useModalContext();
 
   return (
@@ -18,7 +27,7 @@ export default function Strategy(props: TStrategy) {
       </p>
       <div className="flex flex-col @lg:flex-row justify-between items-start @lg:items-center mx-6 mb-6">
         <ExtLink
-          href={provider.url}
+          href={website}
           className="text-sm text-gray-d1 dark:text-gray underline mb-5 @lg:mb-0"
         >
           {provider.name}
@@ -34,7 +43,7 @@ export default function Strategy(props: TStrategy) {
         <KeyVal title="APY" tooltip="some tooltip">
           {apy}%
         </KeyVal>
-        <KeyVal title="Current balance">{humanize(invested)} USD</KeyVal>
+        <KeyVal title="Market Cap">{humanize(market_cap)} USD</KeyVal>
         <button
           type="button"
           disabled={true}

--- a/src/pages/Admin/Charity/Invest/index.tsx
+++ b/src/pages/Admin/Charity/Invest/index.tsx
@@ -1,3 +1,4 @@
+import { TStrategy } from "types/aws";
 import Balances from "../common/Balances";
 import Strategy from "./Strategy";
 import { strategies } from "./strats";
@@ -13,7 +14,7 @@ export default function Invest() {
         Featured Strategies
       </h3>
       <div className="grid gap-3">
-        {strategies.map((strategy, idx) => (
+        {strategies.map((strategy: TStrategy, idx: number) => (
           <Strategy key={idx} {...strategy} />
         ))}
       </div>

--- a/src/pages/Admin/Charity/Invest/strats.ts
+++ b/src/pages/Admin/Charity/Invest/strats.ts
@@ -1,36 +1,28 @@
 /** strategies placeholder */
+import { TStrategy } from "types/aws";
 
-export type TStrategy = {
-  name: string;
-  description: string;
-  provider: { name: string; url: string };
-  rating: string; //"AAA";
-  type: string; // "Uncollateralized Lending";
-  apy: number; //5.2
-  invested: number; // locked + liquid total
-
-  //user balances to be used when investing
-  balances: {
-    locked: number;
-    liquid: number;
-  };
-};
-
-const userBalance: TStrategy["balances"] = { locked: 0, liquid: 0 };
-
-const strategy: TStrategy = {
-  name: "Goldfinch Senior Pool (Coming Soon)",
-  description:
-    "The Senior Pool is a pool of capital that is diversified across all Borrower Pools on the Goldfinch protocol. Liquidity Providers (LPs) who provide capital into the Senior Pool are capital providers in search of passive, diversified exposure across all Borrower Pools. This capital is protected by junior (first-loss) capital in each Borrower Pool.",
-  provider: {
-    name: "More information",
-    url: "https://app.goldfinch.finance/pools/senior",
+export const strategies: TStrategy[] = [
+  {
+    strategy_key: "0x00001",
+    chain_id: "80001",
+    apy: 7.8,
+    contract: "0x5A0801BAd20B6c62d86C566ca90688A6b9ea1d3f",
+    description:
+      "The Senior Pool is a pool of capital that is diversified across all Borrower Pools on the Goldfinch protocol. Liquidity Providers (LPs) who provide capital into the Senior Pool are capital providers in search of passive, diversified exposure across all Borrower Pools. This capital is protected by junior (first-loss) capital in each Borrower Pool.",
+    icon: "https://app.goldfinch.finance/favicon-32x32.png",
+    market_cap: 79350864,
+    name: "Goldfinch Senior Pool (Coming Soon)",
+    provider: {
+      icon: "https://app.goldfinch.finance/favicon-32x32.png",
+      name: "Goldfinch",
+      url: "https://goldfinch.finance/",
+    },
+    rating: "-",
+    type: "Uncollateralized Lending",
+    vaults: {
+      liquid: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+      locked: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+    },
+    website: "https://app.goldfinch.finance/pools/senior",
   },
-  rating: "-",
-  type: "Uncollateralized Lending",
-  apy: 7.8,
-  invested: 0,
-  balances: userBalance,
-};
-
-export const strategies: TStrategy[] = Array(1).fill(strategy);
+];

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -139,6 +139,22 @@ export interface LeaderboardEntry {
   //charity_owner:string
 }
 
+export type TStrategy = {
+  strategy_key: string;
+  chain_id: string;
+  apy: number; // 5.2
+  contract: string;
+  description: string;
+  icon: string;
+  market_cap: number; // 100,024,000 USD
+  name: string;
+  provider: { name: string; url: string; icon: string };
+  rating: string; // "AAA";
+  type: string; // "Uncollateralized Lending";
+  vaults: { locked: string; liquid: string };
+  website: string;
+};
+
 export interface Update {
   endowments: LeaderboardEntry[];
   last_update: string;


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/865c5xnmf (contributes to it only)

## Explanation of the solution
- Moves `TStrategy` type into AWS Types
- Updates the example strategies object to reflect the latest structure of the AWS `strategies` DB object shape returned. See: `src/pages/Admin/Charity/Invest/strats.ts`
- Adds placeholder / temp code to show zero balances for User's strategy balances, as **this is not held in AWS**. Endowment strategy balance information will need to be queried on-chain from the `TStrategy.vaults.<locked | liquid>` contract addresses.

See the `devops` repo PR for more info: https://github.com/AngelProtocolFinance/devops/pull/257

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- visit admin `/admin/21` & go to "Invest Dashboard" page

## UI changes for review
![invest-dash](https://user-images.githubusercontent.com/85138450/234466403-2ac7b7d5-6450-4c4f-bc56-7f6e51259fee.png)
