### PR TITLE
HOT FIX: unplushing profile not working

### DIFF
--- a/src/helpers/__tests__/cleanObject.test.ts
+++ b/src/helpers/__tests__/cleanObject.test.ts
@@ -1,13 +1,33 @@
+// Import the cleanObject function from your TypeScript file.
 import { cleanObject } from "../cleanObject";
 
-//NOTE: intended for shallow form objects only atm
+// Replace 'your-file' with the actual path to your TypeScript file.
+
 describe("cleanObject", () => {
-  test("removes falsy values except 0", () => {
-    expect(
-      cleanObject({ a: undefined, b: "", c: 0, d: null, e: "hello" })
-    ).toStrictEqual({
-      c: 0,
-      e: "hello",
+  test("remove blacklisted values", () => {
+    const inputObject = {
+      prop1: "Hello",
+      prop2: null,
+      prop3: "",
+      prop4: [],
+      prop5: undefined,
+      prop6: {},
+      prop7: "World",
+      prop8: [1, 2, 3],
+      prop9: false,
+      prop10: 0,
+      prop12: { hello: "world" },
+    };
+
+    const cleanedObject = cleanObject(inputObject);
+
+    expect(cleanedObject).toStrictEqual({
+      prop1: "Hello",
+      prop7: "World",
+      prop8: [1, 2, 3],
+      prop9: false,
+      prop10: 0,
+      prop12: { hello: "world" },
     });
   });
 });

--- a/src/helpers/cleanObject.ts
+++ b/src/helpers/cleanObject.ts
@@ -1,14 +1,18 @@
-export function cleanObject<T extends object>(obj: T) {
-  const cleanedObj: Partial<T> = {};
+export function cleanObject<T extends Record<string, any>>(obj: T): T {
+  const cleanedObject: any = {};
+
   for (const key in obj) {
     const val = obj[key];
-    //include all truthy values and 0
-    if (val || isZero(val)) {
-      cleanedObj[key] = val;
+    if (
+      obj.hasOwnProperty(key) && //must be first layer prop
+      val != null && // must not be null or undefined
+      val !== "" && // must not be empty string
+      (Array.isArray(val) ? val.length > 0 : true) && // if array, must not be empty
+      (typeof val === "object" ? Object.keys(val).length > 0 : true) //if object, must not be empty
+    ) {
+      cleanedObject[key] = val;
     }
   }
 
-  return cleanedObj as T;
+  return cleanedObject as T;
 }
-
-const isZero = (val: any) => val === 0;


### PR DESCRIPTION
Ticket(s):
-
when property `published` is set to `false` it is being ommited by `cleanObject` helper

## Explanation of the solution
* update `cleanObject` to explicitly define values that needs to be omitted
* update test

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes