### PR TITLE
AP-785: execption rendering wallet option

### DIFF
--- a/src/contexts/WalletContext/WalletContext.tsx
+++ b/src/contexts/WalletContext/WalletContext.tsx
@@ -282,7 +282,7 @@ export default function WalletContext(props: PropsWithChildren<{}>) {
       <setContext.Provider
         value={{
           connections: IS_MOBILE
-            ? wcConnections
+            ? wcConnections.concat(web3AuthConnection) //web3 auth should also work on mobile
             : [
                 web3AuthConnection,
                 metamaskConnection,

--- a/src/contexts/WalletContext/WalletContext.tsx
+++ b/src/contexts/WalletContext/WalletContext.tsx
@@ -282,7 +282,8 @@ export default function WalletContext(props: PropsWithChildren<{}>) {
       <setContext.Provider
         value={{
           connections: IS_MOBILE
-            ? wcConnections.concat(web3AuthConnection) //web3 auth should also work on mobile
+            ? //web3 auth should also work on mobile
+              [web3AuthConnection].concat(wcConnections)
             : [
                 web3AuthConnection,
                 metamaskConnection,

--- a/src/contexts/WalletContext/types.ts
+++ b/src/contexts/WalletContext/types.ts
@@ -11,6 +11,7 @@ export type WithoutInstallers = Exclude<
 >;
 
 export type Connection = {
+  providerId: ProviderId;
   logo: string;
   installUrl?: string;
   name: string;

--- a/src/contexts/WalletContext/useInjectedProvider.ts
+++ b/src/contexts/WalletContext/useInjectedProvider.ts
@@ -231,6 +231,7 @@ export default function useInjectedProvider(
 
   //connection object to render <Connector/>
   const connection: Connection = {
+    providerId,
     name: connectorName,
     logo: WALLET_METADATA[providerId].logo,
     installUrl: WALLET_METADATA[providerId].installUrl,

--- a/src/contexts/WalletContext/useKeplr/useKeplr.ts
+++ b/src/contexts/WalletContext/useKeplr/useKeplr.ts
@@ -127,7 +127,11 @@ export default function useKeplr() {
       : undefined;
 
   //connection object to render <Connector/>
-  const connection: Connection = { ...WALLET_METADATA.keplr, connect };
+  const connection: Connection = {
+    ...WALLET_METADATA.keplr,
+    connect,
+    providerId: "keplr",
+  };
 
   return {
     connection,

--- a/src/contexts/WalletContext/useTerra.ts
+++ b/src/contexts/WalletContext/useTerra.ts
@@ -47,8 +47,11 @@ export default function useTerra() {
       : undefined;
 
   const terraConnections: Connection[] = availableConnections
+
     .filter(_filter)
     .map((connection) => ({
+      //provider IDs for terra wallets are simply from their identifiers
+      providerId: connection.identifier as ProviderId,
       logo: connection.icon,
       name: connection.name,
       connect: async () => {
@@ -56,16 +59,20 @@ export default function useTerra() {
       },
     }))
     .concat(
-      availableInstallations.filter(_filter).map(({ name, icon, url }) => ({
-        logo: icon,
-        name,
-        connect: async () => {
-          window.open(url, "_blank", "noopener noreferrer");
-        },
-      }))
+      availableInstallations
+        .filter(_filter)
+        .map(({ name, icon, url, identifier }) => ({
+          providerId: identifier as ProviderId,
+          logo: icon,
+          name,
+          connect: async () => {
+            window.open(url, "_blank", "noopener noreferrer");
+          },
+        }))
     );
 
   const wcConnection: Connection = {
+    providerId: "walletconnect",
     name: "Terra Station Mobile",
     logo: "/icons/wallets/terra-extension.jpg",
     async connect() {

--- a/src/contexts/WalletContext/useWeb3Auth/index.ts
+++ b/src/contexts/WalletContext/useWeb3Auth/index.ts
@@ -2,6 +2,7 @@ import type { Maybe, SafeEventEmitterProvider } from "@web3auth/base";
 import Decimal from "decimal.js";
 import { useEffect, useState } from "react";
 import { ProviderInfo } from "../types";
+import { Connection } from "../types";
 import { BaseChain } from "types/aws";
 import { AccountChangeHandler, ChainChangeHandler } from "types/evm";
 import { isEmpty, logger } from "helpers";
@@ -140,13 +141,16 @@ export default function useWeb3Auth() {
         }
       : undefined;
 
+  const connection: Connection = {
+    providerId: "web3auth-torus",
+    connect: login,
+    logo: "https://web3auth.io/images/w3a-L-Favicon-1.svg",
+    name: "Web3 Auth",
+  };
+
   return {
     isLoading: state.status === "loading",
-    connection: {
-      connect: login,
-      logo: "https://web3auth.io/images/w3a-L-Favicon-1.svg",
-      name: "Web3 Auth",
-    },
+    connection,
     providerInfo,
     disconnect: logout,
     switchChain,

--- a/src/contexts/WalletContext/wallet-connect/useEVMWC.ts
+++ b/src/contexts/WalletContext/wallet-connect/useEVMWC.ts
@@ -141,6 +141,7 @@ export function useEVMWC() {
       : undefined;
 
   const connection: Connection = {
+    providerId: "evm-wc",
     name: "Metamask mobile",
     logo: WALLET_METADATA["evm-wc"].logo,
     installUrl: WALLET_METADATA["evm-wc"].logo,

--- a/src/contexts/WalletContext/wallet-connect/useKeplrWC.ts
+++ b/src/contexts/WalletContext/wallet-connect/useKeplrWC.ts
@@ -103,6 +103,7 @@ export function useKeplrWC() {
       : undefined;
 
   const connection: Connection = {
+    providerId: "keplr-wc",
     name: "Keplr mobile",
     logo: WALLET_METADATA["keplr-wc"].logo,
     installUrl: WALLET_METADATA["keplr-wc"].logo,

--- a/src/pages/Launchpad/ConnectWallet/ChooseWallet/WalletConnector.tsx
+++ b/src/pages/Launchpad/ConnectWallet/ChooseWallet/WalletConnector.tsx
@@ -6,6 +6,7 @@ export default function WalletConnector({ name, logo, connect }: Connection) {
 
   return (
     <button
+      type="button"
       onClick={() => connect().catch(handleError)}
       className="flex items-center border border-prim w-full p-4 mb-2 rounded"
     >

--- a/src/pages/Launchpad/ConnectWallet/ChooseWallet/WalletConnector.tsx
+++ b/src/pages/Launchpad/ConnectWallet/ChooseWallet/WalletConnector.tsx
@@ -1,36 +1,15 @@
 import { useErrorContext } from "contexts/ErrorContext";
-import { useSetWallet } from "contexts/WalletContext";
+import { Connection } from "contexts/WalletContext";
 
-export default function WalletConnector({
-  name,
-  label,
-}: {
-  name: string;
-  label: string;
-}) {
-  const { connections } = useSetWallet();
+export default function WalletConnector({ name, logo, connect }: Connection) {
   const { handleError } = useErrorContext();
-  const connection = connections.find((c) => c.name === name)!;
-  async function handleConnect() {
-    try {
-      //wallet is connected at this point
-      //keplr connection is single connection
-      await connection!.connect!();
-    } catch (err: any) {
-      handleError(err);
-    }
-  }
 
   return (
     <button
-      onClick={handleConnect}
+      onClick={() => connect().catch(handleError)}
       className="flex items-center border border-prim w-full p-4 mb-2 rounded"
     >
-      <img
-        src={connection.logo}
-        alt=""
-        className="w-8 h-8 object-contain mr-4"
-      />
+      <img src={logo} alt="" className="w-8 h-8 object-contain mr-4" />
       <span className="font-heading font-bold text-lg">{name}</span>
     </button>
   );

--- a/src/pages/Launchpad/ConnectWallet/ChooseWallet/index.tsx
+++ b/src/pages/Launchpad/ConnectWallet/ChooseWallet/index.tsx
@@ -1,16 +1,29 @@
 import { Link } from "react-router-dom";
+import { ProviderId } from "types/lists";
 import { steps } from "pages/Launchpad/constants";
+import { useSetWallet } from "contexts/WalletContext";
 import WalletConnector from "./WalletConnector";
 
+const supportedProviderIds: ProviderId[] = [
+  "web3auth-torus",
+  "metamask",
+  "evm-wc",
+];
+
 export default function ChooseWallet() {
+  const { connections } = useSetWallet();
   return (
     <div className="w-full grid">
       <h3 className="text-lg">Choose a wallet</h3>
       <p className="mb-8 text-sm text-gray-d1 dark:text-gray mt-2">
         We recommend using a new wallet.
       </p>
-      <WalletConnector name="Web3 Auth" label="Social login or email" />
-      <WalletConnector name="Metamask" label="Metamask" />
+      {connections
+        .filter((c) => supportedProviderIds.includes(c.providerId))
+        .map((connection) => (
+          <WalletConnector key={connection.providerId} {...connection} />
+        ))}
+
       <div className="grid grid-cols-2 md:flex gap-3 items-center mt-8">
         <Link
           to={`../${steps[6]}`}

--- a/src/pages/Registration/Steps/WalletRegistration/ChooseWallet/WalletConnector.tsx
+++ b/src/pages/Registration/Steps/WalletRegistration/ChooseWallet/WalletConnector.tsx
@@ -1,35 +1,24 @@
 import { useErrorContext } from "contexts/ErrorContext";
-import { useSetWallet } from "contexts/WalletContext";
+import { Connection } from "contexts/WalletContext";
 
-type Props = {
-  label: string;
-  connectorName: string;
-};
-export default function WalletConnector({ label, connectorName }: Props) {
-  const { connections } = useSetWallet();
+export default function WalletConnector({
+  connect,
+  logo,
+  name,
+  providerId,
+}: Connection) {
   const { handleError } = useErrorContext();
-  const connection = connections.find((c) => c.name === connectorName)!;
-  async function handleConnect() {
-    try {
-      //wallet is connected at this point
-      //keplr connection is single connection
-      await connection!.connect!();
-    } catch (err: any) {
-      handleError(err);
-    }
-  }
-
   return (
     <button
-      onClick={handleConnect}
+      onClick={() => connect().catch(handleError)}
       className="flex items-center border border-prim w-full p-4 mb-2 rounded"
     >
-      <img
-        src={connection.logo}
-        alt=""
-        className="w-8 h-8 object-contain mr-4"
-      />
-      <span className="font-heading font-bold text-lg">{label}</span>
+      <img src={logo} alt="" className="w-8 h-8 object-contain mr-4" />
+      <span className="font-heading font-bold text-lg">
+        {providerId === "web3auth-torus"
+          ? "Register with Email (Web3 Auth)"
+          : name}
+      </span>
     </button>
   );
 }

--- a/src/pages/Registration/Steps/WalletRegistration/ChooseWallet/index.tsx
+++ b/src/pages/Registration/Steps/WalletRegistration/ChooseWallet/index.tsx
@@ -15,10 +15,6 @@ export default function ChooseWallet() {
   const { data } = useRegState<3>();
   const { connections } = useSetWallet();
 
-  const supportedConnections = connections.filter((c) =>
-    supportedProviderIds.includes(c.providerId)
-  );
-
   return (
     <div className="w-full grid">
       <h3 className="text-lg">Choose a wallet</h3>
@@ -29,9 +25,11 @@ export default function ChooseWallet() {
         <span className="italic">seedphrase</span> and will enable you to use an
         email address or one of your social media accounts to log in.
       </p>
-      {supportedConnections.map((connection) => (
-        <WalletConnector key={connection.providerId} {...connection} />
-      ))}
+      {connections
+        .filter((c) => supportedProviderIds.includes(c.providerId))
+        .map((connection) => (
+          <WalletConnector key={connection.providerId} {...connection} />
+        ))}
       <Link
         to={`../${steps.doc}`}
         state={data.init}

--- a/src/pages/Registration/Steps/WalletRegistration/ChooseWallet/index.tsx
+++ b/src/pages/Registration/Steps/WalletRegistration/ChooseWallet/index.tsx
@@ -1,10 +1,24 @@
 import { Link } from "react-router-dom";
+import { ProviderId } from "types/lists";
+import { useSetWallet } from "contexts/WalletContext";
 import { steps } from "../../../routes";
 import { useRegState } from "../../StepGuard";
 import WalletConnector from "./WalletConnector";
 
+const supportedProviderIds: ProviderId[] = [
+  "web3auth-torus",
+  "metamask",
+  "evm-wc",
+];
+
 export default function ChooseWallet() {
   const { data } = useRegState<3>();
+  const { connections } = useSetWallet();
+
+  const supportedConnections = connections.filter((c) =>
+    supportedProviderIds.includes(c.providerId)
+  );
+
   return (
     <div className="w-full grid">
       <h3 className="text-lg">Choose a wallet</h3>
@@ -15,11 +29,9 @@ export default function ChooseWallet() {
         <span className="italic">seedphrase</span> and will enable you to use an
         email address or one of your social media accounts to log in.
       </p>
-      <WalletConnector
-        label="Register with Email (Web3 Auth)"
-        connectorName="Web3 Auth"
-      />
-      <WalletConnector connectorName="Metamask" label="Metamask" />
+      {supportedConnections.map((connection) => (
+        <WalletConnector key={connection.providerId} {...connection} />
+      ))}
       <Link
         to={`../${steps.doc}`}
         state={data.init}


### PR DESCRIPTION
Ticket(s):
-
* wallet options are set by `wallet name` and sometimes this name can't be found on the list of available connections.

## Explanation of the solution
* instead of finding `name` on connections, just render the `connections[]` directly. This would also handle cases where we need to show connections that are only supported on `mobile`

desktop options
<img width="755" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/a349488c-6db8-423a-be27-7bebd298e0cd">

mobile options
<img width="641" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/f1e9ee05-0038-432a-b8dd-3444128d6ec9">


## Refactors
* include `providerId` in `type Connection` and filter based on it , instead of `string: name`
* also apply this change to `/launchpad/wallet` step

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes