### PR TITLE
Create index fund: single type for form and tx-submission

### DIFF
--- a/src/contracts/createTx/types.ts
+++ b/src/contracts/createTx/types.ts
@@ -1,4 +1,5 @@
 import {
+  NewFund,
   RegistrarConfigPayload,
   SettingsControllerUpdate,
 } from "types/contracts";
@@ -51,15 +52,7 @@ type Txs = {
     fundingGoal: number;
   }>;
   "index-fund.update-owner": Tx<{ newOwner: string }>;
-  "index-fund.create-fund": Tx<{
-    name: string;
-    description: string;
-    members: number[];
-    rotatingFund: boolean;
-    splitToLiquid: number;
-    expiryTime: number;
-    expiryHeight: number;
-  }>;
+  "index-fund.create-fund": Tx<NewFund>;
   "index-fund.remove-fund": Tx<{ id: number }>;
   "index-fund.remove-member": Tx<{ id: number }>;
   "index-fund.update-members": Tx<{

--- a/src/pages/Admin/Core/Templates/index-fund/CreateFund/Form.tsx
+++ b/src/pages/Admin/Core/Templates/index-fund/CreateFund/Form.tsx
@@ -34,18 +34,18 @@ export default function Form() {
       <Field<FV>
         classes="field-admin"
         label="Expiry height"
-        name="expiry.height"
+        name="expiryHeight"
         placeholder="700992312"
       />
       <Field<FV, "datetime-local">
         classes="field-admin"
         type="datetime-local"
         label="Expiry time"
-        name="expiry.time"
+        name="expiryTime"
       />
       <Slider />
       <CheckField<FV>
-        name="isRotating"
+        name="rotatingFund"
         classes="p-3 text-sm rounded bg-orange-l6 dark:bg-blue-d7 border border-prim"
       >
         Included on fund rotation
@@ -62,10 +62,10 @@ export default function Form() {
 
 function Slider() {
   const { register, watch, setValue } = useFormContext<FV>();
-  const splitToLiq = watch("liqSplit");
+  const splitToLiq = watch("splitToLiquid");
 
   function unspecifySplit() {
-    setValue("liqSplit", INIT_SPLIT);
+    setValue("splitToLiquid", INIT_SPLIT);
   }
 
   return (
@@ -81,7 +81,7 @@ function Slider() {
       </Label>
       <div className="rounded bg-orange-l6 dark:bg-blue-d7 grid items-center px-4 py-6 border border-prim">
         <input
-          {...register("liqSplit")}
+          {...register("splitToLiquid")}
           type="range"
           className="range"
           min="0"

--- a/src/pages/Admin/Core/Templates/index-fund/CreateFund/index.tsx
+++ b/src/pages/Admin/Core/Templates/index-fund/CreateFund/index.tsx
@@ -30,12 +30,10 @@ function FundContext(props: { height: string }) {
     mode: "onChange",
     reValidateMode: "onChange",
     defaultValues: {
-      liqSplit: INIT_SPLIT,
-      isRotating: false,
-      expiry: {
-        height: props.height,
-        time: "",
-      },
+      splitToLiquid: INIT_SPLIT,
+      rotatingFund: false,
+      expiryHeight: props.height,
+      expiryTime: "",
     },
   });
 

--- a/src/pages/Admin/Core/Templates/index-fund/CreateFund/schema.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/CreateFund/schema.ts
@@ -10,10 +10,8 @@ const shape: SchemaShape<FormValues> = {
   ...proposalShape,
   name: stringByteSchema(4, 64),
   about: stringByteSchema(4, 1064),
-  expiry: object().shape<SchemaShape<FormValues["expiry"]>>({
-    time: futureDate,
-    height: requiredPositiveNumber,
-  }),
+  expiryTime: futureDate,
+  expiryHeight: requiredPositiveNumber,
 };
 
 export const schema = object(shape);

--- a/src/pages/Admin/Core/Templates/index-fund/CreateFund/types.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/CreateFund/types.ts
@@ -1,24 +1,12 @@
+import { Except } from "type-fest";
 import { ProposalBase } from "../../../../types";
+import { NewFund } from "types/contracts";
 
-export type FormValues = ProposalBase & /**
- * title
- * description
- */ {
-  //fund
-  name: string;
-  about: string;
-  fund: string;
-  members: string[];
-  isRotating: boolean;
-  liqSplit: string;
-  expiry: {
-    time: string;
+export type FormValues = ProposalBase &
+  Except<NewFund, "description"> & {
+    about: string;
+    newFundMemberId: string;
+
+    //meta
     height: string;
   };
-
-  //member id
-  newFundMemberId: string;
-
-  //meta
-  height: string;
-};

--- a/src/pages/Admin/Core/Templates/index-fund/CreateFund/useCreateFund.ts
+++ b/src/pages/Admin/Core/Templates/index-fund/CreateFund/useCreateFund.ts
@@ -29,8 +29,8 @@ export default function useCreateFund() {
       "description",
       "name",
       "about",
-      "expiry.height",
-      "expiry.time",
+      "expiryHeight",
+      "expiryTime",
     ]);
 
     if (!isValid) return;
@@ -42,7 +42,7 @@ export default function useCreateFund() {
     }
 
     const currHeight = getValues("height");
-    let expiryHeight = getValues("expiry.height");
+    let expiryHeight = getValues("expiryHeight");
 
     if (+expiryHeight < +currHeight) {
       return showModal(TxPrompt, {
@@ -50,17 +50,17 @@ export default function useCreateFund() {
       });
     }
 
-    const expiryTime = getValues("expiry.time");
-    const split = getValues("liqSplit");
+    const expiryTime = getValues("expiryTime");
+    const split = getValues("splitToLiquid");
 
     const [data, dest] = encodeTx("index-fund.create-fund", {
       name: getValues("name"),
       description: getValues("about"),
-      members: newFundMembers,
-      rotatingFund: getValues("isRotating"),
-      splitToLiquid: split === INIT_SPLIT ? 0 : +split,
-      expiryTime: expiryTime === "" ? 0 : blockTime(expiryTime),
-      expiryHeight: expiryHeight === "" ? 0 : +expiryHeight,
+      members: newFundMembers.map((m) => m.toString()),
+      rotatingFund: getValues("rotatingFund"),
+      splitToLiquid: split === INIT_SPLIT ? "0" : split,
+      expiryTime: expiryTime === "" ? "0" : blockTime(expiryTime).toString(),
+      expiryHeight: expiryHeight === "" ? "0" : expiryHeight,
     });
 
     const tx = createTx(wallet.address, "multisig.submit-transaction", {

--- a/src/types/contracts/indexfund.ts
+++ b/src/types/contracts/indexfund.ts
@@ -17,3 +17,13 @@ export type FundDetails = {
   expiryTime: number;
   expiryHeight: number;
 };
+
+export type NewFund = {
+  name: string;
+  description: string;
+  members: string[]; //uint256[]
+  rotatingFund: boolean;
+  splitToLiquid: string; // "1-100"
+  expiryTime: string; // uint256
+  expiryHeight: string; // uint256
+};


### PR DESCRIPTION
Ticket(s):
* follow up duplicates removal from #2128 

## Explanation of the solution
* factor or type in `createTx/types`
* reused factored type in `createFund` form
- [x] test create index fund template

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes