### PR TITLE
File size to 6Mb

### DIFF
--- a/src/pages/Registration/Steps/Documentation/schema.ts
+++ b/src/pages/Registration/Steps/Documentation/schema.ts
@@ -9,7 +9,7 @@ import { genFileSchema } from "schemas/file";
 import { requiredString, url } from "schemas/string";
 import { MAX_SDGS } from "constants/unsdgs";
 
-export const MB_LIMIT = 25;
+export const MB_LIMIT = 6;
 const BYTES_IN_MB = 1e6;
 
 const VALID_MIME_TYPES = [


### PR DESCRIPTION
Ticket(s):

ISSUE: 
> The error from the screenshot here is 413 which indicates that the request payload exceeded the payload limit set by the server. In our case, the server is API Gateway which implements a 10 MB payload limit (https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#http-api-quotas). This is the reason why we can't upload files > 10 MB.

## Explanation of the solution
- update schema 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes