### PR TITLE
Fix error parsing registration

### DIFF
--- a/src/helpers/registration/handleMutationResult.ts
+++ b/src/helpers/registration/handleMutationResult.ts
@@ -22,7 +22,7 @@ export function handleMutationResult<T extends any>(
       const d: any = result.error.data;
       if (typeof d === "string") {
         onError(d);
-      } else if ("message" in d) {
+      } else if (withMsg(d)) {
         onError(d.message);
 
         /** update with other aws error formats */
@@ -43,4 +43,8 @@ function isServerError(
   error: FetchBaseQueryError
 ): error is { data: any; status: number } {
   return "status" in error && typeof error.status === "number" && !!error.data;
+}
+
+function withMsg(val: unknown): val is { message: string } {
+  return typeof val === "object" && val !== null && "message" in val;
 }


### PR DESCRIPTION
Ticket(s):
part of https://app.clickup.com/t/863gnc9kh

trying to find `message` in `val` that may not be of format `{ message?:string }` (maybe `null`) 
<img width="738" alt="image" src="https://user-images.githubusercontent.com/89639563/236112757-53214401-ceb8-44ce-849d-0d919b757d1b.png">
## Explanation of the solution
check first if some `val` is object before using `in` operator




## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes