### PR TITLE
Initial Email Sending When Resuming Charity Registration

### DIFF
--- a/src/pages/Registration/Resume/useSubmit.ts
+++ b/src/pages/Registration/Resume/useSubmit.ts
@@ -1,9 +1,12 @@
 import { useFormContext } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { FormValues } from "./types";
-import { useLazyRegQuery } from "services/aws/registration";
+import {
+  useLazyRegQuery,
+  useRequestEmailMutation,
+} from "services/aws/registration";
 import { useErrorContext } from "contexts/ErrorContext";
-import { storeRegistrationReference } from "helpers";
+import { handleMutationResult, storeRegistrationReference } from "helpers";
 import { getRegistrationState } from "../Steps/getRegistrationState";
 import routes from "../routes";
 
@@ -16,6 +19,7 @@ export default function useSubmit() {
   const navigate = useNavigate();
   const { handleError } = useErrorContext();
   const [checkPrevRegistration] = useLazyRegQuery();
+  const [requestEmail] = useRequestEmailMutation();
 
   const onSubmit = async ({ reference }: FormValues) => {
     const { isError, error, data } = await checkPrevRegistration(reference);
@@ -32,6 +36,10 @@ export default function useSubmit() {
     const init = state.data.init;
 
     if ("data" in state && !state.data.init.isEmailVerified) {
+      handleMutationResult(
+        await requestEmail({ uuid: init.reference, email: init.email }),
+        handleError
+      );
       return navigate(`../${routes.confirmEmail}`, { state: init });
     }
 


### PR DESCRIPTION
Ticket(s):
- n/a

## Explanation of the solution
As pointed out by sers @chaunceystjohn and Tim, when they resume a charity registration (where their email has not been confirmed yet), users are expecting that the web app already sent an email out due to this message `We sent an email to <email_here>. Please confirm your email by clicking on the link in the message.`. But in reality only the `GET` request is being sent to fetch registration data. Users would still need to click the button to initiate a `POST` request to send out the email.

### Fix
Added the `requestEmail()` function just before switching pages from `/registration/resume` to `/registration/confirm-email`. This will send the confirmation email initially without user input.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Resume a charity registration and verify that the email confirmation is being sent initially without clicking the "Resend Verification Email" button

## UI changes for review
No major UI changes