### PR TITLE
Staging Implementation for Algolia Marketplace Search

### DIFF
--- a/src/pages/Admin/Charity/WidgetConfigurer/WidgetUrlGenerator/EndowmentCombobox/Combobox.tsx
+++ b/src/pages/Admin/Charity/WidgetConfigurer/WidgetUrlGenerator/EndowmentCombobox/Combobox.tsx
@@ -26,11 +26,11 @@ export default function Combobox() {
   const { data, isLoading, isError } = useEndowmentIdNamesQuery({
     query: debouncedQuery || "matchall",
     sort: "default",
-    endow_types: "Charity",
-    tiers: "Level2,Level3",
+    endow_types: "charity",
+    tiers: "2,3",
     sdgs: Object.keys(unsdgs).join(","),
     kyc_only: "true,false",
-    start: 0,
+    page: 1,
     published: "true",
   });
 

--- a/src/pages/Marketplace/Cards/useCards.ts
+++ b/src/pages/Marketplace/Cards/useCards.ts
@@ -90,7 +90,7 @@ export default function useCards() {
   // initial assumption is that there's no more to load until we get first res from query
   let hasMore = false;
   if (data?.Page !== undefined && data?.NumOfPages !== undefined) {
-    const hasMore = (data?.Page || 0) < (data?.NumOfPages || 0);
+    hasMore = (data?.Page || 0) < (data?.NumOfPages || 0);
   }
 
   return { hasMore, isLoading, isLoadingNextPage, loadNextPage, data, isError };

--- a/src/pages/Marketplace/Cards/useCards.ts
+++ b/src/pages/Marketplace/Cards/useCards.ts
@@ -90,7 +90,7 @@ export default function useCards() {
   // initial assumption is that there's no more to load until we get first res from query
   let hasMore = false;
   if (data?.Page !== undefined && data?.NumOfPages !== undefined) {
-    hasMore = data.Page < data.NumOfPages;
+    const hasMore = (data?.Page || 0) < (data?.NumOfPages || 0);
   }
 
   return { hasMore, isLoading, isLoadingNextPage, loadNextPage, data, isError };

--- a/src/pages/Marketplace/Cards/useCards.ts
+++ b/src/pages/Marketplace/Cards/useCards.ts
@@ -88,10 +88,7 @@ export default function useCards() {
   }
 
   // initial assumption is that there's no more to load until we get first res from query
-  let hasMore = false;
-  if (data?.Page !== undefined && data?.NumOfPages !== undefined) {
-    hasMore = (data?.Page || 0) < (data?.NumOfPages || 0);
-  }
+  const hasMore = (data?.Page || 0) < (data?.NumOfPages || 0);
 
   return { hasMore, isLoading, isLoadingNextPage, loadNextPage, data, isError };
 }

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -1,12 +1,12 @@
 import { createApi, fetchBaseQuery, retry } from "@reduxjs/toolkit/query/react";
 import { Profile } from "../types";
 import {
+  EndowListPaginatedAWSQueryRes,
   EndowmentCard,
   EndowmentProfile,
   EndowmentProfileUpdate,
   EndowmentsQueryParams,
   NewAST,
-  PaginatedAWSQueryRes,
   TStrategy,
   WalletProfile,
 } from "types/aws";
@@ -53,13 +53,13 @@ export const aws = createApi({
   baseQuery: awsBaseQuery,
   endpoints: (builder) => ({
     endowmentCards: builder.query<
-      PaginatedAWSQueryRes<EndowmentCard[]>,
+      EndowListPaginatedAWSQueryRes<EndowmentCard[]>,
       EndowmentsQueryParams
     >({
       providesTags: ["endowments"],
       query: (params) => {
         return {
-          url: `/v4/endowments/${network}`,
+          url: `/${v(5)}/endowments/${network}`,
           params: { ...params, return: endowCardFields },
         };
       },
@@ -74,13 +74,13 @@ export const aws = createApi({
       },
     }),
     endowmentIdNames: builder.query<
-      PaginatedAWSQueryRes<Pick<EndowmentCard, "id" | "name">[]>,
+      EndowListPaginatedAWSQueryRes<Pick<EndowmentCard, "id" | "name">[]>,
       EndowmentsQueryParams
     >({
       providesTags: ["endowments"],
       query: (params) => {
         return {
-          url: `/v4/endowments/${network}`,
+          url: `/${v(5)}/endowments/${network}`,
           params: { ...params, return: ENDOW_ID_NAME_FIELDS },
         };
       },
@@ -174,9 +174,9 @@ export const {
   },
 } = aws;
 
-type EndowCardFields = keyof (Omit<EndowmentCard, "hq" | "categories"> &
+type EndowCardFields = keyof (Omit<EndowmentCard, "hq"> &
   /** replace with cloudsearch specific field format */
-  Pick<EndowmentProfileUpdate, "hq_country" | "categories_sdgs">);
+  Pick<EndowmentProfileUpdate, "hq_country">);
 
 //object format first to avoid duplicates
 const endowCardObj: {
@@ -185,7 +185,7 @@ const endowCardObj: {
   hq_country: "",
   endow_designation: "",
   active_in_countries: "",
-  categories_sdgs: "",
+  categories: "",
   id: "",
   image: "",
   kyc_donors_only: "",

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -117,7 +117,7 @@ export type EndowDesignation =
 export type EndowmentsQueryParams = {
   query: string; //set to "matchAll" if no search query
   sort: "default" | `${EndowmentsSortKey}+${SortDirection}`;
-  start?: number; //to load next page, set start to ItemCutOff + 1
+  page?: number; //to load next page, set to Page + 1
   endow_types: string | null; // comma separated EndowmentType values
   endow_designation?: string; // comma separated EndowDesignation values
   sdgs: string | 0; // comma separated sdg values. The backend recognizes "0" as "no SDG was selected"
@@ -125,7 +125,7 @@ export type EndowmentsQueryParams = {
   kyc_only: string | null; // comma separated boolean values
   hq_country?: string; //comma separated values
   active_in_countries?: string; //comma separated values
-  limit?: number; // Number of items to be returned per request. If not provided, API defaults to return all
+  hits?: number; // Number of items to be returned per request. If not provided, API defaults to return all
   published: string;
 };
 

--- a/src/types/aws/common.ts
+++ b/src/types/aws/common.ts
@@ -4,7 +4,10 @@ export interface AWSQueryRes<T> {
   Items: T;
 }
 
-export type EndowListPaginatedAWSQueryRes<T> = AWSQueryRes<T> & { Page: number, NumOfPages: number };
+export type EndowListPaginatedAWSQueryRes<T> = AWSQueryRes<T> & {
+  Page: number;
+  NumOfPages: number;
+};
 export type PaginatedAWSQueryRes<T> = AWSQueryRes<T> & { ItemCutoff: number };
 
 export type FileObject = {

--- a/src/types/aws/common.ts
+++ b/src/types/aws/common.ts
@@ -4,6 +4,7 @@ export interface AWSQueryRes<T> {
   Items: T;
 }
 
+export type EndowListPaginatedAWSQueryRes<T> = AWSQueryRes<T> & { Page: number, NumOfPages: number };
 export type PaginatedAWSQueryRes<T> = AWSQueryRes<T> & { ItemCutoff: number };
 
 export type FileObject = {


### PR DESCRIPTION
Ticket(s):
- Related to AngelProtocolFinance/devops#273

## Explanation of the solution

Added `staging` API indicator for Marketplace search and to related Widget charity search. This `staging` and `v5` API uses Algolia search instead of AWS CloudSearch. The `ItemCutoff` field is replaced with new fields `Page` and `NumOfPages` which indicates the current page displayed in the result and the total number of pages that can be retrieved, respectively.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- There will only be two dummy records for staging and five records for testnet.

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes