### PR TITLE
Proposal threshold n/m format

### DIFF
--- a/src/pages/Launchpad/Management/DurationForm.tsx
+++ b/src/pages/Launchpad/Management/DurationForm.tsx
@@ -1,0 +1,53 @@
+import { yupResolver } from "@hookform/resolvers/yup";
+import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import { object } from "yup";
+import { SchemaShape } from "schemas/types";
+import { useModalContext } from "contexts/ModalContext";
+import Modal from "components/Modal";
+import { Field } from "components/form";
+import { requiredPositiveNumber } from "schemas/number";
+
+export type Props = {
+  initial: string;
+  onChange(duration: string): void;
+};
+
+type FV = { duration: string };
+
+export default function DurationForm({ onChange, initial }: Props) {
+  const { closeModal } = useModalContext();
+  const methods = useForm<FV>({
+    defaultValues: { duration: initial },
+    resolver: yupResolver(
+      object().shape<SchemaShape<FV>>({
+        duration: requiredPositiveNumber,
+      })
+    ),
+  });
+  const { handleSubmit } = methods;
+
+  const submit: SubmitHandler<FV> = ({ duration }) => {
+    onChange(duration);
+    closeModal();
+  };
+
+  return (
+    <Modal
+      onSubmit={handleSubmit(submit)}
+      as="form"
+      className="p-6 fixed-center z-10 grid gap-4 text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
+    >
+      <FormProvider {...methods}>
+        <Field<FV>
+          name="duration"
+          label="Duration (hours)"
+          classes={{ container: "mt-8 mb-4" }}
+          required
+        />
+      </FormProvider>
+      <button type="submit" className="btn btn-orange mt-6">
+        Submit
+      </button>
+    </Modal>
+  );
+}

--- a/src/pages/Launchpad/Management/Form.tsx
+++ b/src/pages/Launchpad/Management/Form.tsx
@@ -1,11 +1,10 @@
-import { useEffect } from "react";
+import { PropsWithChildren, useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 import { FV } from "./types";
 import { useModalContext } from "contexts/ModalContext";
-import { Field } from "components/form";
 import Form, { Desc, FormProps, Title } from "../common/Form";
 import NavButtons from "../common/NavButtons";
-import Toggle from "../common/Toggle";
+import DurationForm from "./DurationForm";
 import Members from "./Members";
 import ThresholdForm from "./ThresholdForm";
 
@@ -14,14 +13,14 @@ export default function ManageForm(props: FormProps) {
   const { showModal } = useModalContext();
 
   const members = watch("members");
-  const threshold = watch("proposal.threshold");
+  const { duration, threshold, isAutoExecute } = watch("proposal");
 
   /** watch for members and adjust threshold accordingly */
   useEffect(() => {
     const n = members.length || 1;
     const threshold = getValues("proposal.threshold");
     if (n < +threshold) setValue("proposal.threshold", n);
-  }, [members]);
+  }, [members, getValues, setValue]);
 
   return (
     <Form {...props}>
@@ -36,45 +35,72 @@ export default function ManageForm(props: FormProps) {
       <Members classes="mb-8" />
 
       <div className="content-start border border-prim p-4 md:p-8 rounded">
-        <h2 className="font-bold text-center sm:text-left text-xl mb-2">
+        <h2 className="font-bold text-center sm:text-left text-xl mb-8">
           Proposal settings
         </h2>
-        <div className="border border-prim rounded px-4">
-          <div className="flex items-center py-3">
+        <div className="border border-prim rounded divide-y divide-prim">
+          <Container
+            onBtnClick={() =>
+              showModal(ThresholdForm, {
+                added: getValues("members").map((m) => m),
+                initial: threshold,
+                onChange: (v) => setValue("proposal.threshold", v),
+              })
+            }
+          >
             <p>
-              Proposals can be executed when {threshold} out{" "}
-              {members.length || 1} members cast their vote.
+              Proposals can be executed when <Bold>{threshold}</Bold> out{" "}
+              <Bold>{members.length || 1}</Bold> members cast their vote.
             </p>
-            <button
-              type="button"
-              className="btn-outline-filled px-8 py-2 text-sm"
-              onClick={() =>
-                showModal(ThresholdForm, {
-                  added: getValues("members").map((m) => m),
-                  initial: threshold,
-                  onChange: (v) => setValue("proposal.threshold", v),
-                })
-              }
-            >
-              change
-            </button>
-          </div>
+          </Container>
+          <Container
+            onBtnClick={() =>
+              showModal(DurationForm, {
+                initial: duration,
+                onChange: (v) => setValue("proposal.duration", v),
+              })
+            }
+          >
+            <p>
+              Proposals duration is <Bold>{duration}</Bold> hour
+              {+duration > 1 ? "s" : ""}.
+            </p>
+          </Container>
+          <Container
+            onBtnClick={() => {
+              const prev = getValues("proposal.isAutoExecute");
+              setValue("proposal.isAutoExecute", !prev);
+            }}
+          >
+            <p>
+              Proposals auto-execution is turned{" "}
+              <Bold>{isAutoExecute ? "ON" : "OFF"}</Bold>.
+            </p>
+          </Container>
         </div>
-        <Field<FV>
-          name="proposal.duration"
-          label="Duration ( hours )"
-          classes={{ container: "mt-8 mb-6" }}
-          required
-        />
-        <Toggle<FV>
-          name="proposal.isAutoExecute"
-          classes={{ container: "mb-4 text-sm" }}
-        >
-          Auto execute after passing vote
-        </Toggle>
       </div>
 
       <NavButtons classes="mt-8" curr={2} />
     </Form>
   );
 }
+
+const Container = ({
+  children,
+  onBtnClick,
+}: PropsWithChildren<{ onBtnClick(): void }>) => (
+  <div className="flex items-center py-3 px-4 justify-between">
+    {children}
+    <button
+      type="button"
+      className="btn-outline-filled px-8 py-2 text-sm"
+      onClick={onBtnClick}
+    >
+      change
+    </button>
+  </div>
+);
+
+const Bold = ({ children }: PropsWithChildren) => (
+  <span className="font-bold">{children}</span>
+);

--- a/src/pages/Launchpad/Management/Form.tsx
+++ b/src/pages/Launchpad/Management/Form.tsx
@@ -36,7 +36,7 @@ export default function ManageForm(props: FormProps) {
 
       <div className="content-start border border-prim p-4 md:p-8 rounded">
         <h2 className="font-bold text-center sm:text-left text-xl mb-8">
-          Proposal settings
+          Settings
         </h2>
         <div className="border border-prim rounded divide-y divide-prim">
           <Container

--- a/src/pages/Launchpad/Management/Form.tsx
+++ b/src/pages/Launchpad/Management/Form.tsx
@@ -50,7 +50,7 @@ export default function ManageForm(props: FormProps) {
               className="btn-outline-filled px-8 py-2 text-sm"
               onClick={() =>
                 showModal(ThresholdForm, {
-                  added: getValues("members").map((m) => m.addr),
+                  added: getValues("members").map((m) => m),
                   initial: threshold,
                   onChange: (v) => setValue("proposal.threshold", v),
                 })

--- a/src/pages/Launchpad/Management/Form.tsx
+++ b/src/pages/Launchpad/Management/Form.tsx
@@ -1,11 +1,28 @@
+import { PropsWithChildren, ReactNode, useEffect } from "react";
+import { useFormContext } from "react-hook-form";
 import { FV } from "./types";
+import { useModalContext } from "contexts/ModalContext";
 import { Field } from "components/form";
 import Form, { Desc, FormProps, Title } from "../common/Form";
 import NavButtons from "../common/NavButtons";
 import Toggle from "../common/Toggle";
 import Members from "./Members";
+import ThresholdForm from "./ThresholdForm";
 
 export default function ManageForm(props: FormProps) {
+  const { setValue, getValues, watch } = useFormContext<FV>();
+  const { showModal } = useModalContext();
+
+  const members = watch("members");
+  const threshold = watch("proposal.threshold");
+
+  /** watch for members and adjust threshold accordingly */
+  useEffect(() => {
+    const n = members.length;
+    const threshold = getValues("proposal.threshold");
+    if (n < +threshold) setValue("proposal.threshold", n);
+  }, [members]);
+
   return (
     <Form {...props}>
       <Title className="mb-2">AST Management</Title>
@@ -22,6 +39,27 @@ export default function ManageForm(props: FormProps) {
         <h2 className="font-bold text-center sm:text-left text-xl mb-2">
           Proposal settings
         </h2>
+        <div className="border border-prim rounded px-4">
+          <div className="flex items-center py-3">
+            <p>
+              Proposals can be executed when {threshold} out {members.length}{" "}
+              members cast their vote.
+            </p>
+            <button
+              type="button"
+              className="btn-outline-filled px-8 py-2 text-sm"
+              onClick={() =>
+                showModal(ThresholdForm, {
+                  added: getValues("members").map((m) => m.addr),
+                  initial: threshold,
+                  onChange: (v) => setValue("proposal.threshold", v),
+                })
+              }
+            >
+              change
+            </button>
+          </div>
+        </div>
         <Field<FV>
           name="proposal.threshold"
           label="Pass threshold ( % )"

--- a/src/pages/Launchpad/Management/Form.tsx
+++ b/src/pages/Launchpad/Management/Form.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactNode, useEffect } from "react";
+import { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 import { FV } from "./types";
 import { useModalContext } from "contexts/ModalContext";
@@ -18,7 +18,7 @@ export default function ManageForm(props: FormProps) {
 
   /** watch for members and adjust threshold accordingly */
   useEffect(() => {
-    const n = members.length;
+    const n = members.length || 1;
     const threshold = getValues("proposal.threshold");
     if (n < +threshold) setValue("proposal.threshold", n);
   }, [members]);
@@ -42,8 +42,8 @@ export default function ManageForm(props: FormProps) {
         <div className="border border-prim rounded px-4">
           <div className="flex items-center py-3">
             <p>
-              Proposals can be executed when {threshold} out {members.length}{" "}
-              members cast their vote.
+              Proposals can be executed when {threshold} out{" "}
+              {members.length || 1} members cast their vote.
             </p>
             <button
               type="button"
@@ -60,12 +60,6 @@ export default function ManageForm(props: FormProps) {
             </button>
           </div>
         </div>
-        <Field<FV>
-          name="proposal.threshold"
-          label="Pass threshold ( % )"
-          classes={{ container: "mt-8 mb-4" }}
-          required
-        />
         <Field<FV>
           name="proposal.duration"
           label="Duration ( hours )"

--- a/src/pages/Launchpad/Management/Form.tsx
+++ b/src/pages/Launchpad/Management/Form.tsx
@@ -38,7 +38,7 @@ export default function ManageForm(props: FormProps) {
         <h2 className="font-bold text-center sm:text-left text-xl mb-8">
           Settings
         </h2>
-        <div className="border border-prim rounded divide-y divide-prim">
+        <div className="@container border border-prim rounded divide-y divide-prim">
           <Container
             onBtnClick={() =>
               showModal(ThresholdForm, {
@@ -89,11 +89,11 @@ const Container = ({
   children,
   onBtnClick,
 }: PropsWithChildren<{ onBtnClick(): void }>) => (
-  <div className="flex items-center py-3 px-4 justify-between">
+  <div className="grid @lg:flex @lg:items-center py-3 px-4 @lg:justify-between">
     {children}
     <button
       type="button"
-      className="btn-outline-filled px-8 py-2 text-sm"
+      className="btn-outline-filled px-8 py-2 text-sm mt-4 @lg:mt-0"
       onClick={onBtnClick}
     >
       change

--- a/src/pages/Launchpad/Management/MemberForm.tsx
+++ b/src/pages/Launchpad/Management/MemberForm.tsx
@@ -2,41 +2,38 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { object } from "yup";
 import { SchemaShape } from "schemas/types";
-import { Member } from "slices/launchpad/types";
 import { useModalContext } from "contexts/ModalContext";
 import Modal from "components/Modal";
 import { Field } from "components/form";
-import { requiredPositiveNumber } from "schemas/number";
 import { requiredWalletAddr } from "schemas/string";
 import { chainIds } from "constants/chainIds";
 
 export type Props = {
-  initial?: Member;
+  initial?: string;
   added: string[];
-  onChange(member: Member): void;
+  onChange(member: string): void;
 };
 
-type FV = Member;
+type FV = { addr: string };
 
 export default function MemberForm({ onChange, added, initial }: Props) {
   const { closeModal } = useModalContext();
   const isEdit = initial !== undefined;
   const methods = useForm<FV>({
-    defaultValues: initial || { addr: "", weight: "1" },
+    defaultValues: initial ? { addr: initial } : { addr: "" },
     resolver: yupResolver(
       object().shape<SchemaShape<FV>>({
         addr: requiredWalletAddr(chainIds.polygon).notOneOf(
           initial ? [] : added,
           "address already added"
         ),
-        weight: requiredPositiveNumber,
       })
     ),
   });
   const { handleSubmit } = methods;
 
   const submit: SubmitHandler<FV> = (data) => {
-    onChange(data);
+    onChange(data.addr);
     closeModal();
   };
 
@@ -47,8 +44,12 @@ export default function MemberForm({ onChange, added, initial }: Props) {
       className="p-6 fixed-center z-10 grid gap-4 text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
     >
       <FormProvider {...methods}>
-        <Field name="addr" label="Member address" required disabled={isEdit} />
-        <Field name="weight" label="Member weight" required />
+        <Field<FV>
+          name="addr"
+          label="Member address"
+          required
+          disabled={isEdit}
+        />
       </FormProvider>
       <button type="submit" className="btn btn-orange mt-6">
         Add member

--- a/src/pages/Launchpad/Management/Members.tsx
+++ b/src/pages/Launchpad/Management/Members.tsx
@@ -1,6 +1,5 @@
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { FV } from "./types";
-import { Member } from "slices/launchpad/types";
 import { useModalContext } from "contexts/ModalContext";
 import Icon from "components/Icon";
 import TableSection, { Cells } from "components/TableSection";
@@ -11,27 +10,18 @@ import MemberForm from "./MemberForm";
 
 const name: keyof FV = "members";
 
-type MemberItem = Member & { idx: number };
-
 export default function Members({ classes = "" }) {
   const { showModal } = useModalContext();
   const { getValues } = useFormContext<FV>();
-  const { fields, append, remove, update } = useFieldArray({
+  const { fields, append, remove } = useFieldArray({
     name,
   });
 
-  async function handleAdd(member: Member) {
+  async function handleAdd(member: string) {
     append(member);
   }
   async function handleRemove(index: number) {
     remove(index);
-  }
-  async function handleEdit(member: MemberItem) {
-    showModal(MemberForm, {
-      onChange: (m) => update(member.idx, m),
-      initial: member,
-      added: getValues("members").map((m) => m.addr),
-    });
   }
 
   return (
@@ -42,7 +32,7 @@ export default function Members({ classes = "" }) {
         onClick={() =>
           showModal(MemberForm, {
             onChange: handleAdd,
-            added: getValues("members").map((m) => m.addr),
+            added: getValues("members").map((m) => m),
           })
         }
         className="btn-outline-filled sm:justify-self-end text-sm py-3 px-8 gap-3 mb-5"
@@ -63,7 +53,6 @@ export default function Members({ classes = "" }) {
           >
             <Cells type="th" cellClass="text-xs uppercase text-left py-3 px-4">
               <>member</>
-              <>Vote weight</>
               <></>
             </Cells>
           </TableSection>
@@ -72,12 +61,7 @@ export default function Members({ classes = "" }) {
             rowClass="border-b border-prim last:border-none even:bg-orange-l6 even:dark:bg-blue-d7"
           >
             {fields.map((field, idx) => (
-              <Row
-                key={field.id}
-                idx={idx}
-                onRemove={handleRemove}
-                onEdit={handleEdit}
-              />
+              <Row key={field.id} idx={idx} onRemove={handleRemove} />
             ))}
           </TableSection>
         </table>
@@ -89,27 +73,14 @@ export default function Members({ classes = "" }) {
 type Props = {
   idx: number;
   onRemove(idx: number): void;
-  onEdit(member: MemberItem): void;
 };
 
-function Row({ idx, onRemove, onEdit }: Props) {
+function Row({ idx, onRemove }: Props) {
   const { getValues } = useFormContext<FV>();
   const member = getValues(`members.${idx}`);
-  const { addr, weight } = member;
   return (
     <Cells type="td" cellClass="py-3 px-4 text-sm">
-      <div className="truncate w-[4.8rem] sm:w-28 md:w-full">{addr}</div>
-      <td className="font-work">
-        {weight}{" "}
-        <button
-          onClick={() => onEdit({ ...member, idx })}
-          type="button"
-          className="inline-block underline"
-        >
-          (change)
-        </button>
-      </td>
-
+      <div className="truncate w-[4.8rem] sm:w-28 md:w-full">{member}</div>
       <td className="w-14 h-full relative">
         <button
           className="text-center absolute-center"

--- a/src/pages/Launchpad/Management/ThresholdForm.tsx
+++ b/src/pages/Launchpad/Management/ThresholdForm.tsx
@@ -24,7 +24,8 @@ export default function ThresholdForm({ onChange, added, initial }: Props) {
           .typeError("required")
           .integer("no decimals")
           .min(1, "at least 1")
-          .max(added.length, "can't be more than number of members"),
+          //if no members set, default to 1
+          .max(added.length || 1, "can't be more than number of members"),
       })
     ),
   });

--- a/src/pages/Launchpad/Management/index.tsx
+++ b/src/pages/Launchpad/Management/index.tsx
@@ -6,7 +6,7 @@ import { SchemaShape } from "schemas/types";
 import { useGetWallet } from "contexts/WalletContext";
 import { useLaunchpad } from "slices/launchpad";
 import { requiredPercent, requiredPositiveNumber } from "schemas/number";
-import { isJunoAddress } from "schemas/tests";
+import { isEthereumAddress } from "schemas/tests";
 import { withStepGuard } from "../withStepGuard";
 import Form from "./Form";
 
@@ -25,8 +25,8 @@ export default withStepGuard<2>(function Management({ data }) {
     ),
     defaultValues: data || {
       members:
-        wallet?.address && isJunoAddress(wallet.address)
-          ? [{ addr: wallet.address, weight: "1" }]
+        wallet?.address && isEthereumAddress(wallet.address)
+          ? [wallet.address]
           : [],
 
       proposal: {

--- a/src/pages/Launchpad/Management/index.tsx
+++ b/src/pages/Launchpad/Management/index.tsx
@@ -31,7 +31,7 @@ export default withStepGuard<2>(function Management({ data }) {
 
       proposal: {
         duration: "",
-        threshold: "",
+        threshold: 1,
         isAutoExecute: true,
       },
     },

--- a/src/pages/Launchpad/Management/index.tsx
+++ b/src/pages/Launchpad/Management/index.tsx
@@ -1,11 +1,7 @@
-import { yupResolver } from "@hookform/resolvers/yup";
 import { FormProvider, useForm } from "react-hook-form";
-import { object } from "yup";
 import { FV } from "./types";
-import { SchemaShape } from "schemas/types";
 import { useGetWallet } from "contexts/WalletContext";
 import { useLaunchpad } from "slices/launchpad";
-import { requiredPercent, requiredPositiveNumber } from "schemas/number";
 import { isEthereumAddress } from "schemas/tests";
 import { withStepGuard } from "../withStepGuard";
 import Form from "./Form";
@@ -15,14 +11,6 @@ export default withStepGuard<2>(function Management({ data }) {
   const { wallet } = useGetWallet();
 
   const methods = useForm<FV>({
-    resolver: yupResolver(
-      object().shape<SchemaShape<FV>>({
-        proposal: object().shape<SchemaShape<FV["proposal"]>>({
-          duration: requiredPositiveNumber,
-          threshold: requiredPercent,
-        }),
-      })
-    ),
     defaultValues: data || {
       members:
         wallet?.address && isEthereumAddress(wallet.address)

--- a/src/pages/Launchpad/Summary/Management.tsx
+++ b/src/pages/Launchpad/Summary/Management.tsx
@@ -8,7 +8,7 @@ export default function Management({
   proposal,
   ...props
 }: SectionProps<TManagement>) {
-  const _members = members.map((m) => <li key={m.addr}>{m.addr}</li>);
+  const _members = members.map((m) => <li key={m}>{m}</li>);
 
   return (
     <Section {...props}>

--- a/src/pages/Launchpad/Summary/Management.tsx
+++ b/src/pages/Launchpad/Summary/Management.tsx
@@ -20,19 +20,21 @@ export default function Management({
       ) : (
         <ul className="list-disc list-inside grid gap-y-2">{_members}</ul>
       )}
-      <p className="font-semibold mt-6 mb-2">Proposal settings:</p>
+      <p className="font-semibold mt-6 mb-2">Settings:</p>
 
       <ul className="list-disc list-inside grid gap-y-2">
         <li>
-          Pass threshold is{" "}
-          <span className="font-semibold">{proposal.threshold} %</span>
+          Proposals can be executed when{" "}
+          <span className="font-semibold">{proposal.threshold}</span> out of{" "}
+          {<span className="font-semibold">{members.length || 1}</span>} members
+          cast their vote.
         </li>
         <li>
-          Voting duration is{" "}
+          Proposals duration is{" "}
           <span className="font-semibold">{proposal.duration}</span> hours
         </li>
         <li>
-          Proposal auto-execution is turned{" "}
+          Proposals auto-execution is turned{" "}
           <span className="font-semibold">
             {proposal.isAutoExecute ? "ON" : "OFF"}
           </span>

--- a/src/schemas/number.ts
+++ b/src/schemas/number.ts
@@ -32,7 +32,7 @@ export const tokenAmountString = Yup.lazy((value) =>
     : tokenConstraint
 );
 
-function lazyNumber(constraint: any, isRequired?: true) {
+export function lazyNumber(constraint: any, isRequired?: true) {
   return Yup.lazy((value) => {
     if (value === "") {
       return isRequired ? Yup.string().required("required") : Yup.string();

--- a/src/slices/launchpad/types.ts
+++ b/src/slices/launchpad/types.ts
@@ -1,8 +1,7 @@
 /** Types primed to be for form usage */
-export type Member = { addr: string; weight: string };
 export type TAbout = { name: string; tagline: string };
 export type TManagement = {
-  members: Member[];
+  members: string[];
   //proposal config defaulted to percentage
   proposal: {
     threshold: number; // integer

--- a/src/slices/launchpad/types.ts
+++ b/src/slices/launchpad/types.ts
@@ -5,7 +5,7 @@ export type TManagement = {
   members: Member[];
   //proposal config defaulted to percentage
   proposal: {
-    threshold: string; // "1" - "100"
+    threshold: number; // integer
     duration: string; // in hours
     isAutoExecute: boolean;
   };


### PR DESCRIPTION
Ticket(s): 
- https://app.clickup.com/t/865c6pgd3

pending 
https://app.clickup.com/t/865c7ezn9

## Explanation of the solution
* change management settings look
<img width="728" alt="image" src="https://user-images.githubusercontent.com/89639563/234804943-5ee33417-4d92-4a65-b23f-67907e83c085.png">

* clicking change opens form to change value 
<img width="785" alt="image" src="https://user-images.githubusercontent.com/89639563/234805029-f1fba743-890a-4409-a45e-6d53b7bdfa16.png">



### Others
* convert `type {addr: string, weight:number}` to just `string` since there's no `weight` in polygon multisig
* 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes