### PR TITLE
Balances may be absent for new ASTs

### DIFF
--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
@@ -6,9 +6,9 @@ export default function Balances() {
 
   return (
     <div className="flex flex-col items-center gap-4 w-full">
-      <Balance title="Total Value" amount={on_hand_overall} />
-      <Balance title="Total Endowment Account" amount={on_hand_lock} />
-      <Balance title="Total Current Account" amount={on_hand_liq} />
+      <Balance title="Total Value" amount={on_hand_overall || 0} />
+      <Balance title="Total Endowment Account" amount={on_hand_lock || 0} />
+      <Balance title="Total Current Account" amount={on_hand_liq || 0} />
     </div>
   );
 }

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -62,7 +62,7 @@ export type ASTProfile = Pick<EndowmentProfile,
   | typeof _npo_type 
   | typeof _categories
   >>
-  & EndowmentBalances
+  & Partial<EndowmentBalances>
 
 export type EndowmentCard = EndowmentBase & {
   endow_type: EndowmentType;


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/860qqqxyp

visiting a new AST crashes as web app is expecting balances field - may not be scraped yet

## Explanation of the solution
* make balances field `partial` for ASTs
* fix typescript errors

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes