### PR TITLE
ap-764: Legacy profile

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -44,7 +44,7 @@ export default function App() {
               />
               <Route
                 path={`${appRoutes.profile}/:id/*`}
-                element={<Profile />}
+                element={<Profile legacy />}
               />
               <Route path={`${appRoutes.admin}/:id/*`} element={<Admin />} />
 

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -39,6 +39,10 @@ export default function App() {
             />
             <Route element={<Layout />}>
               <Route
+                path={`${appRoutes.marketplace}/:id/*`}
+                element={<Profile />}
+              />
+              <Route
                 path={`${appRoutes.profile}/:id/*`}
                 element={<Profile />}
               />

--- a/src/App/Header/index.tsx
+++ b/src/App/Header/index.tsx
@@ -67,6 +67,7 @@ function hasBanner(location: Location): boolean {
       appRoutes.gift + "/*",
       appRoutes.donate + "/:id",
       appRoutes.profile + "/:id",
+      appRoutes.marketplace + "/:id",
     ].map((r) => ({ path: r })),
     location
   );

--- a/src/components/KYC/Form/Controls.tsx
+++ b/src/components/KYC/Form/Controls.tsx
@@ -41,7 +41,7 @@ export default function Controls({
       </button>
 
       <Link
-        to={appRoutes.profile + `/${endowId}`}
+        to={appRoutes.marketplace + `/${endowId}`}
         className="col-span-full btn-outline btn-donate"
       >
         Cancel

--- a/src/components/WalletSuite/ConnectedWallet/Details/Favourites/Favourite.tsx
+++ b/src/components/WalletSuite/ConnectedWallet/Details/Favourites/Favourite.tsx
@@ -1,13 +1,23 @@
 import { Link } from "react-router-dom";
+import { WalletProfileVersion } from "services/types";
 import { EndowmentBookmark } from "types/aws";
 import Image from "components/Image";
 import { appRoutes } from "constants/routes";
 
-export default function Favourite({ name, endowId, logo }: EndowmentBookmark) {
+export default function Favourite({
+  name,
+  endowId,
+  logo,
+  version,
+}: EndowmentBookmark & { version: WalletProfileVersion }) {
   return (
     <li>
       <Link
-        to={appRoutes.profile + "/" + endowId}
+        to={
+          appRoutes[version === "latest" ? "marketplace" : "profile"] +
+          "/" +
+          endowId
+        }
         className="flex items-center gap-2 py-1 font-heading font-semibold text-sm hover:bg-orange-l5 dark:hover:bg-blue-d3 rounded"
       >
         <Image src={logo} className="w-4 h-4 rounded-full" />

--- a/src/components/WalletSuite/ConnectedWallet/Details/Favourites/index.tsx
+++ b/src/components/WalletSuite/ConnectedWallet/Details/Favourites/index.tsx
@@ -1,3 +1,4 @@
+import { WalletProfileVersion } from "services/types";
 import { EndowmentBookmark } from "types/aws";
 import QueryLoader from "components/QueryLoader";
 import Favourite from "./Favourite";
@@ -5,12 +6,18 @@ import Favourite from "./Favourite";
 const MAX_ELEMENTS_TO_DISPLAY = 7;
 
 type Props = {
+  version: WalletProfileVersion;
   bookmarks: EndowmentBookmark[] | undefined;
   isError: boolean;
   isLoading: boolean;
 };
 
-export default function Favourites({ bookmarks, isError, isLoading }: Props) {
+export default function Favourites({
+  bookmarks,
+  isError,
+  isLoading,
+  version,
+}: Props) {
   return (
     <div className="flex flex-col gap-3 max-h-[244px] flex-1 p-4 border-b border-prim">
       <h3 className="flex justify-between gap-2">
@@ -39,7 +46,11 @@ export default function Favourites({ bookmarks, isError, isLoading }: Props) {
         {(bookmarks) => (
           <ul className="grid gap-1">
             {bookmarks.slice(0, MAX_ELEMENTS_TO_DISPLAY).map((b) => (
-              <Favourite key={`favourite-${b.endowId}`} {...b} />
+              <Favourite
+                key={`favourite-${b.endowId}`}
+                {...b}
+                version={version}
+              />
             ))}
           </ul>
         )}

--- a/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/Links.tsx
+++ b/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/Links.tsx
@@ -1,11 +1,19 @@
 import { Link } from "react-router-dom";
+import { WalletProfileVersion } from "services/types";
 import { appRoutes } from "constants/routes";
 
-export default function Links({ endowmentId }: { endowmentId: number }) {
+type Props = {
+  endowmentId: number;
+  version: WalletProfileVersion;
+};
+
+export default function Links({ endowmentId, version }: Props) {
   return (
     <div className="flex items-center uppercase font-heading font-semibold text-xs underline underline-offset-2">
       <Link
-        to={`${appRoutes.profile}/${endowmentId}`}
+        to={`${
+          appRoutes[version == "latest" ? "marketplace" : "profile"]
+        }/${endowmentId}`}
         className="pr-2 text-orange hover:text-orange-l2 decoration-1 hover:decoration-2"
       >
         profile

--- a/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/Links.tsx
+++ b/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/Links.tsx
@@ -12,7 +12,7 @@ export default function Links({ endowmentId, version }: Props) {
     <div className="flex items-center uppercase font-heading font-semibold text-xs underline underline-offset-2">
       <Link
         to={`${
-          appRoutes[version == "latest" ? "marketplace" : "profile"]
+          appRoutes[version === "latest" ? "marketplace" : "profile"]
         }/${endowmentId}`}
         className="pr-2 text-orange hover:text-orange-l2 decoration-1 hover:decoration-2"
       >

--- a/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/MyEndowments.tsx
+++ b/src/components/WalletSuite/ConnectedWallet/Details/MyEndowments/MyEndowments.tsx
@@ -1,11 +1,12 @@
+import { WalletProfileVersion } from "services/types";
 import { EndowmentBookmark } from "types/aws";
 import Image from "components/Image";
 import { IS_AST } from "constants/env";
 import Links from "./Links";
 
-type Props = { endowments: EndowmentBookmark[] };
+type Props = { endowments: EndowmentBookmark[]; version: WalletProfileVersion };
 
-export default function MyEndowments({ endowments }: Props) {
+export default function MyEndowments({ endowments, version }: Props) {
   return (
     <div className="grid p-4 gap-3 border-b border-prim">
       <h3 className="text-sm text-gray-d1 dark:text-gray">
@@ -24,7 +25,7 @@ export default function MyEndowments({ endowments }: Props) {
 
             <div className="grid items-center">
               <Name value={endowment.name} />
-              <Links endowmentId={endowment.endowId} />
+              <Links endowmentId={endowment.endowId} version={version} />
             </div>
           </div>
         ))}

--- a/src/components/WalletSuite/ConnectedWallet/Details/index.tsx
+++ b/src/components/WalletSuite/ConnectedWallet/Details/index.tsx
@@ -17,7 +17,7 @@ import MyEndowments from "./MyEndowments";
 
 export default function Details(props: WalletState) {
   const {
-    data: profile,
+    data: walletProfile,
     isLoading,
     isFetching,
     isError,
@@ -37,8 +37,11 @@ export default function Details(props: WalletState) {
             <MobileTitle className="sm:hidden" onClose={close} />
             <AdminLinks {...props} />
 
-            {!!profile?.admin?.length && (
-              <MyEndowments endowments={profile.admin} />
+            {!!walletProfile?.admin?.length && (
+              <MyEndowments
+                endowments={walletProfile.admin}
+                version={walletProfile.version}
+              />
             )}
 
             <div className="grid gap-3 p-4 border-b border-prim">
@@ -48,7 +51,8 @@ export default function Details(props: WalletState) {
             </div>
             <MyDonations address={props.address} />
             <Favourites
-              bookmarks={profile?.bookmarks}
+              version={walletProfile?.version ?? "latest"}
+              bookmarks={walletProfile?.bookmarks}
               isError={isError}
               isLoading={isLoading || isFetching}
             />

--- a/src/components/donation/Steps/Donater/Form/index.tsx
+++ b/src/components/donation/Steps/Donater/Form/index.tsx
@@ -103,7 +103,7 @@ export default function Form(props: {
         {!isInsideWidget && (
           <Link
             className="btn-outline-filled btn-donate w-1/2"
-            to={`${appRoutes.profile}/${endowId}`}
+            to={`${appRoutes.marketplace}/${endowId}`}
           >
             Cancel
           </Link>

--- a/src/components/donation/Steps/Result/Err.tsx
+++ b/src/components/donation/Steps/Result/Err.tsx
@@ -28,7 +28,7 @@ export default function Err({
       </p>
       <div className="grid sm:grid-cols-2 mt-12 gap-5 w-full sm:w-auto">
         <Link
-          to={appRoutes.profile + `/${endowId}`}
+          to={appRoutes.marketplace + `/${endowId}`}
           className="btn-outline-filled btn-donate w-full text-center"
         >
           Back to the platform

--- a/src/components/donation/Steps/Result/Success/index.tsx
+++ b/src/components/donation/Steps/Result/Success/index.tsx
@@ -60,7 +60,7 @@ export default function Success({
       </div>
 
       <Link
-        to={appRoutes.profile + `/${id}`}
+        to={appRoutes.marketplace + `/${id}`}
         className="w-full sm:w-auto btn-orange btn-donate"
       >
         Back to the platform

--- a/src/components/donation/Steps/Submit/index.tsx
+++ b/src/components/donation/Steps/Submit/index.tsx
@@ -81,7 +81,7 @@ export default function Submit(props: WithWallet<SubmitStep>) {
           Complete
         </button>
         <Link
-          to={appRoutes.profile + `/${endowId}`}
+          to={appRoutes.marketplace + `/${endowId}`}
           className="col-span-full btn-outline btn-donate"
         >
           Cancel

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -79,7 +79,8 @@ const _chains: { [key in chainIDs]: Info } = {
 };
 
 export const chains: { [index: string]: Info } = new Proxy(_chains, {
-  get(target, key: chainIDs) {
+  get(target, key: chainIDs | "staging") {
+    if (key === "staging") return target["80001"];
     return (
       target[key] ?? {
         txExplorer: DAPP_URL,

--- a/src/pages/Admin/Charity/DonationsTable/Table.tsx
+++ b/src/pages/Admin/Charity/DonationsTable/Table.tsx
@@ -43,14 +43,6 @@ export default function Table({
           >
             Amount
           </HeaderButton>
-          <HeaderButton
-            onClick={handleHeaderClick("amount")}
-            _activeSortKey={sortKey}
-            _sortKey="amount"
-            _sortDirection={sortDirection}
-          >
-            Amount
-          </HeaderButton>
           <>Currency</>
           <HeaderButton
             onClick={handleHeaderClick("date")}

--- a/src/pages/Admin/Charity/EditProfile/Form.tsx
+++ b/src/pages/Admin/Charity/EditProfile/Form.tsx
@@ -38,7 +38,7 @@ export default function Form({
     >
       <fieldset disabled={!!tooltip} className="group contents">
         <Link
-          to={`${appRoutes.profile}/${id}`}
+          to={`${appRoutes.marketplace}/${id}`}
           className="text-blue hover:text-orange text-sm flex items-center gap-1"
         >
           <Icon type="Back" />

--- a/src/pages/Admin/Charity/EditProfile/index.tsx
+++ b/src/pages/Admin/Charity/EditProfile/index.tsx
@@ -18,7 +18,12 @@ import { toProfileUpdate } from "./update";
 
 export default function EditProfile() {
   const { id } = useAdminContext(ops);
-  const { data: profile, isLoading, isFetching, isError } = useProfileQuery(id);
+  const {
+    data: profile,
+    isLoading,
+    isFetching,
+    isError,
+  } = useProfileQuery({ endowId: id });
 
   const content =
     isLoading || isFetching ? (

--- a/src/pages/Admin/Charity/OtherSettings/DonorVerification/DonorVerification.tsx
+++ b/src/pages/Admin/Charity/OtherSettings/DonorVerification/DonorVerification.tsx
@@ -17,7 +17,7 @@ import ChangeSettingsPrompt from "./Prompt";
 
 export default function DonorVerification() {
   const { id } = useAdminContext<"charity">();
-  const queryState = useProfileQuery(id, { skip: id === 0 });
+  const queryState = useProfileQuery({ endowId: id }, { skip: id === 0 });
 
   return (
     <>

--- a/src/pages/Admin/Charity/Programs/List.tsx
+++ b/src/pages/Admin/Charity/Programs/List.tsx
@@ -7,7 +7,7 @@ import { Program } from "./Program";
 
 export default function List() {
   const { id } = useAdminContext();
-  const queryState = useProfileQuery(id);
+  const queryState = useProfileQuery({ endowId: id });
 
   return (
     <QueryLoader

--- a/src/pages/Admin/Charity/Seo.tsx
+++ b/src/pages/Admin/Charity/Seo.tsx
@@ -12,7 +12,7 @@ export default function Seo({
   url?: string;
 }) {
   const { id } = useAdminContext();
-  const { data: profile } = useProfileQuery(id);
+  const { data: profile } = useProfileQuery({ endowId: id });
 
   return (
     <CommonSEO

--- a/src/pages/Admin/Charity/WidgetConfigurer/useLoadDefaultEndowmentName.ts
+++ b/src/pages/Admin/Charity/WidgetConfigurer/useLoadDefaultEndowmentName.ts
@@ -21,7 +21,7 @@ export default function useLoadDefaultEndowmentName(
       }
 
       try {
-        const { data, isError, error } = await queryProfile(endowId);
+        const { data, isError, error } = await queryProfile({ endowId });
 
         if (isError) {
           return handleError(error);

--- a/src/pages/Admin/Charity/common/useUpdateEndowmentProfile.ts
+++ b/src/pages/Admin/Charity/common/useUpdateEndowmentProfile.ts
@@ -58,7 +58,7 @@ export default function useUpdateEndowmentProfile() {
           message: "Profile successfully updated",
           link: {
             description: "View changes",
-            url: `${appRoutes.profile}/${cleanUpdates.id}`,
+            url: `${appRoutes.marketplace}/${cleanUpdates.id}`,
           },
         },
       });

--- a/src/pages/Admin/Sidebar/Header/CharityHeader.tsx
+++ b/src/pages/Admin/Sidebar/Header/CharityHeader.tsx
@@ -9,7 +9,11 @@ import MyEndowments from "./MyEndowments";
 
 export default function CharityHeader() {
   const { id } = useAdminContext();
-  const { data: profile, isLoading, isError } = useProfileQuery(id);
+  const {
+    data: profile,
+    isLoading,
+    isError,
+  } = useProfileQuery({ endowId: id });
   const { wallet } = useGetWallet();
   const { data } = useWalletProfileQuery(wallet?.address!, {
     skip: !wallet,

--- a/src/pages/Donate/Content.tsx
+++ b/src/pages/Donate/Content.tsx
@@ -41,7 +41,7 @@ function Content(props: DonationRecipient) {
             { title: "Marketplace", to: appRoutes.marketplace },
             {
               title: props.name,
-              to: `${appRoutes.profile}/${props.id}`,
+              to: `${appRoutes.marketplace}/${props.id}`,
             },
             {
               title: "Donate",

--- a/src/pages/Donate/index.tsx
+++ b/src/pages/Donate/index.tsx
@@ -10,7 +10,7 @@ import Content from "./Content";
 export default function Donate() {
   const { id } = useParams<{ id: string }>();
   const numId = idParamToNum(id);
-  const queryState = useProfileQuery(numId, { skip: numId === 0 });
+  const queryState = useProfileQuery({ endowId: numId }, { skip: numId === 0 });
 
   return (
     <section className="grid content-start w-full font-work min-h-screen sm:min-h-[900px] pb-20">

--- a/src/pages/DonateWidget/EndowmentLoader.tsx
+++ b/src/pages/DonateWidget/EndowmentLoader.tsx
@@ -10,7 +10,7 @@ type Props = { children(data: Profile): ReactElement };
 export default function EndowmentLoader({ children }: Props) {
   const { id } = useParams<{ id: string }>();
   const endowId = idParamToNum(id);
-  const queryState = useProfileQuery(endowId, { skip: endowId === 0 });
+  const queryState = useProfileQuery({ endowId }, { skip: endowId === 0 });
 
   return (
     <QueryLoader

--- a/src/pages/Donations/Table.tsx
+++ b/src/pages/Donations/Table.tsx
@@ -7,6 +7,7 @@ import useKYC from "components/KYC/useKYC";
 import TableSection, { Cells } from "components/TableSection";
 import useSort from "hooks/useSort";
 import { getTxUrl, humanize } from "helpers";
+import { chainIds } from "constants/chainIds";
 import { appRoutes } from "constants/routes";
 import LoadMoreBtn from "./LoadMoreBtn";
 
@@ -98,7 +99,11 @@ export default function Table({
               }`}
             >
               <Link
-                to={`${appRoutes.profile}/${row.id}`}
+                to={`${
+                  appRoutes[
+                    row.chainId === chainIds.juno ? "profile" : "marketplace"
+                  ]
+                }/${row.id}`}
                 className="flex items-center justify-between gap-1 cursor-pointer text-sm hover:underline"
               >
                 <span className="truncate max-w-[12rem]">

--- a/src/pages/Gift/Purchase/Purchaser/Form/index.tsx
+++ b/src/pages/Gift/Purchase/Purchaser/Form/index.tsx
@@ -41,7 +41,10 @@ export default function Form({ classes = "" }) {
       <Recipient classes="mt-8" />
 
       <div className="grid grid-cols-2 gap-5 font-body mt-8 md:mt-12">
-        <Link className="btn-outline btn-gift" to={`${appRoutes.profile}/1`}>
+        <Link
+          className="btn-outline btn-gift"
+          to={`${appRoutes.marketplace}/1`}
+        >
           Cancel
         </Link>
         <button

--- a/src/pages/Leaderboard/Table/Row/index.tsx
+++ b/src/pages/Leaderboard/Table/Row/index.tsx
@@ -24,7 +24,7 @@ export default function Row({
         className="h-16 aspect-video rounded border border-gray-l3 dark:border-none dark:bg-white p-2"
       />
       <Link
-        to={`../${appRoutes.profile}/${endowment_id}`}
+        to={`../${appRoutes.marketplace}/${endowment_id}`}
         className="hover:text-blue active:text-blue-d1"
       >
         {charity_name}

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -33,7 +33,7 @@ export default function Card({
         <BookmarkBtn endowId={id} />
       </div>
       <Link
-        to={`${appRoutes.profile}/${id}`}
+        to={`${appRoutes.marketplace}/${id}`}
         className="grid grid-rows-[auto_1fr] h-full"
       >
         <Image

--- a/src/pages/Profile/Body/Body.tsx
+++ b/src/pages/Profile/Body/Body.tsx
@@ -23,7 +23,7 @@ export default function Body() {
               ? []
               : [
                   { title: "Marketplace", to: appRoutes.marketplace },
-                  { title: p.name, to: `${appRoutes.profile}/${p.id}` },
+                  { title: p.name, to: `${appRoutes.marketplace}/${p.id}` },
                 ]
           }
         />

--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -1,24 +1,39 @@
-import { useParams } from "react-router-dom";
+import { Navigate, useParams } from "react-router-dom";
 import { useProfileQuery } from "services/aws/aws";
 import Image from "components/Image";
 import Seo from "components/Seo";
 import { idParamToNum } from "helpers";
 import { APP_NAME, DAPP_URL } from "constants/env";
+import { appRoutes } from "constants/routes";
 import Body from "./Body";
 import PageError from "./PageError";
 import ProfileContext, { useProfileContext } from "./ProfileContext";
 import Skeleton from "./Skeleton";
 import Unpublished from "./Unpublished";
 
-export default function Profile() {
+export default function Profile({ legacy = false }) {
   const { id } = useParams<{ id: string }>();
   const numId = idParamToNum(id);
-  const { isLoading, isError, data } = useProfileQuery(numId, {
-    skip: numId === 0,
-  });
+  const { isLoading, isError, data } = useProfileQuery(
+    { endowId: numId, isLegacy: legacy },
+    {
+      skip: numId === 0,
+    }
+  );
 
   if (isLoading) return <Skeleton />;
   if (isError || !data) return <PageError />;
+
+  if (legacy) {
+    if (data.id === null) {
+      return <Navigate to={appRoutes.marketplace} />;
+    }
+
+    if (data.id !== numId) {
+      return <Navigate to={`${appRoutes.profile}/${data.id}`} />;
+    }
+  }
+
   if (!data.published) return <Unpublished />;
 
   return (

--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -30,7 +30,7 @@ export default function Profile({ legacy = false }) {
     }
 
     if (data.id !== numId) {
-      return <Navigate to={`${appRoutes.profile}/${data.id}`} />;
+      return <Navigate to={`${appRoutes.marketplace}/${data.id}`} />;
     }
   }
 

--- a/src/pages/Registration/Signup/useSubmit.ts
+++ b/src/pages/Registration/Signup/useSubmit.ts
@@ -4,6 +4,7 @@ import { InitReg } from "../types";
 import { FormValues } from "./types";
 import { useNewApplicationMutation } from "services/aws/registration";
 import { useErrorContext } from "contexts/ErrorContext";
+import { storeRegistrationReference } from "helpers";
 import routes from "../routes";
 
 export default function useSubmit() {
@@ -22,6 +23,7 @@ export default function useSubmit() {
         email: res.ContactPerson.Email,
         reference: res.ContactPerson.PK,
       };
+      storeRegistrationReference(state.reference);
       navigate(routes.welcome, { state });
     } catch (err) {
       handleError(err);

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -114,12 +114,14 @@ export const aws = createApi({
       },
       transformResponse: (response: { data: any }) => response,
     }),
-    profile: builder.query<Profile, number>({
+    profile: builder.query<Profile, { endowId: number; isLegacy?: boolean }>({
       providesTags: ["profile"],
-      query: (endowId) =>
-        IS_AST
+      query: ({ endowId, isLegacy = false }) => ({
+        params: { legacy: isLegacy },
+        url: IS_AST
           ? `/${v(1)}/ast/${chainIds.polygon}/${endowId}`
           : `/${v(2)}/profile/${network}/endowment/${endowId}`,
+      }),
       transformResponse(r: EndowmentProfile) {
         //transform cloudsearch placeholders
         const tagline = r.tagline === " " ? "" : r.tagline;

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -1,5 +1,10 @@
 import { createApi, fetchBaseQuery, retry } from "@reduxjs/toolkit/query/react";
-import { Profile, ProfileUpdatePayload, isDeleteMsg } from "../types";
+import {
+  Profile,
+  ProfileUpdatePayload,
+  VersionSpecificWalletProfile,
+  isDeleteMsg,
+} from "../types";
 import {
   EndowListPaginatedAWSQueryRes,
   EndowmentCard,
@@ -84,9 +89,15 @@ export const aws = createApi({
         };
       },
     }),
-    walletProfile: builder.query<WalletProfile, string>({
+    walletProfile: builder.query<VersionSpecificWalletProfile, string>({
       providesTags: ["walletProfile"],
       query: getWalletProfileQuery,
+      transformResponse(res: WalletProfile, meta, walletAddr) {
+        return {
+          ...res,
+          version: walletAddr.startsWith("juno") ? "legacy" : "latest",
+        };
+      },
     }),
     toggleBookmark: builder.mutation<
       unknown,

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -4,4 +4,4 @@ import { IS_AST, IS_TEST } from "constants/env";
 export const network: NetworkType = IS_TEST ? "testnet" : "mainnet";
 export const client: DonateClient = IS_AST ? "normal" : "apes";
 export const GRAPHQL_ENDPOINT =
-  "https://api.studio.thegraph.com/query/49156/angel-giving/v0.0.39";
+  "https://api.studio.thegraph.com/query/49156/angel-giving/v0.0.43";

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -3,6 +3,7 @@ import {
   BridgeFees,
   EndowmentProfile,
   EndowmentProfileUpdate,
+  WalletProfile,
 } from "types/aws";
 import { EndowmentDetails } from "types/contracts";
 import { AccountType, EndowmentType } from "types/lists";
@@ -122,3 +123,8 @@ export type FiscalSponsorhipAgreementSigner =
       email: string;
     }
   | string; //signerEID;
+
+export type WalletProfileVersion = "legacy" | "latest";
+export type VersionSpecificWalletProfile = WalletProfile & {
+  version: "legacy" | "latest";
+};


### PR DESCRIPTION
Ticket(s):
-

## Explanation of the solution
* change polygon links to from `/profile` to `/marketplace`
* point juno donation profile links  to `/profile` the rest to `/marketplace`
* point juno wallet profile links to `/profile`, the rest to `/marketplace`
* test, go to `/profile/1` --> redirect to `marketplace/2` 



## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes