### PR TITLE
FIX: whitelisted bene/contributors not showing after update

### DIFF
--- a/src/pages/Admin/Charity/Whitelists/Whitelists.tsx
+++ b/src/pages/Admin/Charity/Whitelists/Whitelists.tsx
@@ -29,7 +29,8 @@ export default function Whitelists() {
 
   const methods = useForm<FV>({
     defaultValues: {
-      ...initial,
+      beneficiaries: allowlistedBeneficiaries,
+      contributors: allowlistedContributors,
       initial,
     },
   });


### PR DESCRIPTION
Ticket(s):
* starting account:id `4` of the current contracts deployment, changes to whitelists is now reflected when querying `queryEndowmentDetails` but somehow still now shown in form

## Explanation of the solution
* fix missed form value initialization, initial values now show on form
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/01ba5fde-d8b8-44b4-94d2-11ab9fbba7a8)


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes