### PR TITLE
ap-748: Disable fiat when not AST

### DIFF
--- a/src/components/KYC/Form/index.tsx
+++ b/src/components/KYC/Form/index.tsx
@@ -10,8 +10,7 @@ import Tooltip from "./Tooltip";
 import { states } from "./us-states";
 import useSubmit from "./useSubmit";
 
-export const formStyle =
-  "w-full bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white font-work p-3";
+export const formStyle = "w-full text-gray-d2 dark:text-white font-work p-3";
 
 export default function Form({ classes = "", ...props }: Props) {
   const {

--- a/src/components/donation/Steps/CurrentStep.tsx
+++ b/src/components/donation/Steps/CurrentStep.tsx
@@ -3,7 +3,8 @@ import { useGetWallet } from "contexts/WalletContext";
 import KYC from "components/KYC";
 import Status, { LoadingStatus } from "components/Status";
 import { useGetter, useSetter } from "store/accessors";
-import { fiatWallet, isFiat, resetDetails } from "slices/donation";
+import { fiatWallet, resetDetails } from "slices/donation";
+import { IS_AST } from "constants/env";
 import { ConfigParams } from "..";
 import Donater from "./Donater";
 import Result from "./Result";
@@ -12,9 +13,8 @@ import Submit from "./Submit";
 export default function CurrentStep(props: ConfigParams) {
   const state = useGetter((state) => state.donation);
   const dispatch = useSetter();
-  const { wallet = fiatWallet, isLoading } = useGetWallet();
-
-  const _key = isFiat(wallet) ? "fiat" : "crypto";
+  const { wallet = IS_AST ? fiatWallet : undefined, isLoading } =
+    useGetWallet();
 
   /** reset form state when user disconnects, user might change wallet */
   useEffect(() => {
@@ -55,7 +55,7 @@ export default function CurrentStep(props: ConfigParams) {
       );
     }
     case "donate-form": {
-      return <Donater {...state} config={props} wallet={wallet} key={_key} />;
+      return <Donater {...state} config={props} wallet={wallet} />;
     }
 
     //init

--- a/src/components/donation/Steps/Donater/Form/index.tsx
+++ b/src/components/donation/Steps/Donater/Form/index.tsx
@@ -70,7 +70,7 @@ export default function Form(props: {
             fieldName="country"
             onReset={() => resetField("country")}
             classes={{
-              container: "px-4 dark:bg-blue-d6",
+              container: "px-4 dark:bg-blue-d6 mb-3",
               input: "py-3.5 placeholder:text-sm",
               error: "field-error",
             }}

--- a/src/components/donation/Steps/Donater/index.tsx
+++ b/src/components/donation/Steps/Donater/index.tsx
@@ -45,7 +45,7 @@ export default function Donater({
   const methods = useForm<DonateValues>({
     mode: "onChange",
     reValidateMode: "onChange",
-    defaultValues: state.details || {
+    values: state.details || {
       token: initCoin,
       pctLiquidSplit: liquidPct,
 

--- a/src/components/donation/Steps/index.tsx
+++ b/src/components/donation/Steps/index.tsx
@@ -1,6 +1,7 @@
 import { useGetter } from "store/accessors";
 import { DonationState } from "slices/donation";
 import { PAYMENT_WORDS } from "constants/common";
+import { IS_AST } from "constants/env";
 import CurrentStep from "./CurrentStep";
 
 export type ConfigParams = {
@@ -20,7 +21,9 @@ export function Steps({ className = "", ...params }: Props) {
       {!isFinalized(state) && (
         <span className="text-center font-normal text-xs sm:text-sm mb-12">
           Connect the wallet of your choice to donate crypto. <br />
-          Continue below to {PAYMENT_WORDS.verb} fiat (Dollars, GBP, AUD, Euro)
+          {IS_AST
+            ? `Continue below to ${PAYMENT_WORDS.verb} fiat (Dollars, GBP, AUD, Euro)`
+            : ""}
         </span>
       )}
 

--- a/src/constants/contracts.ts
+++ b/src/constants/contracts.ts
@@ -15,11 +15,11 @@ const mainnet:Contracts = {
 
 //prettier-ignore
 const testnet:Contracts = {
-  registrar:             "0xF4A06771BFCADf6B750e92281E19e8d50455763a",
-  "index-fund":          "0xcECd3FB781F3188A6A68536D65364E5259ac8BcC",
-  "multisig/ap":         "0x9fb2Fe98029D760167E74115B09bab97124EbC7E",
-  "multisig/review":     "0x9f4F6436E351Fc04731ac522Ab90C5C1a3a8FDF4",
-  accounts:              "0xf04B21CAF20A131588a3B577BB7AD6c8b37b4326",
+  registrar:             "0x3a6401423dd7D145b3EdF3b21f77caC180866BF9",
+  "index-fund":          "0x46F9E60BacBa503e406A099aF30c16a8062BFeBA",
+  "multisig/ap":         "0xB8A37752b3Ed29A3F984127e4b9eF8514E9be371",
+  "multisig/review":     "0x98aD858917410Eb4E0f7E617Ce385B57B4142c88",
+  accounts:              "0x7602AB005DEe896A0ecac7B87C6D09f8609348d4",
   "gift-card":           "0x47e49a7700c9D79412bb47385eD349106d4941F9",
 }
 

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -4,4 +4,4 @@ import { IS_AST, IS_TEST } from "constants/env";
 export const network: NetworkType = IS_TEST ? "testnet" : "mainnet";
 export const client: DonateClient = IS_AST ? "normal" : "apes";
 export const GRAPHQL_ENDPOINT =
-  "https://api.studio.thegraph.com/query/49156/angel-giving/v0.0.36";
+  "https://api.studio.thegraph.com/query/49156/angel-giving/v0.0.39";


### PR DESCRIPTION
Ticket(s):

## Explanation of the solution
* only pass `fiatWallet` when AST - when wallet is not connected for charity, prompt will show instead of fiat options
<img width="561" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/31a30699-ce21-40df-9c99-ac67a280602a">




## Other fixes
* kyc form incorrect background on `/admin/deposit` - remove and let it blend with container background
* `Please send me tax receipt` have no space together with `Country of residence` - add margin to `Country of residence`
* update to latest contracts and subgraph endpoint 


## Instructions on making this work


- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes