### PR TITLE
Fix maturity query

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node": "18.16.1"
   },
   "dependencies": {
-    "@cosmjs/encoding": "^0.30.0",
+    "@cosmjs/encoding": "0.31.0",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/bignumber": "^5.7.0",
     "@headlessui/react": "^1.7.4",

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -125,7 +125,9 @@ export class TxResultFail extends Error {
   txHash: string;
   constructor(chain: Chain, txHash: string) {
     //No need to dump to user technical details of why result failed, a link to failed tx is sufficient
-    super("Failed to broadcast transaction");
+    super(
+      "Failed to broadcast transaction. Please try transaction again later"
+    );
     this.chain = chain;
     this.txHash = txHash;
     this.name = "TxResultFail";

--- a/src/services/juno/index.ts
+++ b/src/services/juno/index.ts
@@ -25,7 +25,7 @@ export const junoApi = createApi({
   tagTypes: rootTags,
   endpoints: (builder) => ({
     latestBlock: builder.query<string, unknown>({
-      query: () => "/blocks/latest",
+      query: () => "/cosmos/base/tendermint/v1beta1/blocks/latest",
       transformResponse: (res: BlockLatest) => {
         return res.block.header.height;
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,14 +1850,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cosmjs/encoding@npm:^0.30.0":
-  version: 0.30.0
-  resolution: "@cosmjs/encoding@npm:0.30.0"
+"@cosmjs/encoding@npm:0.31.0":
+  version: 0.31.0
+  resolution: "@cosmjs/encoding@npm:0.31.0"
   dependencies:
     base64-js: ^1.3.0
     bech32: ^1.1.4
     readonly-date: ^1.0.0
-  checksum: 18ac0fd63d336b340726f9faf65dae89ae14e13237b4831b4cc7b34d31b4b1a453b60b1220540bbaa940e994c462bbf718628ad451722f9dc1c36986d191a795
+  checksum: 82b9a93a76c46e545704a65d66762e63a30e93b97689128a9774fc7f714783a88e166193532cafe3d1be5f9aa7473c5230379fdae381e8772ce49b3ed6382a0e
   languageName: node
   linkType: hard
 
@@ -5194,7 +5194,7 @@ __metadata:
     "@babel/core": ^7.22.1
     "@babel/plugin-syntax-flow": ^7.18.6
     "@babel/plugin-transform-react-jsx": ^7.22.3
-    "@cosmjs/encoding": ^0.30.0
+    "@cosmjs/encoding": 0.31.0
     "@ethersproject/abi": ^5.7.0
     "@ethersproject/bignumber": ^5.7.0
     "@headlessui/react": ^1.7.4


### PR DESCRIPTION
Ticket(s):
- #2304 
- #2250


## Explanation of the solution
* update `block/latest` endpoint
spec: `https://lcd-juno.itastakers.com/#/gRPC`

error now gone for charity `id: 147`
<img width="653" alt="Screenshot 2023-08-21 at 12 19 09" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/e3c9be66-a215-402a-bada-0ea51d07ddc5">

* for ticket (#2250 ) - the `txhash` is 404 on mintscan because it is not broadcasted thus `BROADCAST ERROR`. 
`propose_locked_withdraw` doesn't have any problems because simulation is succesful - broadcasting is tested to work with this [transaction](https://www.mintscan.io/juno/transactions/62E7167A05E95D56CCA0FBF8B2DF65B913C47E8152976125CEB6DFFF48668578). User should simply retry the transaction 🤞- added helpful message in broadcast error https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/2306/commits/db7cd4e5dd6b3b339a94f23c223e93a31cf5d4d8



## others
* update minor version `@cosmjs/encoding` package 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes