### PR TITLE
HOT FIX: bridge fee from AWS 

### DIFF
--- a/src/pages/Admin/Charity/Withdraws/Transactions/Table/LogRow.tsx
+++ b/src/pages/Admin/Charity/Withdraws/Transactions/Table/LogRow.tsx
@@ -11,7 +11,7 @@ export default function LogRow(props: WithdrawLog) {
   const { amount, symbol, target_wallet } = props;
   const finalRoute = getFinalRoute(props);
   return (
-    <Cells type="td" cellClass="p-2 text-white/80">
+    <Cells type="td" cellClass="p-2">
       <Amount val={amount} symbol={symbol} />
 
       <span className="font-mono text-sm">{maskAddress(target_wallet)}</span>

--- a/src/pages/Admin/Charity/Withdraws/Transactions/Table/index.tsx
+++ b/src/pages/Admin/Charity/Withdraws/Transactions/Table/index.tsx
@@ -10,11 +10,8 @@ type Props = {
 export default function Table({ withdraws, classes = "" }: Props) {
   return (
     <table className={`w-full mt-6 ${classes}`}>
-      <TableSection type="thead" rowClass="border-b-2 border-white/20">
-        <Cells
-          type="th"
-          cellClass="text-left font-heading text-white/80 uppercase p-2"
-        >
+      <TableSection type="thead" rowClass="border-b-2 border-prim">
+        <Cells type="th" cellClass="text-left font-heading uppercase p-2">
           <>Amount</>
           <>Receiver</>
           <>Status</>
@@ -22,7 +19,7 @@ export default function Table({ withdraws, classes = "" }: Props) {
           <>Transaction hash</>
         </Cells>
       </TableSection>
-      <TableSection type="tbody" rowClass="border-b border-white/10">
+      <TableSection type="tbody" rowClass="border-b border-prim">
         {withdraws.map((log, i) => (
           <LogRow {...log} key={i} />
         ))}

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Breakdown.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Breakdown.tsx
@@ -24,9 +24,21 @@ export default function Breakdown() {
   if (network === chainIds.juno || usdc <= 0 || toReceive < 0) return null;
 
   return (
-    <div>
-      <span>bridge fee: {prettyFee} USDC</span>
-      <span>to receive amount: {toReceive} </span>
+    <div className="divide-y divide-gray-l2 dark:divide-bluegray-d1">
+      <p className="uppercase font-bold font-heading mb-2 text-sm">Summary</p>
+      <Item title="amount" value={prettyFee.toFixed(2) + " USDC"} />
+      <Item title="bridge fee" value={prettyFee.toFixed(2) + " USDC"} />
+      <Item title="to receive" value={toReceive.toFixed(2) + " USDC"} />
+    </div>
+  );
+}
+
+type Props = { title: string; value: string };
+function Item({ title, value }: Props) {
+  return (
+    <div className="flex justify-between items-center w-full text-sm py-1 text-gray-d1 dark:text-gray">
+      <span className="uppercase font-semibold text-xs">{title}:</span>
+      <span>{value}</span>
     </div>
   );
 }

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Breakdown.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Breakdown.tsx
@@ -26,7 +26,7 @@ export default function Breakdown() {
   return (
     <div className="divide-y divide-gray-l2 dark:divide-bluegray-d1">
       <p className="uppercase font-bold font-heading mb-2 text-sm">Summary</p>
-      <Item title="amount" value={prettyFee.toFixed(2) + " USDC"} />
+      <Item title="amount" value={usdc.toFixed(2) + " USDC"} />
       <Item title="bridge fee" value={prettyFee.toFixed(2) + " USDC"} />
       <Item title="to receive" value={toReceive.toFixed(2) + " USDC"} />
     </div>

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Breakdown.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Breakdown.tsx
@@ -1,0 +1,32 @@
+import { useFormContext } from "react-hook-form";
+import { WithdrawValues } from "./types";
+import { chainIds } from "constants/chainIds";
+import { denoms } from "constants/tokens";
+import { fee } from "./helpers";
+
+export default function Breakdown() {
+  const { watch, getValues } = useFormContext<WithdrawValues>();
+  const fees = getValues("fees");
+  const network = watch("network");
+  const amounts = watch("amounts");
+  const amount =
+    amounts.find((a) => a.tokenId === denoms.axlusdc)?.value ?? "0";
+  const usdc = +amount;
+
+  const prettyFee = fee(network, fees);
+  const toReceive = usdc - prettyFee;
+
+  /** only show breakdown:
+   *  cross chain transfer
+   *  USDC is to be withdrawn
+   *  bridge fee is greater than withraw amount
+   */
+  if (network === chainIds.juno || usdc <= 0 || toReceive < 0) return null;
+
+  return (
+    <div>
+      <span>bridge fee: {prettyFee} USDC</span>
+      <span>to receive amount: {toReceive} </span>
+    </div>
+  );
+}

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Form.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Form.tsx
@@ -17,9 +17,11 @@ export default function Form() {
       noValidate
     >
       <Amounts />
-      <Breakdown />
+
       <Network />
-      <Beneficiary classes="mt-6 mb-2" />
+      <Beneficiary classes="my-6" />
+      <Breakdown />
+
       {network !== "Juno" && (
         <>
           <Warning classes="mt-4 mb-2">

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Form.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Form.tsx
@@ -1,5 +1,6 @@
 import Amounts from "./Amounts";
 import Beneficiary from "./Beneficiary";
+import Breakdown from "./Breakdown";
 import Network from "./Network";
 import Submit from "./Submit";
 import Warning from "./Warning";
@@ -16,6 +17,7 @@ export default function Form() {
       noValidate
     >
       <Amounts />
+      <Breakdown />
       <Network />
       <Beneficiary classes="mt-6 mb-2" />
       {network !== "Juno" && (

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Form.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/Form.tsx
@@ -6,7 +6,7 @@ import Warning from "./Warning";
 import useWithdraw from "./useWithdraw";
 
 export default function Form() {
-  const { withdraw } = useWithdraw();
+  const { withdraw, fee, network } = useWithdraw();
 
   return (
     <form
@@ -18,14 +18,17 @@ export default function Form() {
       <Amounts />
       <Network />
       <Beneficiary classes="mt-6 mb-2" />
-      <Warning classes="mt-4 mb-2">
-        All withdraws to Ethereum & Binance are processed on a hourly basis by
-        our cross-chain pipelines.
-      </Warning>
-      <Warning classes="mb-2">
-        The minimum withdrawal for Ethereum & Binance is $40 & $20 USDC,
-        respectively.
-      </Warning>
+      {network !== "Juno" && (
+        <>
+          <Warning classes="mt-4 mb-2">
+            Withraws to {network} are processed on a hourly basis by our
+            cross-chain pipelines.
+          </Warning>
+          <Warning classes="mb-2">
+            The minimum withdrawal amount is {fee} USDC.
+          </Warning>
+        </>
+      )}
       <Warning classes="mb-2">
         We recommend not using crypto exchange addresses for withdrawals. We are
         not responsible for the loss of funds.

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/helpers.ts
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/helpers.ts
@@ -1,0 +1,27 @@
+import { AxelarBridgeFees } from "types/aws";
+import { chainIds } from "constants/chainIds";
+
+export const fee = (
+  network: string,
+  fees: AxelarBridgeFees["withdraw"]
+): number => {
+  //prettier-ignore
+  switch (network) {
+    case chainIds.binance: return Math.ceil(fees.binance);
+    case chainIds.polygon: return Math.ceil(fees.polygon);
+    case chainIds.ethereum: return Math.ceil(fees.ethereum)
+    default: return 0;
+  }
+};
+
+export const names = (
+  network: string
+): "Binance" | "Ethereum" | "Polygon" | "Juno" => {
+  //prettier-ignore
+  switch (network) {
+    case chainIds.binance: return "Binance";
+    case chainIds.polygon: return "Polygon";
+    case chainIds.ethereum: return "Ethereum";
+    default: return "Juno";
+  }
+};

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/index.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/index.tsx
@@ -17,14 +17,14 @@ export default function Withdrawer({
   const cw20s: Amount[] = cw20.map((c) => ({
     type: "cw20",
     tokenId: c.address,
-    balance: roundDown(condense(c.amount), 4),
+    balance: roundDown(condense(c.amount), 4) + 100,
     value: "",
   }));
 
   const natives: Amount[] = native.map((n) => ({
     type: "native",
     tokenId: n.denom,
-    balance: roundDown(condense(n.amount), 4),
+    balance: roundDown(condense(n.amount), 4) + 100,
     value: "",
   }));
 

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/index.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/index.tsx
@@ -10,6 +10,7 @@ import { schema } from "./schema";
 export default function Withdrawer({
   balance: { cw20, native },
   type,
+  fees,
 }: WithdrawerProps) {
   const { wallet } = useGetWallet();
 
@@ -37,6 +38,7 @@ export default function Withdrawer({
       amounts: [...natives, ...cw20s],
       height: 0,
       type,
+      fees,
     },
     resolver: yupResolver(schema),
   });

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/schema.ts
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/schema.ts
@@ -3,7 +3,7 @@ import { Amount, WithdrawValues as WV } from "./types";
 import { SchemaShape } from "schemas/types";
 import { tokenConstraint } from "schemas/number";
 import { requiredWalletAddr } from "schemas/string";
-import { chainIds } from "constants/chainIds";
+import { fee } from "./helpers";
 
 type TVal = Amount["value"];
 type TBal = Amount["balance"];
@@ -34,13 +34,8 @@ const amount: (network: TNetwork, fees: TFees) => SchemaShape<Amount> = (
                * NOTE: this is on the assumption that endow TOH would just be USDC
                * for other tokens, must first get dollar amount
                */
-              `minimum ${fees[network as "ethereum" | "binance"]} USDC`,
-              () =>
-                network === chainIds.juno
-                  ? true
-                  : network === chainIds.ethereum
-                  ? +val >= 40
-                  : +val >= 20
+              `minimum ${fee(network, fees)} USDC`,
+              () => +val >= fee(network, fees)
             )
         )
   ),

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/schema.ts
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/schema.ts
@@ -35,7 +35,7 @@ const amount: (network: TNetwork, fees: TFees) => SchemaShape<Amount> = (
                * for other tokens, must first get dollar amount
                */
               `minimum ${fee(network, fees)} USDC`,
-              () => +val > fee(network, fees)
+              () => +val >= fee(network, fees)
             )
         )
   ),

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/schema.ts
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/schema.ts
@@ -35,7 +35,7 @@ const amount: (network: TNetwork, fees: TFees) => SchemaShape<Amount> = (
                * for other tokens, must first get dollar amount
                */
               `minimum ${fee(network, fees)} USDC`,
-              () => +val >= fee(network, fees)
+              () => +val > fee(network, fees)
             )
         )
   ),

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/types.ts
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/types.ts
@@ -1,3 +1,5 @@
+import { WithdrawInfo } from "services/types";
+import { AxelarBridgeFees } from "types/aws";
 import { AccountType, GenericBalance } from "types/contracts";
 
 export type Amount = {
@@ -17,10 +19,12 @@ export type WithdrawValues = {
   _amounts: string; //collective amounts error
   height: number;
   type: AccountType;
+  fees: WithdrawInfo["withdraw"];
 };
 
 export type WithdrawerProps = {
   balance: GenericBalance;
   type: AccountType;
+  fees: AxelarBridgeFees["withdraw"];
 };
 //form meta

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/useWithdraw.ts
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/Withdrawer/useWithdraw.ts
@@ -11,15 +11,18 @@ import useCosmosTxSender from "hooks/useCosmosTxSender/useCosmosTxSender";
 import { scaleToStr } from "helpers";
 import { ap_wallets } from "constants/ap_wallets";
 import { chainIds } from "constants/chainIds";
+import { fee, names } from "./helpers";
 import useLogWithdrawProposal from "./useLogWithdrawProposal";
 
 export default function useWithdraw() {
   const {
+    watch,
     handleSubmit,
     getValues,
     formState: { isValid, isDirty, isSubmitting },
   } = useFormContext<WithdrawValues>();
 
+  const network = watch("network");
   const { cw3, endowmentId, endowment, propMeta } = useAdminResources();
   const { wallet } = useGetWallet();
 
@@ -100,5 +103,7 @@ export default function useWithdraw() {
     withdraw: handleSubmit(withdraw),
     isSubmitDisabled: !isValid || !isDirty || isSubmitting,
     type,
+    fee: fee(network, getValues("fees")),
+    network: names(network),
   };
 }

--- a/src/pages/Admin/Charity/Withdraws/WithdrawTabs/index.tsx
+++ b/src/pages/Admin/Charity/Withdraws/WithdrawTabs/index.tsx
@@ -1,11 +1,15 @@
 import { Tab } from "@headlessui/react";
 import { useLocation } from "react-router-dom";
-import { AccountType, EndowmentState } from "types/contracts";
+import { WithdrawInfo } from "services/types";
+import { AccountType } from "types/contracts";
 import { accountTypeDisplayValue } from "../../constants";
 import Withdrawer from "./Withdrawer";
 
 const tabs: AccountType[] = ["liquid", "locked"];
-export default function WithdrawTabs({ tokens_on_hand }: EndowmentState) {
+export default function WithdrawTabs({
+  tokens_on_hand,
+  withdraw: withdrawFees,
+}: WithdrawInfo) {
   const { state } = useLocation(); //state is set from dashboard withdraw link
   const type = state as AccountType;
   return (
@@ -33,7 +37,11 @@ export default function WithdrawTabs({ tokens_on_hand }: EndowmentState) {
       <Tab.Panels className="w-full max-w-md border rounded border-prim">
         {tabs.map((t) => (
           <Tab.Panel key={t}>
-            <Withdrawer balance={tokens_on_hand[t]} type={t} />
+            <Withdrawer
+              balance={tokens_on_hand[t]}
+              type={t}
+              fees={withdrawFees}
+            />
           </Tab.Panel>
         ))}
       </Tab.Panels>

--- a/src/pages/Admin/Charity/Withdraws/index.tsx
+++ b/src/pages/Admin/Charity/Withdraws/index.tsx
@@ -1,12 +1,12 @@
 import { useAdminResources } from "pages/Admin/Guard";
-import { useStateQuery } from "services/juno/account";
+import { useWithdrawInfoQuery } from "services/juno/custom";
 import QueryLoader from "components/QueryLoader";
 import Transactions from "./Transactions";
 import WithdrawTabs from "./WithdrawTabs";
 
 export default function Withdraws() {
   const { endowmentId } = useAdminResources();
-  const queryState = useStateQuery({ id: endowmentId });
+  const queryState = useWithdrawInfoQuery({ id: endowmentId });
 
   return (
     <div className="grid content-start font-work">
@@ -17,7 +17,7 @@ export default function Withdraws() {
           error: "Failed to load withdraw form",
         }}
       >
-        {(balance) => <WithdrawTabs {...balance} />}
+        {(state) => <WithdrawTabs {...state} />}
       </QueryLoader>
 
       <h3 className="uppercase font-extrabold text-2xl mt-6 border-t border-prim pt-2">

--- a/src/services/juno/custom.ts
+++ b/src/services/juno/custom.ts
@@ -211,18 +211,12 @@ export const customApi = junoApi.injectEndpoints({
         };
       },
     }),
-    withdrawInfo: builder.query<WithdrawInfo, { id?: string }>({
+    withdrawInfo: builder.query<WithdrawInfo, { id: number }>({
       providesTags: [
         { type: "admin", id: adminTags.proposal },
         { type: "admin", id: adminTags.votes },
       ],
-      async queryFn(args) {
-        const id = Number(args.id);
-
-        if (isNaN(id)) {
-          return { error: undefined };
-        }
-
+      async queryFn({ id }) {
         const [state, fees] = await Promise.all([
           queryContract("accState", contracts.accounts, {
             id,
@@ -247,6 +241,7 @@ export const customApi = junoApi.injectEndpoints({
 });
 
 export const {
+  useWithdrawInfoQuery,
   useIsMemberQuery,
   useAdminResourcesQuery,
   useProposalDetailsQuery,

--- a/src/services/juno/custom.ts
+++ b/src/services/juno/custom.ts
@@ -221,7 +221,7 @@ export const customApi = junoApi.injectEndpoints({
           queryContract("accState", contracts.accounts, {
             id,
           }),
-          fetch(APIs.aws + "/v1/axelar-bridge-fees").then<AxelarBridgeFees>(
+          fetch(APIs.apes + "/v1/axelar-bridge-fees").then<AxelarBridgeFees>(
             (res) => {
               if (!res.ok) throw new Error("Failed to get fees");
               return res.json();

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,9 +1,11 @@
 import { PayloadAction } from "@reduxjs/toolkit";
 import { TagDescription } from "@reduxjs/toolkit/dist/query/endpointDefinitions";
+import { AxelarBridgeFees } from "types/aws";
 import {
   AdminVoteInfo,
   CW3Config,
   EndowmentDetails,
+  EndowmentState,
   Proposal,
 } from "types/contracts";
 import { TxArgs } from "hooks/useCosmosTxSender";
@@ -49,3 +51,5 @@ export type JunoTags =
   | "account"
   | "registrar"
   | "custom";
+
+export type WithdrawInfo = EndowmentState & AxelarBridgeFees;

--- a/src/types/aws/apes/index.ts
+++ b/src/types/aws/apes/index.ts
@@ -75,3 +75,17 @@ export type WithdrawLog = {
   num_routes?: number;
   routes?: WithdrawRoute[];
 };
+
+export type AxelarBridgeFees = {
+  deposit: {
+    binance: number;
+    ethereum: number;
+    polygon: number;
+    "terra-2": number;
+  };
+  withdraw: {
+    binance: number;
+    ethereum: number;
+    polygon: number;
+  };
+};


### PR DESCRIPTION
Ticket(s):
-

## Explanation of the solution
* create custom query with result `endowment_state + bridge_fees` - for single loading
* since bridge fees doesn't depent on amount, withdraw summary including fees can simply be shown straight in withdraw form
<img width="513" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/4568d566-8959-44a6-86e9-f84b3c03d71c">


## Other fixes
* transaction table items is hidden (text is white even though background is also white ) in lightmode

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
* when juno network is is selected 
<img width="530" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/a6865485-96fd-4dcb-a29a-c7567832455f">

* when other network is selected ( cross chain ) but withraw amount is less than balance
<img width="504" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/17b43db7-b8a3-4c11-a393-23fefadf7a82">

* cross chain withdraw but withdraw amount is less than minimum 
<img width="491" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/abada9b0-637c-42f5-a870-0bcd962dc08b">

* cross chain withdraw and withdraw amount is `>=` bridge fee
<img width="495" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/a49ff5ad-ae29-44a5-892e-1b7e7ecbf3ce">



When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes