### PR TITLE
RC-v1.8: Legal entity back to input text

### DIFF
--- a/src/pages/Admin/Review/Applications/__tests__/Applications.test.tsx
+++ b/src/pages/Admin/Review/Applications/__tests__/Applications.test.tsx
@@ -96,7 +96,7 @@ const mockApplications: EndowmentProposal[] = [
     HqCountry: "",
     CashEligible: true,
     AuthorizedToReceiveTaxDeductibleDonations: false,
-    LegalEntityType: "corporation",
+    LegalEntityType: "Corporation",
     ProjectDescription: "",
   },
   {
@@ -123,7 +123,7 @@ const mockApplications: EndowmentProposal[] = [
     HqCountry: "",
     CashEligible: true,
     AuthorizedToReceiveTaxDeductibleDonations: false,
-    LegalEntityType: "corporation",
+    LegalEntityType: "Corporation",
     ProjectDescription: "",
   },
   {
@@ -150,7 +150,7 @@ const mockApplications: EndowmentProposal[] = [
     HqCountry: "",
     CashEligible: true,
     AuthorizedToReceiveTaxDeductibleDonations: false,
-    LegalEntityType: "corporation",
+    LegalEntityType: "Corporation",
     ProjectDescription: "",
   },
 ];

--- a/src/pages/Registration/SignNotice.tsx
+++ b/src/pages/Registration/SignNotice.tsx
@@ -43,7 +43,7 @@ export default function SignatureNotice({ classes = "" }) {
         role: contact.role === "other" ? contact.otherRole : contact.role,
         org: {
           name: contact.orgName,
-          legalEntityType: documentation.legalEntityType.value,
+          legalEntityType: documentation.legalEntityType,
           hq: documentation.hqCountry.name,
           projectDescription: documentation.projectDescription,
         },

--- a/src/pages/Registration/SignNotice.tsx
+++ b/src/pages/Registration/SignNotice.tsx
@@ -38,7 +38,15 @@ export default function SignatureNotice({ classes = "" }) {
       const { url } = await generateSigningURL({
         id: reference,
         email: init.email,
-        name: contact.firstName + " " + contact.lastName,
+        firstName: contact.firstName,
+        lastName: contact.lastName,
+        role: contact.role,
+        org: {
+          name: contact.orgName,
+          legalEntityType: documentation.legalEntityType.value,
+          hq: documentation.hqCountry.name,
+          projectDescription: documentation.projectDescription,
+        },
       }).unwrap();
 
       window.location.href = url;

--- a/src/pages/Registration/SignNotice.tsx
+++ b/src/pages/Registration/SignNotice.tsx
@@ -40,7 +40,7 @@ export default function SignatureNotice({ classes = "" }) {
         email: init.email,
         firstName: contact.firstName,
         lastName: contact.lastName,
-        role: contact.role,
+        role: contact.role === "other" ? contact.otherRole : contact.role,
         org: {
           name: contact.orgName,
           legalEntityType: documentation.legalEntityType.value,

--- a/src/pages/Registration/Steps/Documentation/Form/index.tsx
+++ b/src/pages/Registration/Steps/Documentation/Form/index.tsx
@@ -125,7 +125,7 @@ export default function Form() {
         <Field<FV, "textarea">
           type="textarea"
           name="projectDescription"
-          label="Please provide a thorough description of your organization's charitable activities as well as your charitable mission."
+          label="Please provide a description of your organization's charitable activities as well as your charitable mission."
           required
           classes={{ container: "mb-6 mt-4" }}
           placeholder=""

--- a/src/pages/Registration/Steps/Documentation/Form/index.tsx
+++ b/src/pages/Registration/Steps/Documentation/Form/index.tsx
@@ -1,6 +1,5 @@
 import { Link } from "react-router-dom";
 import { FormValues as FV } from "../types";
-import { LegalEntityType } from "types/aws";
 import ActivityCountries from "components/ActivityCountries";
 import CountrySelector from "components/CountrySelector";
 import ExtLink from "components/ExtLink";
@@ -16,17 +15,6 @@ import { useRegState } from "../../StepGuard";
 import { MB_LIMIT } from "../schema";
 // import { CashEligibleCheckbox } from "./CashEligibleCheckbox";
 import useSubmit from "./useSubmit";
-
-const legalEntityTypes: { [K in LegalEntityType]: K } = {
-  "": "",
-  "Nonprofit Organization": "Nonprofit Organization",
-  "Limited Liability Company (LLC)": "Limited Liability Company (LLC)",
-  "Sole Proprietorship": "Sole Proprietorship",
-  "Government Agency": "Government Agency",
-  Corporation: "Corporation",
-  Partnership: "Partnership",
-  Other: "Other",
-};
 
 export default function Form() {
   const { data } = useRegState<2>();
@@ -104,18 +92,14 @@ export default function Form() {
           error: "field-error",
         }}
       />
-      <Label className="mb-2 mt-6" required>
-        What type of legal entity is your organization registered as? This can
-        usually be found in your registration/organizing document
-      </Label>
-      <Selector<FV, "legalEntityType", string>
+      <Field<FV>
         name="legalEntityType"
-        options={Object.entries(legalEntityTypes).map(([value, label]) => ({
-          label,
-          value,
-        }))}
+        label="What type of legal entity is your organization registered as? This can
+        usually be found in your registration/organizing document"
+        required
+        classes={{ container: "mb-2 mt-6" }}
+        placeholder="e.g. Nonprofit Organization"
       />
-
       <Label className="mt-6 mb-2">
         Select the countries your organization is active in
       </Label>

--- a/src/pages/Registration/Steps/Documentation/Form/index.tsx
+++ b/src/pages/Registration/Steps/Documentation/Form/index.tsx
@@ -19,12 +19,12 @@ import useSubmit from "./useSubmit";
 
 const legalEntityTypes: { [K in LegalEntityType]: K } = {
   "": "",
-  Corporation: "Corporation",
-  "Limited Liability Company (LLC)": "Limited Liability Company (LLC)",
-  Partnership: "Partnership",
-  "Sole Proprietorship": "Sole Proprietorship",
   "Nonprofit Organization": "Nonprofit Organization",
+  "Limited Liability Company (LLC)": "Limited Liability Company (LLC)",
+  "Sole Proprietorship": "Sole Proprietorship",
   "Government Agency": "Government Agency",
+  Corporation: "Corporation",
+  Partnership: "Partnership",
   Other: "Other",
 };
 

--- a/src/pages/Registration/Steps/Documentation/Form/index.tsx
+++ b/src/pages/Registration/Steps/Documentation/Form/index.tsx
@@ -17,10 +17,15 @@ import { MB_LIMIT } from "../schema";
 // import { CashEligibleCheckbox } from "./CashEligibleCheckbox";
 import useSubmit from "./useSubmit";
 
-const legalEntityTypes: { [K in LegalEntityType]: string } = {
-  "": "Select type",
-  corporation: "corporation",
-  organization: "organization",
+const legalEntityTypes: { [K in LegalEntityType]: K } = {
+  "": "",
+  Corporation: "Corporation",
+  "Limited Liability Company (LLC)": "Limited Liability Company (LLC)",
+  Partnership: "Partnership",
+  "Sole Proprietorship": "Sole Proprietorship",
+  "Nonprofit Organization": "Nonprofit Organization",
+  "Government Agency": "Government Agency",
+  Other: "Other",
 };
 
 export default function Form() {

--- a/src/pages/Registration/Steps/Documentation/Form/useSubmit.ts
+++ b/src/pages/Registration/Steps/Documentation/Form/useSubmit.ts
@@ -66,7 +66,7 @@ export default function useSubmit() {
         EIN: ein,
         AuthorizedToReceiveTaxDeductibleDonations:
           isAuthorizedToReceiveTaxDeductibleDonations === "Yes" ? true : false,
-        LegalEntityType: legalEntityType.value,
+        LegalEntityType: legalEntityType,
         ProjectDescription: projectDescription,
       });
     } catch (err) {

--- a/src/pages/Registration/Steps/Documentation/Form/useSubmit.ts
+++ b/src/pages/Registration/Steps/Documentation/Form/useSubmit.ts
@@ -44,7 +44,7 @@ export default function useSubmit() {
     ...documents
   }) => {
     try {
-      if (documentation && !isDirty) {
+      if (!isDirty && documentation) {
         return navigate(`../${step}`, { state: init });
       }
       const previews = await getFilePreviews({ ...documents });

--- a/src/pages/Registration/Steps/Documentation/index.tsx
+++ b/src/pages/Registration/Steps/Documentation/index.tsx
@@ -31,7 +31,7 @@ function Documentation() {
           isAuthorizedToReceiveTaxDeductibleDonations: "Yes",
           signedFiscalSponsorshipAgreement: "",
           fiscalSponsorshipAgreementSigningURL: "",
-          legalEntityType: { label: "", value: "" },
+          legalEntityType: "",
           projectDescription: "",
 
           hasAuthority: false,

--- a/src/pages/Registration/Steps/Documentation/schema.ts
+++ b/src/pages/Registration/Steps/Documentation/schema.ts
@@ -53,7 +53,7 @@ export const schema = object<any, SchemaShape<FormValues>>({
     name: requiredString,
   }),
   endowDesignation: optionSchema,
-  legalEntityType: optionSchema,
+  legalEntityType: requiredString,
   //isKYCRequired defaulted to No on default value
   projectDescription: string().when(
     authorizedToReceiveTaxDeductibleDonationsKey,

--- a/src/pages/Registration/Steps/getRegistrationState.ts
+++ b/src/pages/Registration/Steps/getRegistrationState.ts
@@ -127,7 +127,7 @@ function formatDocumentation({
       AuthorizedToReceiveTaxDeductibleDonations ? "Yes" : "No",
     fiscalSponsorshipAgreementSigningURL: FiscalSponsorshipAgreementSigningURL,
     signedFiscalSponsorshipAgreement: SignedFiscalSponsorshipAgreement,
-    legalEntityType: { value: LegalEntityType, label: LegalEntityType },
+    legalEntityType: LegalEntityType,
     projectDescription: ProjectDescription,
 
     //meta

--- a/src/pages/Registration/types.ts
+++ b/src/pages/Registration/types.ts
@@ -1,9 +1,4 @@
-import {
-  ContactRoles,
-  LegalEntityType,
-  ReferralMethods,
-  RegistrationStatus,
-} from "types/aws";
+import { ContactRoles, ReferralMethods, RegistrationStatus } from "types/aws";
 import { EndowmentTierNum } from "types/contracts";
 import { Country } from "types/countries";
 import { UNSDG_NUMS } from "types/lists";
@@ -56,7 +51,7 @@ export type Documentation = {
   isAuthorizedToReceiveTaxDeductibleDonations: "Yes" | "No";
   fiscalSponsorshipAgreementSigningURL: string;
   signedFiscalSponsorshipAgreement: string;
-  legalEntityType: OptionType<LegalEntityType>;
+  legalEntityType: string;
   projectDescription: string;
 
   //others

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -119,8 +119,16 @@ export type Multisig = {
 export type FiscalSponsorhipAgreementSigner =
   | {
       id: string;
-      name: string;
+      firstName: string;
+      lastName: string;
       email: string;
+      role: string;
+      org: {
+        name: string;
+        legalEntityType: string;
+        hq: string;
+        projectDescription: string;
+      };
     }
   | string; //signerEID;
 

--- a/src/types/aws/ap/registration.ts
+++ b/src/types/aws/ap/registration.ts
@@ -8,7 +8,15 @@ export type RegistrationStatus =
 
 export type ApplicationStatus = "approved" | "not-complete" | "under-review";
 
-export type LegalEntityType = "" | "organization" | "corporation";
+export type LegalEntityType =
+  | ""
+  | "Corporation"
+  | "Limited Liability Company (LLC)"
+  | "Partnership"
+  | "Sole Proprietorship"
+  | "Nonprofit Organization"
+  | "Government Agency"
+  | "Other";
 
 export type ReferralMethods =
   | ""

--- a/src/types/aws/ap/registration.ts
+++ b/src/types/aws/ap/registration.ts
@@ -8,16 +8,6 @@ export type RegistrationStatus =
 
 export type ApplicationStatus = "approved" | "not-complete" | "under-review";
 
-export type LegalEntityType =
-  | ""
-  | "Corporation"
-  | "Limited Liability Company (LLC)"
-  | "Partnership"
-  | "Sole Proprietorship"
-  | "Nonprofit Organization"
-  | "Government Agency"
-  | "Other";
-
 export type ReferralMethods =
   | ""
   | "referral"
@@ -89,7 +79,7 @@ export type TDocumentation = {
   HqCountry: string;
   EndowDesignation: string;
   ActiveInCountries: string[];
-  LegalEntityType: LegalEntityType;
+  LegalEntityType: string;
   ProjectDescription: string;
 
   //fiscal sponsorship


### PR DESCRIPTION
Ticket(s):
-
follow up to 
* #2354
related to
- https://github.com/AngelProtocolFinance/devops/pull/344

## Explanation of the solution
input field legal entity
<img width="740" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/961dbbea-042b-4e83-ac2a-1b25f6124532">




## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes