### PR TITLE
Fix: add checks on AST maturity when editing some settings 

### DIFF
--- a/src/pages/Admin/Charity/Whitelists/Whitelists.tsx
+++ b/src/pages/Admin/Charity/Whitelists/Whitelists.tsx
@@ -29,7 +29,8 @@ export default function Whitelists() {
 
   const methods = useForm<FV>({
     defaultValues: {
-      ...initial,
+      beneficiaries: allowlistedBeneficiaries,
+      contributors: allowlistedContributors,
       initial,
     },
   });


### PR DESCRIPTION
Ticket(s):
- follow-up on #2231 ( PR description was edited there )

## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes