### PR TITLE
Prod fix: amount input not accepting values

### DIFF
--- a/src/components/TokenField/TokenField.tsx
+++ b/src/components/TokenField/TokenField.tsx
@@ -26,7 +26,7 @@ export default function TokenField<T extends FieldValues, K extends Path<T>>({
     register,
     setValue,
     resetField,
-    formState: { errors, isDirty },
+    formState: { errors },
   } = useFormContext<T>();
   const {
     field: { onChange, value: token },
@@ -37,9 +37,8 @@ export default function TokenField<T extends FieldValues, K extends Path<T>>({
   const amountField: any = `${name}.${amountKey}`;
 
   useEffect(() => {
-    //don't reset on initial form load
-    if (isDirty) resetField(amountField);
-  }, [token.token_id, amountField, resetField, isDirty]);
+    resetField(amountField);
+  }, [token.token_id, amountField, resetField]);
 
   const onSetAmount: OnSetAmount = (balance) =>
     setValue(amountField, balance as any, {

--- a/src/components/donation/Steps/Donater/index.tsx
+++ b/src/components/donation/Steps/Donater/index.tsx
@@ -28,7 +28,7 @@ export default function Donater({
     mode: "onChange",
     reValidateMode: "onChange",
     defaultValues: state.details || {
-      token: wallet.displayCoin,
+      token: _tokens[0],
       pctLiquidSplit: liquidPct,
 
       //meta


### PR DESCRIPTION
Ticket(s):
- N/A

when input is 0, inputting a number is not accepted 
<img width="538" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/6051c7ee-b6a7-4b7b-b207-36d9faa93d95">


## Explanation of the solution
* `amount` resets when `isDirty` is being toggled caused by [commit](https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/2294/files#diff-0ae2be466fca4f2e716263a94f063c005c3fdb9abf76fd1ff2bc8cd937a83acaR42) (applied to correct form being `dirty` on first load)
* revert [incorrect fix](https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/2294/files#diff-0ae2be466fca4f2e716263a94f063c005c3fdb9abf76fd1ff2bc8cd937a83acaR42) 
* set correct default value of the token so that `isDirty` is properly evaluated 


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes