### PR TITLE
AST launchpad Split fixes

### DIFF
--- a/src/pages/Launchpad/Splits/Form/index.tsx
+++ b/src/pages/Launchpad/Splits/Form/index.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useEffect } from "react";
+import { PropsWithChildren } from "react";
 import { useFormContext } from "react-hook-form";
 import { FV } from "../types";
 import Form, {
@@ -16,14 +16,6 @@ export default function SplitsForm(props: FormProps) {
   const { watch, resetField } = useFormContext<FV>();
   const isCustom = watch("isCustom");
 
-  useEffect(() => {
-    if (!isCustom) {
-      resetField("default", { defaultValue: "50" }); //reset to these defaults - since persisted value is used as default value
-      resetField("min", { defaultValue: "0" });
-      resetField("max", { defaultValue: "100" });
-    }
-  }, [isCustom, resetField]);
-
   return (
     <Form {...props}>
       <Title className="mb-2">Split of Contributions</Title>
@@ -33,7 +25,17 @@ export default function SplitsForm(props: FormProps) {
         between your Locked account and your Liquid account. You can deactivate
         that to default to a value that you set or set minimum & maximum values.
       </Desc>
-      <Toggle<FV> name="isCustom" classes={{ container: "my-9 text-sm" }}>
+      <Toggle<FV>
+        name="isCustom"
+        classes={{ container: "my-9 text-sm" }}
+        onChange={(isCustom) => {
+          if (!isCustom) {
+            //reset to these defaults - since persisted value is used as default value
+            resetField("min", { defaultValue: "0" });
+            resetField("max", { defaultValue: "100" });
+          }
+        }}
+      >
         Allow contributors to define a Locked/Liquid Split
       </Toggle>
 
@@ -47,7 +49,6 @@ export default function SplitsForm(props: FormProps) {
           names={{ min: "defaultMin", max: "default" }}
           hidden="max"
           hideLabels
-          disabled={!isCustom}
         >
           {(min, max, disabled) => (
             <div className="flex justify-between text-sm">

--- a/src/pages/Launchpad/Splits/index.tsx
+++ b/src/pages/Launchpad/Splits/index.tsx
@@ -6,16 +6,19 @@ import Form from "./Form";
 
 export default withStepGuard<5>(function Splits({ data }) {
   const { update } = useLaunchpad(5);
-  const methods = useForm<FV>({
-    defaultValues: data || {
-      isCustom: false,
-      //set max diff so user see how UI is used
-      min: "0",
-      max: "100",
 
-      default: "50",
-      defaultMin: "0",
-    },
+  const methods = useForm<FV>({
+    defaultValues: data
+      ? { ...data, defaultMin: "0" }
+      : {
+          isCustom: false,
+          //set max diff so user see how UI is used
+          min: "0",
+          max: "100",
+
+          default: "50",
+          defaultMin: "0",
+        },
   });
 
   const { handleSubmit } = methods;

--- a/src/pages/Launchpad/Summary/toEVMAST.ts
+++ b/src/pages/Launchpad/Summary/toEVMAST.ts
@@ -12,7 +12,7 @@ export default function toEVMAST(
     2: management,
     3: whitelists,
     4: maturity,
-    5: splits,
+    5: splits, //locked
     6: fees,
   }: Completed,
   creator: string
@@ -50,9 +50,10 @@ export default function toEVMAST(
     whitelistedBeneficiaries: whitelists.beneficiaries,
     whitelistedContributors: whitelists.contributors,
 
-    splitMax: +splits.max,
-    splitMin: +splits.min,
-    splitDefault: +splits.default,
+    //not used in contract
+    splitMax: 100 - +splits.max,
+    splitMin: 100 - +splits.min,
+    splitDefault: 100 - +splits.default,
 
     // //fees
     earningsFee: toEndowFee(fees.earnings),
@@ -121,11 +122,11 @@ export default function toEVMAST(
     // settingsController: SettingsController; //not included in launchpad, for edit later
     parent: 0,
     maturityWhitelist: maturity.beneficiaries.map((b) => b.addr),
-    ignoreUserSplits: false,
+    ignoreUserSplits: !splits.isCustom,
     splitToLiquid: {
-      min: 0,
-      max: 100,
-      defaultSplit: 50,
+      min: 100 - +splits.max,
+      max: 100 - +splits.min,
+      defaultSplit: 100 - +splits.default,
     },
 
     // referral_id: fees.referral_id || 0, //TODO: add on later ver of contracts

--- a/src/pages/Launchpad/common/Toggle.tsx
+++ b/src/pages/Launchpad/common/Toggle.tsx
@@ -15,6 +15,7 @@ type Props<T extends FV> = PropsWithChildren<{
   classes?: Classes;
   disabled?: boolean;
   required?: boolean;
+  onChange?(value: boolean): void;
 }>;
 
 export default function Toggle<T extends FV>({
@@ -23,6 +24,7 @@ export default function Toggle<T extends FV>({
   disabled,
   required,
   classes,
+  onChange: onChangeProp,
 }: Props<T>) {
   const {
     formState: { isSubmitting, errors },
@@ -44,7 +46,10 @@ export default function Toggle<T extends FV>({
         <Switch
           disabled={disabled || isSubmitting}
           checked={value}
-          onChange={onChange}
+          onChange={(val) => {
+            onChange(val);
+            onChangeProp?.(val);
+          }}
           className="border border-prim peer relative inline-flex h-8 w-14 items-center rounded-full transition-colors"
         >
           <span


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/860qqrabe

## Explanation of the solution
* always enable default slider
<img width="848" alt="image" src="https://user-images.githubusercontent.com/89639563/236119323-9ec9dfbf-0be4-4771-a5f1-d0d7134d0f48.png">

* map split data on used (instantiated with `AccountStorage.Endowment({})`)
* use `liquid` split instead of `locked` split in `type NewAST`

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes