### PR TITLE
[Hot Fix] Reduced File Size Upload for Charity Registration from 25 to 6 MB

### DIFF
--- a/src/pages/Registration/Steps/Documentation/schema.ts
+++ b/src/pages/Registration/Steps/Documentation/schema.ts
@@ -9,7 +9,7 @@ import { genFileSchema } from "schemas/file";
 import { requiredString } from "schemas/string";
 import { MAX_SDGS } from "constants/unsdgs";
 
-export const MB_LIMIT = 25;
+export const MB_LIMIT = 6;
 const BYTES_IN_MB = 1e6;
 
 const VALID_MIME_TYPES = [


### PR DESCRIPTION
Ticket(s):
- n/a

## Explanation of the solution

Due to some applicants uploading files greater than 10 MB, and also to API Gateway's payload limit of 10 MB. We would need to tell the users that the actual file size that we can handle for now is ~6 MB.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify that file size limit requirement was reduced from 25 to 6

## UI changes for review

No major UI changes