### PR TITLE
OAuth manual redirect

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/react";
 import { WalletProvider } from "@terra-money/wallet-provider";
 import { lazy } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+import OAUTHRedirector from "pages/OAuthRedirector";
 import ModalContext from "contexts/ModalContext";
 import WalletContext from "contexts/WalletContext";
 import useScrollTop from "hooks/useScrollTop";
@@ -73,6 +74,10 @@ export default function App() {
               <Route path={`${appRoutes.gift}/*`} element={<Gift />} />
               <Route path={appRoutes.marketplace} element={<Marketplace />} />
               <Route path={appRoutes.signin} element={<Signin />} />
+              <Route
+                path={appRoutes.auth_redirector}
+                element={<OAUTHRedirector />}
+              />
               <Route path={appRoutes.marketplace}>
                 <Route path=":id/*" element={<Profile />} />
                 <Route index element={<Marketplace />} />

--- a/src/App/Header/UserMenu/UserMenu.tsx
+++ b/src/App/Header/UserMenu/UserMenu.tsx
@@ -1,6 +1,10 @@
 import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react";
 import { Popover } from "@headlessui/react";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import Icon from "components/Icon";
+import { OAUTH_PATH_STORAGE_KEY } from "constants/o-auth";
+import { appRoutes } from "constants/routes";
 import Menu from "./Menu";
 
 export default function UserMenu() {
@@ -48,10 +52,22 @@ export default function UserMenu() {
           <Menu user={user} signOut={signOut} isLoading={isLoading} />
         </Popover.Panel>
       ) : (
-        <Popover.Panel className="mt-2 absolute z-10 w-max max-sm:fixed-center sm:right-0">
-          <Authenticator formFields={{ signUp: { name: { order: 1 } } }} />
-        </Popover.Panel>
+        <AuthenticatorPanel />
       )}
     </Popover>
+  );
+}
+
+function AuthenticatorPanel() {
+  const location = useLocation();
+  useEffect(() => {
+    if (location.pathname.startsWith(appRoutes.auth_redirector)) return;
+    localStorage.setItem(OAUTH_PATH_STORAGE_KEY, location.pathname);
+    //eslint-disable-next-line
+  }, [location.pathname]);
+  return (
+    <Popover.Panel className="mt-2 absolute z-10 w-max max-sm:fixed-center sm:right-0">
+      <Authenticator formFields={{ signUp: { name: { order: 1 } } }} />
+    </Popover.Panel>
   );
 }

--- a/src/App/Header/index.tsx
+++ b/src/App/Header/index.tsx
@@ -47,7 +47,10 @@ export default function Header({ classes, links }: Props) {
         />
         <div className="flex gap-4 justify-self-end items-center">
           <ThemeToggle classes="hidden lg:flex" />
-          {location.pathname !== appRoutes.signin && <UserMenu />}
+          {!(
+            location.pathname === appRoutes.signin ||
+            location.pathname === appRoutes.auth_redirector
+          ) && <UserMenu />}
         </div>
         <MobileNavOpener classes="flex ml-2 lg:hidden" links={links} />
       </div>

--- a/src/constants/o-auth.ts
+++ b/src/constants/o-auth.ts
@@ -1,0 +1,1 @@
+export const OAUTH_PATH_STORAGE_KEY = "OATH_ORIGIN";

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,4 +1,5 @@
 export enum appRoutes {
+  auth_redirector = "/auth-redirector",
   marketplace = "/marketplace",
   leaderboard = "/leaderboard",
   admin = "/admin",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import Loader from "components/Loader";
 import { store } from "store/store";
 import { initTheme } from "helpers";
 import ErrorBoundary from "errors/ErrorBoundary";
+import { appRoutes } from "constants/routes";
 import config from "./aws-exports";
 import "./index.css";
 import reportWebVitals from "./reportWebVitals";
@@ -29,7 +30,8 @@ Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,
 });
 
-config.oauth.redirectSignIn = window.location.origin + "/";
+config.oauth.redirectSignIn =
+  window.location.origin + `${appRoutes.auth_redirector}/`;
 config.oauth.redirectSignOut = window.location.origin + "/";
 Amplify.configure(config);
 

--- a/src/pages/OAuthRedirector.tsx
+++ b/src/pages/OAuthRedirector.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import LoaderRing from "components/LoaderRing";
+import { OAUTH_PATH_STORAGE_KEY } from "constants/o-auth";
+
+export default function OAUTHRedirector() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    const from = localStorage.getItem(OAUTH_PATH_STORAGE_KEY);
+    navigate(from || "/");
+  }, [navigate]);
+  return (
+    <div className="grid place-items-center">
+      <LoaderRing thickness={12} classes="w-32" />
+    </div>
+  );
+}

--- a/src/pages/Signin/Signin.tsx
+++ b/src/pages/Signin/Signin.tsx
@@ -1,14 +1,24 @@
 import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react";
 import { useEffect } from "react";
 import { Location, useLocation, useNavigate } from "react-router-dom";
+import LoaderRing from "components/LoaderRing";
+import { OAUTH_PATH_STORAGE_KEY } from "constants/o-auth";
 
 export default function Signin() {
   const { state } = useLocation();
   const navigate = useNavigate();
   const _state = state as { from?: Location } | undefined;
-  const { route } = useAuthenticator((context) => [context.route]);
+  const { route, authStatus } = useAuthenticator((context) => [
+    context.route,
+    context.authStatus,
+  ]);
 
   const from = _state?.from?.pathname || "/";
+
+  useEffect(() => {
+    localStorage.setItem(OAUTH_PATH_STORAGE_KEY, from);
+    //eslint-disable-next-line
+  }, []);
 
   useEffect(() => {
     if (route === "authenticated") {
@@ -17,8 +27,13 @@ export default function Signin() {
   }, [route, navigate, from]);
 
   return (
-    <div className="grid content-start justify-items-center pt-8 pb-16">
-      <Authenticator formFields={{ signUp: { name: { order: 1 } } }} />
+    <div className="grid place-items-center py-14">
+      {authStatus === "configuring" || authStatus === "authenticated" ? (
+        //while user is still authenticated, use loader in place of authenticator while navigating
+        <LoaderRing thickness={12} classes="w-32" />
+      ) : (
+        <Authenticator formFields={{ signUp: { name: { order: 1 } } }} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Ticket(s):
- https://discord.com/channels/834976399228010527/1098542651218866208/1168752393194835969

## Explanation of the solution
* since we can't pass auth initiator as state n oauth url yet per issue
https://github.com/aws-amplify/amplify-ui/issues/2625
- save auth state in local storage 

tests redirects:
- [x]  register --> signin --> register
- [x]  admin/x --> signin --> admin/x
- [x] when logging in using header, just redirect back to the current path

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes