### PR TITLE
Legacy: continue button disabled

### DIFF
--- a/src/components/donation/Steps/Donater/Form/index.tsx
+++ b/src/components/donation/Steps/Donater/Form/index.tsx
@@ -35,6 +35,8 @@ export default function Form(props: {
     reset();
   }
 
+  const isStepOneCompleted = !!getValues("token").amount;
+
   return (
     <form
       onSubmit={handleSubmit(submit)}
@@ -79,8 +81,11 @@ export default function Form(props: {
         )}
         <button
           className="btn-orange btn-donate w-1/2"
-          //make sure that fields doesn't make form dirty on initial load
-          disabled={!isValid || !isDirty || isSubmitting}
+          // * make sure that fields doesn't make form dirty on initial load
+          // * isStepOneCompleted, when user goes back to step 1 (filled out previously)
+          disabled={
+            !isValid || isSubmitting || !(isDirty || isStepOneCompleted)
+          }
           type="submit"
         >
           Continue


### PR DESCRIPTION
Ticket(s):
- N/A
Repro:
  1. fill amount (e.g 1 usdc )
  2. continue
  3. go back to `step 1`, continue is disabled although `1 usdc` amount is given

## Explanation of the solution
* add `isStepOneCompleted`  flag 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes