### PR TITLE
RC-v1.8: donation fixes

### DIFF
--- a/src/pages/Donate/Content.tsx
+++ b/src/pages/Donate/Content.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import Breadcrumbs from "components/Breadcrumbs";
 import { Steps } from "components/donation";
 import { useGetter, useSetter } from "store/accessors";
@@ -10,7 +10,7 @@ import {
 import { IS_AST, PAYMENT_WORDS } from "constants/env";
 import { appRoutes } from "constants/routes";
 
-export default function Content(props: DonationRecipient) {
+function Content(props: DonationRecipient) {
   const dispatch = useSetter();
   const state = useGetter((state) => state.donation);
   useEffect(() => {
@@ -51,7 +51,7 @@ export default function Content(props: DonationRecipient) {
         />
       )}
 
-      {isFinalized(state) && (
+      {!isFinalized(state) && (
         <h3 className="text-center text-xl sm:text-3xl leading-snug mb-4">
           You're about to make a {PAYMENT_WORDS.noun.singular} to{" "}
           {state.recipient?.name}
@@ -68,3 +68,6 @@ function isFinalized(state: DonationState): boolean {
     state.step === 4 && (state.status === "error" || "hash" in state.status)
   );
 }
+
+//memoize to prevent useEffect ( based on props ) from running when parent re-renders with the same props
+export default memo(Content);

--- a/src/slices/donation/donation.ts
+++ b/src/slices/donation/donation.ts
@@ -24,6 +24,7 @@ const donation = createSlice({
         return {
           ...(state as SubmitStep),
           step: 3,
+          kyc: "skipped",
           details: payload,
         };
       }

--- a/src/slices/donation/sendDonation/index.ts
+++ b/src/slices/donation/sendDonation/index.ts
@@ -5,6 +5,7 @@ import { isTxResultError } from "types/tx";
 import { invalidateApesTags } from "services/apes";
 import { createAuthToken, logger } from "helpers";
 import { sendTx } from "helpers/tx";
+import { chainIds } from "constants/chainIds";
 import { IS_TEST } from "constants/env";
 import { APIs } from "constants/urls";
 // import { SERVICE_PROVIDER } from "constants/fiatTransactions";
@@ -85,6 +86,7 @@ export const sendDonation = createAsyncThunk<void, DonateArgs>(
         ...kycData /** receipt is sent to user if kyc is provider upfront */,
         amount: +token.amount,
         chainId: wallet.chain.chain_id,
+        destinationChainId: chainIds.polygon,
         chainName: wallet.chain.chain_name,
         charityName: recipient.name,
         denomination: token.symbol,
@@ -96,7 +98,6 @@ export const sendDonation = createAsyncThunk<void, DonateArgs>(
       });
 
       updateTx({ hash });
-
       //invalidate cache entries
       dispatch(invalidateApesTags(["chain", "donations"]));
     } catch (err) {

--- a/src/types/aws/apes/donation.ts
+++ b/src/types/aws/apes/donation.ts
@@ -1,6 +1,7 @@
 export type Donation = {
   amount: number;
   chainId: string;
+  destinationChainId: string;
   chainName: string;
   charityName: string;
   date: string;
@@ -27,23 +28,6 @@ export type KYCData = {
 export type ReceiptPayload = KYCData & {
   transactionId: string; // tx hash
 };
-
-type TxBase = {
-  amount: number;
-  chainId: string;
-  chainName: string;
-  charityName: string;
-  denomination: string;
-  splitLiq: string; //"50"
-  transactionId: string;
-  transactionDate: string;
-  endowmentId: number;
-};
-
-type CryptoTx = TxBase & {
-  walletAddress: string; //user wallet address, undefined for
-};
-
 export type DonationsQueryParams = {
   id: string;
   chain_id: string;
@@ -56,4 +40,17 @@ export type DonationsQueryParams = {
   limit?: number; // Number of items to be returned per request
 };
 
-export type TxLogPayload = CryptoTx & { kycData?: KYCData };
+export type TxLogPayload = {
+  amount: number;
+  chainId: string;
+  destinationChainId: string;
+  chainName: string;
+  charityName: string;
+  denomination: string;
+  splitLiq: string; //"50"
+  transactionId: string;
+  transactionDate: string;
+  endowmentId: number;
+  walletAddress: string;
+  kycData?: KYCData;
+};


### PR DESCRIPTION
Ticket(s):
-

`sendDonation` encounters error (trying to read some `kyc.name` ) when running donation with skipped (no UI shown) KYC


## Explanation of the solution
* set kyc data to `"skipped"` when skipping KYC, so that `sendDonation` won't try to access `kyc` 
* add `destinationChainId` as it is now required by `v3/donation` endpoint

## Other fixes
* After donation success, Success page is not shown 
  * fixed by making sure `setRecipient` isn't run when parent of `<Content/>` renders
* Presence of verbiage `You'are about to make donation...` even the donation is complete
  * fix incorrect `isFinalized` usage
  
### Others
 * Remove unused types related to log donation

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes