### PR TITLE
FIX: revert demo change

### DIFF
--- a/src/pages/Admin/Charity/OtherSettings/common/Btn.tsx
+++ b/src/pages/Admin/Charity/OtherSettings/common/Btn.tsx
@@ -3,12 +3,8 @@ import { FC, PropsWithChildren } from "react";
 type Btn = FC<PropsWithChildren<{ classes?: string; disabled?: boolean }>>;
 
 export const Submit: Btn = ({ children, classes = "" }) => (
-  <button
-    disabled={true}
-    type="submit"
-    className={`${classes} btn-orange w-44 h-12 text-sm`}
-  >
-    Locked forever
+  <button type="submit" className={`${classes} btn-orange w-44 h-12 text-sm`}>
+    {children}
   </button>
 );
 


### PR DESCRIPTION
Ticket(s):
-

## Explanation of the solution
* revert commited demo `locked-forever` btn. Locked forevert button would be added all at once

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes