### PR TITLE
Fix splits

### DIFF
--- a/src/pages/Launchpad/Splits/Form/index.tsx
+++ b/src/pages/Launchpad/Splits/Form/index.tsx
@@ -52,8 +52,8 @@ export default function SplitsForm(props: FormProps) {
         >
           {(min, max, disabled) => (
             <div className="flex justify-between text-sm">
-              <Percent disabled={disabled}>{max}%</Percent>
               <Percent disabled={disabled}>{100 - max}%</Percent>
+              <Percent disabled={disabled}>{max}%</Percent>
             </div>
           )}
         </MinmaxSlider>

--- a/src/pages/Launchpad/Splits/types.ts
+++ b/src/pages/Launchpad/Splits/types.ts
@@ -1,3 +1,8 @@
 import { TSplits } from "slices/launchpad/types";
 
+/**
+ * from UI:
+ * min and max are based on locked
+ * default is based on liquid
+ */
 export type FV = TSplits & { defaultMin: string };

--- a/src/pages/Launchpad/Summary/Splits.tsx
+++ b/src/pages/Launchpad/Summary/Splits.tsx
@@ -14,10 +14,10 @@ export default function Splits({
       <p className="font-semibold mb-2">Default values</p>
       <ul className="list-disc list-inside mb-6">
         <Item classes="mb-2" title="To locked">
-          {def} %
+          {100 - +def} %
         </Item>
         <Item classes="mb-2" title="To liquid">
-          {100 - +def} %
+          {def} %
         </Item>
       </ul>
 

--- a/src/pages/Launchpad/Summary/toEVMAST.ts
+++ b/src/pages/Launchpad/Summary/toEVMAST.ts
@@ -53,7 +53,7 @@ export default function toEVMAST(
     //not used in contract
     splitMax: 100 - +splits.max,
     splitMin: 100 - +splits.min,
-    splitDefault: 100 - +splits.default,
+    splitDefault: +splits.default,
 
     // //fees
     earningsFee: toEndowFee(fees.earnings),

--- a/src/pages/Launchpad/Summary/toEVMAST.ts
+++ b/src/pages/Launchpad/Summary/toEVMAST.ts
@@ -126,7 +126,7 @@ export default function toEVMAST(
     splitToLiquid: {
       min: 100 - +splits.max,
       max: 100 - +splits.min,
-      defaultSplit: 100 - +splits.default,
+      defaultSplit: +splits.default,
     },
 
     // referral_id: fees.referral_id || 0, //TODO: add on later ver of contracts

--- a/src/pages/Registration/Steps/Dashboard/index.tsx
+++ b/src/pages/Registration/Steps/Dashboard/index.tsx
@@ -27,7 +27,7 @@ function Dashboard() {
       handleError,
       () => {
         if (window.hasOwnProperty("lintrk")) {
-          window.lintrk("track", { conversion_id: 12807754 });
+          (window as any).lintrk("track", { conversion_id: 12807754 });
         }
         showModal(Prompt, {
           type: "success",


### PR DESCRIPTION
Ticket(s):
- https://app.clickup.com/t/865cdurzy
for `splitDefault` UI is based on `liquid` (that is `To Liquid` is in the right of the slider ) but value is treated as `locked`

## Explanation of the solution
* treat `splitDefault` as liquid
* verify values in summary `message` - ok
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes