### PR TITLE
App Type drives SideMenu & Dashboard title wording

### DIFF
--- a/src/pages/Admin/Charity/Dashboard/index.tsx
+++ b/src/pages/Admin/Charity/Dashboard/index.tsx
@@ -1,12 +1,13 @@
 import { useAdminResources } from "pages/Admin/Guard";
 import { useProposalsQuery } from "services/juno/custom";
 import QueryLoader from "components/QueryLoader";
+import { IS_AST } from "constants/env";
 import Seo from "../Seo";
 import Balances from "../common/Balances";
 import Table from "./Table";
 
 export default function Dashboard() {
-  const { endow_type, multisig } = useAdminResources<"charity">();
+  const { multisig } = useAdminResources<"charity">();
   const { data, ...rest } = useProposalsQuery({
     multisig,
     status: "pending",
@@ -15,9 +16,7 @@ export default function Dashboard() {
 
   return (
     <div className="grid content-start mt-6">
-      <Seo
-        title={`${endow_type === "charity" ? "Endowment" : "AST"} Dashboard`}
-      />
+      <Seo title={`${!IS_AST ? "Endowment" : "AST"} Dashboard`} />
       <h3 className="uppercase font-extrabold text-2xl mb-4">Balances</h3>
       <Balances />
       <h3 className="mt-10 mb-4 uppercase font-extrabold text-2xl">

--- a/src/pages/Admin/constants.ts
+++ b/src/pages/Admin/constants.ts
@@ -3,6 +3,7 @@ import { Templates } from "pages/Admin/types";
 import { ProposalBase } from "pages/Admin/types";
 import { SchemaShape } from "schemas/types";
 import { stringByteSchema } from "schemas/string";
+import { IS_AST, PAYMENT_WORDS } from "constants/env";
 import { adminRoutes } from "constants/routes";
 
 export const templates: { [key in Templates]: string } = {
@@ -75,7 +76,7 @@ export const LINKS: {
     },
   },
   liquidAccount: {
-    title: "Liquid Account",
+    title: `${IS_AST ? "Liquid" : "Current"} Account`,
     to: sidebarRoutes.liquidAccount,
     icon: {
       type: "WaterDrop",
@@ -83,7 +84,7 @@ export const LINKS: {
     },
   },
   lockedAccount: {
-    title: "Locked Account",
+    title: `${IS_AST ? "Locked" : "Endowment"} Account`,
     to: sidebarRoutes.lockedAccount,
     icon: {
       type: "Lock",
@@ -125,7 +126,7 @@ export const LINKS: {
     },
   },
   contributions: {
-    title: "Contributions",
+    title: PAYMENT_WORDS.noun.plural,
     to: sidebarRoutes.contributions,
     icon: {
       type: "DollarCircle",


### PR DESCRIPTION
Ticket(s):
- Bugs raised by Tim in Discord: https://discord.com/channels/834976399228010527/1098542651218866208/1108673500052471858

## Explanation of the solution
- App Type drives sidemenu link title wording

## Instructions on making this work
- Set the REACT_APP_APP_TYPE to anything but "AST"
- View the Admin sidebar and note wording is correct for charities

## UI changes for review
None