### PR TITLE
RC-v1.8: demo fixes

### DIFF
--- a/src/contexts/ErrorContext/ErrorContext.tsx
+++ b/src/contexts/ErrorContext/ErrorContext.tsx
@@ -54,6 +54,9 @@ export default function ErrorContext(props: PropsWithChildren<{}>) {
         handleError(error.data);
       } else if ("message" in error) {
         handleError(error.message);
+        //TODO: specify controlled error shapes
+      } else if (error.data && typeof error.data === "string") {
+        handleError(error.data);
       } else if (error.data && "message" in error.data) {
         handleError(error.data.message);
       } else if ("error" in error) {

--- a/src/pages/Admin/Charity/index.tsx
+++ b/src/pages/Admin/Charity/index.tsx
@@ -41,7 +41,14 @@ const COMMON: LinkGroup[] = [
   { title: "Profile", links: [LINKS.edit_profile, LINKS.programs] },
 ];
 
-const LINK_GROUPS: { [key in Exclude<EndowmentType, "daf">]: LinkGroup[] } = {
+const LINK_GROUPS: { [key in EndowmentType]: LinkGroup[] } = {
+  daf: [
+    ...COMMON,
+    {
+      title: "Manage",
+      links: [LINKS.admin_wallet, LINKS.proposals],
+    },
+  ],
   charity: [
     ...COMMON,
     {
@@ -70,13 +77,7 @@ export default function Charity() {
 
   return (
     <Routes>
-      <Route
-        element={
-          <Layout
-            linkGroups={LINK_GROUPS[endowType === "daf" ? "charity" : "ast"]}
-          />
-        }
-      >
+      <Route element={<Layout linkGroups={LINK_GROUPS[endowType]} />}>
         <Route path={`${adminRoutes.proposal}/:id`} element={<Proposal />} />
         <Route path={adminRoutes.proposals} element={<Proposals />} />
         <Route path={`${adminRoutes.templates}/*`} element={<Templates />} />

--- a/src/pages/Registration/Steps/ContactDetails/constants.ts
+++ b/src/pages/Registration/Steps/ContactDetails/constants.ts
@@ -24,7 +24,7 @@ export const referralMethods: { [key in ReferralMethods]: string } = {
   press: "Press",
   "search-engines": "Search engines",
   twitter: "Twitter",
-  referral: "Referral",
+  referral: "Referral Code",
   other: "Other",
 };
 


### PR DESCRIPTION
Ticket(s):
- https://linear.app/angel-protocol/issue/AP-736/ast-and-angel-giving-dashboard
- https://linear.app/angel-protocol/issue/AP-737/anvil-form-success-page-text

## Explanation of the solution
* ast sections still showing in charity admin
  - corrected incorrect `show/hide` logic
* `fetch` errors not showing, can't parse received error structure
  - add case in error handler
* referral code label


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes