### PR TITLE
Fix: marketplace link active 

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -39,10 +39,6 @@ export default function App() {
             />
             <Route element={<Layout />}>
               <Route
-                path={`${appRoutes.marketplace}/:id/*`}
-                element={<Profile />}
-              />
-              <Route
                 path={`${appRoutes.profile}/:id/*`}
                 element={<Profile legacy />}
               />
@@ -64,6 +60,11 @@ export default function App() {
               />
               <Route path={`${appRoutes.gift}/*`} element={<Gift />} />
               <Route path={appRoutes.marketplace} element={<Marketplace />} />
+
+              <Route path={appRoutes.marketplace}>
+                <Route path=":id" element={<Profile />} />
+                <Route index element={<Marketplace />} />
+              </Route>
             </Route>
             <Route
               path="*"

--- a/src/App/Header/DesktopNav.tsx
+++ b/src/App/Header/DesktopNav.tsx
@@ -24,6 +24,7 @@ export default function DesktopNav({ classes, links }: Props) {
         ) : (
           <NavLink
             key={`header-link-${link.title}`}
+            end={link.end}
             to={link.href}
             className={createNavLinkStyler(
               styles,

--- a/src/App/Header/MobileNav/Menu.tsx
+++ b/src/App/Header/MobileNav/Menu.tsx
@@ -45,6 +45,7 @@ export default function Menu({
               key={`header-link-${link.title}`}
               className={styler}
               to={link.href}
+              end={link.end}
             >
               {link.title}
             </NavLink>

--- a/src/App/constants.ts
+++ b/src/App/constants.ts
@@ -15,6 +15,7 @@ export const CHARITY_LINKS: LINKS = {
     {
       title: "Marketplace",
       href: appRoutes.marketplace,
+      end: true,
     },
     {
       title: "Giving Partners",

--- a/src/App/types.ts
+++ b/src/App/types.ts
@@ -8,6 +8,7 @@ export type Link = {
   };
   href: string;
   external?: boolean;
+  end?: boolean;
 };
 
 type SocialMedia =
@@ -20,7 +21,7 @@ type SocialMedia =
   | "Linkedin"
   | "Instagram";
 
-export type SocialMediaLink = Required<Omit<Link, "external">> & {
+export type SocialMediaLink = Required<Omit<Link, "external" | "end">> & {
   title: SocialMedia;
 };
 
@@ -29,5 +30,6 @@ export type LinkGroup = {
   links: {
     text: string;
     href?: string;
+    exact?: boolean;
   }[];
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from "@sentry/react";
-import React from "react";
 import { StrictMode, Suspense, lazy } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";


### PR DESCRIPTION
Ticket(s):
- when visiting `marketplace/:id` the marketplace link is active even though user is visiting a segment deeper

## Explanation of the solution
- mark `/marketplace` end so it wont `active` when visiting deeper segments
not active anymore
<img width="1470" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/65ed6190-0ef9-46ca-91e0-6eb1379e3e0a">

-  group marketplace related links

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes