### PR TITLE
AP-798 v1.9: Marketplace cards use logo instead of image

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -46,7 +46,7 @@ export const ENDOW_DESIGNATIONS: {
   value: EndowDesignation;
   icon: IconType;
 }[] = [
-  { label: "Charity", value: "Charity", icon: "Charity" },
+  { label: "Charity", value: "Charity", icon: "HeartFill" },
   {
     label: "Religious Organization",
     value: "Religious Organization",

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -15,7 +15,7 @@ const PLACEHOLDER_TAGLINE = " ";
 export default function Card({
   active_in_countries = [],
   name,
-  image,
+  logo,
   id,
   endow_designation,
   sdgs,
@@ -38,7 +38,7 @@ export default function Card({
       >
         <Image
           loading="lazy"
-          src={image}
+          src={logo}
           className="h-40 w-full object-cover bg-blue-l4 dark:bg-blue-d2"
           onError={(e) => e.currentTarget.classList.add("bg-blue-l3")}
         />

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Tags.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Tags.tsx
@@ -10,7 +10,7 @@ export default function Tags(props: EndowmentProfile) {
       {<EndowDesignationTag {...props} />}
       {props.kyc_donors_only && (
         <Tag>
-          Verification required <Icon type="Info" size={24} />
+          <Icon type="SecurityScan" size={24} /> Donor Verification required
         </Tag>
       )}
       {props.sdgs.map((unsdg_num) => (

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -200,7 +200,7 @@ const endowCardObj: {
   active_in_countries: "",
   sdgs: "",
   id: "",
-  image: "",
+  logo: "",
   kyc_donors_only: "",
   contributor_verification_required: "",
   name: "",

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -41,7 +41,7 @@ type EndowmentBase = {
   active_in_countries?: string[];
   sdgs: UNSDG_NUMS[];
   id: number;
-  image: string;
+  logo: string;
   kyc_donors_only: boolean;
   contributor_verification_required: boolean;
   program: Program[];
@@ -53,7 +53,7 @@ type EndowmentBase = {
 export type EndowmentProfile = EndowmentBase & {
   fiscal_sponsored: boolean;
   contact_email: string;
-  logo: string;
+  image: string;
   overview?: string;
   published: boolean;
   registration_number?: string;


### PR DESCRIPTION
Ticket(s):
- https://linear.app/angel-protocol/issue/AP-798/marketplace-cards-use-logo-images

## Explanation of the solution
- Switch to use logo instead of banner image for marketplace cards. 
- Minor fixes to profile details tags

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes