### PR TITLE
[Bug Fix] Added validation check for `Website` field in Documentation Form

### DIFF
--- a/src/pages/Registration/Steps/Documentation/schema.ts
+++ b/src/pages/Registration/Steps/Documentation/schema.ts
@@ -6,7 +6,7 @@ import { Country } from "types/countries";
 import { OptionType } from "components/Selector";
 import { Asset } from "components/registration";
 import { genFileSchema } from "schemas/file";
-import { requiredString, url } from "schemas/string";
+import { requiredString } from "schemas/string";
 import { MAX_SDGS } from "constants/unsdgs";
 
 export const MB_LIMIT = 6;
@@ -34,7 +34,7 @@ function genAssetShape(isRequired: boolean = false): SchemaShape<Asset> {
 export const schema = Yup.object().shape<SchemaShape<FormValues>>({
   proofOfIdentity: Yup.object().shape(genAssetShape(true)),
   proofOfRegistration: Yup.object().shape(genAssetShape(true)),
-  website: url,
+  website: Yup.string().required("required").url("invalid url"),
   sdgs: Yup.array()
     .min(1, "required")
     .max(MAX_SDGS, `maximum ${MAX_SDGS} selections allowed`),


### PR DESCRIPTION
## Explanation of the solution
Users are not aware that the URL they provided in the form is invalid because they are not flagged down for it. The solution already exists in the `staging` environment but it's not yet implemented in `production`. I just transferred the check to `master` branch.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Initiate a charity registration and once you're in the `Documentation` step, enter a website without it's protocol part (`http` or `https`). Submit the form and you should be flagged down.

## UI changes for review
No major UI changes.