### PR TITLE
Documentation upload error

### DIFF
--- a/src/pages/Registration/Steps/Dashboard/index.tsx
+++ b/src/pages/Registration/Steps/Dashboard/index.tsx
@@ -26,7 +26,7 @@ function Dashboard() {
       }),
       handleError,
       () => {
-        if ((window as any).lintrk) {
+        if (window.hasOwnProperty("lintrk")) {
           (window as any).lintrk("track", { conversion_id: 12807754 });
         }
         showModal(Prompt, {

--- a/src/pages/Registration/Steps/Dashboard/index.tsx
+++ b/src/pages/Registration/Steps/Dashboard/index.tsx
@@ -26,8 +26,8 @@ function Dashboard() {
       }),
       handleError,
       () => {
-        if (window.hasOwnProperty("lintrk")) {
-          window.lintrk("track", { conversion_id: 12807754 });
+        if ((window as any).lintrk) {
+          (window as any).lintrk("track", { conversion_id: 12807754 });
         }
         showModal(Prompt, {
           type: "success",

--- a/src/services/aws/registration/registration.ts
+++ b/src/services/aws/registration/registration.ts
@@ -55,7 +55,7 @@ const registration_api = aws.injectEndpoints({
       transformErrorResponse(res, meta, { type }) {
         return {
           status: res.status,
-          data: `Failed to update ${type}. Please try again later.`,
+          message: `${res.status}: Failed to update ${type}. Please try again later.`,
         };
       },
       /** pessimistic manual cache update so not to GET fresh data */


### PR DESCRIPTION
Ticket(s): closes #2190
* #2190 

when `updateReg` encounters an error from server, it transform it to this format
```ts
type Custom = { status:number, data: string }
```
this gets passed to `ErrorContext` where it is parsed 
```ts
// using `in` in `string`
} else if (error.data && "message" in error.data) {
```

## Explanation of the solution
* align custom format to what error handler expects
```ts
type Custom = { status:number, message: string }
```

### Others
* fix typescript error
* also include `status` on message
<img width="555" alt="Screenshot 2023-05-25 at 10 38 34 AM" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/d758dc06-29eb-4b82-8cb2-a1f3d9dbff0e">


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes