### PR TITLE
Create reusable `optionType()` schema

### DIFF
--- a/src/components/ActivityCountries.tsx
+++ b/src/components/ActivityCountries.tsx
@@ -1,6 +1,7 @@
 import { FieldValues, Path, PathValue } from "react-hook-form";
+import { OptionType } from "types/utils";
 import countries from "assets/countries/all.json";
-import { MultiSelector, OptionType } from "components/Selector";
+import { MultiSelector } from "components/Selector";
 
 type Props<T extends FieldValues, K extends Path<T>> = {
   name: PathValue<T, K> extends OptionType<string>[] ? K : never;

--- a/src/components/KYC/Form/us-states.ts
+++ b/src/components/KYC/Form/us-states.ts
@@ -1,4 +1,4 @@
-import { OptionType } from "components/Selector";
+import { OptionType } from "types/utils";
 
 export const states: OptionType<string>[] = [
   //from https://usastatescode.com/state-array-json

--- a/src/components/Selector/MultiSelector.tsx
+++ b/src/components/Selector/MultiSelector.tsx
@@ -8,8 +8,8 @@ import {
   useController,
   useFormContext,
 } from "react-hook-form";
-import { MultiselectorProps, ValKey } from "./types";
-import { OptionType } from "types/utils";
+import { MultiselectorProps } from "./types";
+import { OptionType, ValKey } from "types/utils";
 import Icon, { DrawerIcon } from "components/Icon";
 import FocusableInput from "./FocusableInput";
 import { styles, valueKey } from "./constants";

--- a/src/components/Selector/MultiSelector.tsx
+++ b/src/components/Selector/MultiSelector.tsx
@@ -8,7 +8,8 @@ import {
   useController,
   useFormContext,
 } from "react-hook-form";
-import { MultiselectorProps, OptionType, ValKey } from "./types";
+import { MultiselectorProps, ValKey } from "./types";
+import { OptionType } from "types/utils";
 import Icon, { DrawerIcon } from "components/Icon";
 import FocusableInput from "./FocusableInput";
 import { styles, valueKey } from "./constants";

--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -1,7 +1,8 @@
 import { Listbox } from "@headlessui/react";
 import { ErrorMessage } from "@hookform/error-message";
 import { FieldValues, Path, get, useController } from "react-hook-form";
-import { OptionType, Props, ValKey } from "./types";
+import { Props, ValKey } from "./types";
+import { OptionType } from "types/utils";
 import { DrawerIcon } from "components/Icon";
 import FocusableInput from "./FocusableInput";
 import { styles, valueKey } from "./constants";

--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -1,8 +1,8 @@
 import { Listbox } from "@headlessui/react";
 import { ErrorMessage } from "@hookform/error-message";
 import { FieldValues, Path, get, useController } from "react-hook-form";
-import { Props, ValKey } from "./types";
-import { OptionType } from "types/utils";
+import { Props } from "./types";
+import { OptionType, ValKey } from "types/utils";
 import { DrawerIcon } from "components/Icon";
 import FocusableInput from "./FocusableInput";
 import { styles, valueKey } from "./constants";

--- a/src/components/Selector/constants.ts
+++ b/src/components/Selector/constants.ts
@@ -1,4 +1,4 @@
-import { OptionType } from "./types";
+import { OptionType } from "types/utils";
 
 export const valueKey: keyof OptionType<any> = "value";
 

--- a/src/components/Selector/index.ts
+++ b/src/components/Selector/index.ts
@@ -3,6 +3,5 @@ import { styles } from "./constants";
 export { MultiSelector } from "./MultiSelector";
 export { Selector } from "./Selector";
 export { default as FocusableInput } from "./FocusableInput";
-export { type OptionType } from "./types";
 
 export const { selectorButton: selectorButtonStyle } = styles;

--- a/src/components/Selector/types.ts
+++ b/src/components/Selector/types.ts
@@ -1,8 +1,6 @@
 import { ReactNode } from "react";
 import { FieldValues, Path, PathValue } from "react-hook-form";
-import { OptionType } from "types/utils";
-
-export type ValKey = string | number;
+import { OptionType, ValKey } from "types/utils";
 
 type Classes = {
   container?: string;

--- a/src/components/Selector/types.ts
+++ b/src/components/Selector/types.ts
@@ -1,9 +1,8 @@
 import { ReactNode } from "react";
 import { FieldValues, Path, PathValue } from "react-hook-form";
+import { OptionType } from "types/utils";
 
 export type ValKey = string | number;
-
-export type OptionType<V> = { label: string; value: V };
 
 type Classes = {
   container?: string;

--- a/src/components/Selector/types.ts
+++ b/src/components/Selector/types.ts
@@ -4,6 +4,7 @@ import { FieldValues, Path, PathValue } from "react-hook-form";
 export type ValKey = string | number;
 
 export type OptionType<V> = { label: string; value: V };
+
 type Classes = {
   container?: string;
   button?: string;

--- a/src/pages/Admin/Charity/EditProfile/getSDGLabelValuePair.ts
+++ b/src/pages/Admin/Charity/EditProfile/getSDGLabelValuePair.ts
@@ -1,5 +1,5 @@
 import { UNSDG_NUMS } from "types/lists";
-import { OptionType } from "components/Selector";
+import { OptionType } from "types/utils";
 
 export const getSDGLabelValuePair = (
   key: string | number,

--- a/src/pages/Admin/Charity/EditProfile/schema.ts
+++ b/src/pages/Admin/Charity/EditProfile/schema.ts
@@ -2,8 +2,8 @@ import { ObjectSchema, array, object } from "yup";
 import { FV } from "./types";
 import { SchemaShape } from "schemas/types";
 import { ImgLink } from "components/ImgEditor";
-import { OptionType } from "components/Selector";
 import { genFileSchema } from "schemas/file";
+import { optionType } from "schemas/shape";
 import { requiredString, url } from "schemas/string";
 import { MAX_SDGS } from "constants/unsdgs";
 
@@ -23,7 +23,6 @@ const fileObj = object<any, SchemaShape<ImgLink>>({
 });
 
 //construct strict shape to avoid hardcoding shape keys
-
 export const schema = object<any, SchemaShape<FV>>({
   sdgs: array()
     .min(1, "required")
@@ -33,10 +32,7 @@ export const schema = object<any, SchemaShape<FV>>({
   logo: fileObj,
   url: url,
   // registration_number: no need to validate,
-  endow_designation: object<any, SchemaShape<OptionType<string>>>({
-    label: requiredString,
-    value: requiredString,
-  }),
+  endow_designation: optionType({ required: true }),
   name: requiredString,
   active_in_countries: array(),
   social_media_urls: object().shape<SchemaShape<FV["social_media_urls"]>>({

--- a/src/pages/Admin/Charity/EditProfile/types.ts
+++ b/src/pages/Admin/Charity/EditProfile/types.ts
@@ -2,8 +2,8 @@ import { OverrideProperties } from "type-fest";
 import { EndowDesignation, EndowmentProfileUpdate } from "types/aws";
 import { Country } from "types/countries";
 import { UNSDG_NUMS } from "types/lists";
+import { OptionType } from "types/utils";
 import { ImgLink } from "components/ImgEditor";
-import { OptionType } from "components/Selector";
 
 export type FV = OverrideProperties<
   EndowmentProfileUpdate,

--- a/src/pages/Donations/Filter/constants.ts
+++ b/src/pages/Donations/Filter/constants.ts
@@ -1,4 +1,4 @@
-import { OptionType } from "components/Selector";
+import { OptionType } from "types/utils";
 
 export const statuses: OptionType<string>[] = [
   { label: "RECEIVED", value: "RECEIVED" },

--- a/src/pages/Donations/Filter/types.ts
+++ b/src/pages/Donations/Filter/types.ts
@@ -1,4 +1,4 @@
-import { OptionType } from "components/Selector";
+import { OptionType } from "types/utils";
 
 export type FormValues = {
   startDate: string;

--- a/src/pages/Registration/Steps/ContactDetails/constants.ts
+++ b/src/pages/Registration/Steps/ContactDetails/constants.ts
@@ -1,5 +1,5 @@
 import { ContactRoles, ReferralMethods } from "types/aws";
-import { OptionType } from "components/Selector";
+import { OptionType } from "types/utils";
 
 export const roles: { [key in ContactRoles]: string } = {
   "": "",

--- a/src/pages/Registration/Steps/ContactDetails/index.tsx
+++ b/src/pages/Registration/Steps/ContactDetails/index.tsx
@@ -2,7 +2,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { FormProvider, useForm } from "react-hook-form";
 import { FormValues } from "./types";
 import { ContactRoles, ReferralMethods } from "types/aws";
-import { OptionType } from "components/Selector";
+import { OptionType } from "types/utils";
 import { useRegState, withStepGuard } from "../StepGuard";
 import Form from "./Form";
 import { referralMethods, roles } from "./constants";

--- a/src/pages/Registration/Steps/ContactDetails/schema.ts
+++ b/src/pages/Registration/Steps/ContactDetails/schema.ts
@@ -2,7 +2,7 @@ import { ObjectSchema, object, string } from "yup";
 import { FormValues } from "./types";
 import { SchemaShape } from "schemas/types";
 import { ContactRoles, ReferralMethods } from "types/aws";
-import { OptionType } from "components/Selector";
+import { OptionType } from "types/utils";
 import { optionType } from "schemas/shape";
 import { requiredString } from "schemas/string";
 

--- a/src/pages/Registration/Steps/ContactDetails/schema.ts
+++ b/src/pages/Registration/Steps/ContactDetails/schema.ts
@@ -3,6 +3,7 @@ import { FormValues } from "./types";
 import { SchemaShape } from "schemas/types";
 import { ContactRoles, ReferralMethods } from "types/aws";
 import { OptionType } from "components/Selector";
+import { optionType } from "schemas/shape";
 import { requiredString } from "schemas/string";
 
 type Key = keyof FormValues;
@@ -22,18 +23,14 @@ const otherReferralMethod = (referralMethod: ReferralMethods) =>
       : schema
   );
 
-const selectorOptionSchema = object<any, SchemaShape<OptionType<string>>>({
-  value: string().required("required"),
-});
-
 export const schema = object<any, SchemaShape<FormValues>>({
   orgName: requiredString,
   firstName: requiredString,
   lastName: requiredString,
   //email: disabled: already validated at signup
   goals: requiredString,
-  role: selectorOptionSchema,
-  referralMethod: selectorOptionSchema,
+  role: optionType({ required: true }),
+  referralMethod: optionType({ required: true }),
   otherReferralMethod: otherReferralMethod("other"),
   referralCode: otherReferralMethod("referral"),
   otherRole: otherRole,

--- a/src/pages/Registration/Steps/ContactDetails/types.ts
+++ b/src/pages/Registration/Steps/ContactDetails/types.ts
@@ -1,6 +1,6 @@
 import { ContactPerson } from "../../types";
 import { ContactRoles, ReferralMethods } from "types/aws";
-import { OptionType } from "components/Selector";
+import { OptionType } from "types/utils";
 
 export type FormValues = Omit<ContactPerson, "role" | "referralMethod"> & {
   role: OptionType<ContactRoles>;

--- a/src/pages/Registration/Steps/Documentation/schema.ts
+++ b/src/pages/Registration/Steps/Documentation/schema.ts
@@ -3,9 +3,9 @@ import { FormValues } from "./types";
 import { SchemaShape } from "schemas/types";
 import { FileObject } from "types/aws";
 import { Country } from "types/countries";
-import { OptionType } from "components/Selector";
 import { Asset } from "components/registration";
 import { genFileSchema } from "schemas/file";
+import { optionType } from "schemas/shape";
 import { requiredString } from "schemas/string";
 import { MAX_SDGS } from "constants/unsdgs";
 
@@ -37,11 +37,6 @@ function genAssetShape(isRequired: boolean = false): SchemaShape<Asset> {
   };
 }
 
-const optionSchema = object<any, SchemaShape<OptionType<string>>>({
-  label: requiredString,
-  value: requiredString,
-});
-
 export const schema = object<any, SchemaShape<FormValues>>({
   proofOfIdentity: object(genAssetShape(true)),
   proofOfRegistration: object(genAssetShape(true)),
@@ -52,7 +47,7 @@ export const schema = object<any, SchemaShape<FormValues>>({
   hqCountry: object<any, SchemaShape<Country>>({
     name: requiredString,
   }),
-  endowDesignation: optionSchema,
+  endowDesignation: optionType({ required: true }),
   legalEntityType: requiredString,
   //isKYCRequired defaulted to No on default value
   projectDescription: string().when(

--- a/src/pages/Registration/types.ts
+++ b/src/pages/Registration/types.ts
@@ -3,7 +3,7 @@ import { EndowmentTierNum } from "types/aws";
 import { Country } from "types/countries";
 import { UNSDG_NUMS } from "types/lists";
 import { Optional } from "types/utils";
-import { OptionType } from "components/Selector";
+import { OptionType } from "types/utils";
 import { Asset } from "components/registration";
 
 //REF_ID is global to registration

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -1,7 +1,7 @@
 import * as Yup from "yup";
 import { SchemaShape } from "./types";
 import type { TokenWithAmount as TWA } from "types/tx";
-import { OptionType } from "components/Selector";
+import { OptionType } from "types/utils";
 import { tokenConstraint } from "./number";
 import { requiredString } from "./string";
 

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -1,7 +1,9 @@
 import * as Yup from "yup";
 import { SchemaShape } from "./types";
 import type { TokenWithAmount as TWA } from "types/tx";
+import { OptionType } from "components/Selector";
 import { tokenConstraint } from "./number";
+import { requiredString } from "./string";
 
 type Key = keyof TWA;
 type Min = TWA["min_donation_amnt"];
@@ -12,7 +14,7 @@ const balKey: Key = "balance";
 export const tokenShape = (withMin = true): SchemaShape<TWA> => ({
   amount: Yup.lazy((amount: string) =>
     amount === ""
-      ? Yup.string().required("required")
+      ? requiredString
       : tokenConstraint.when([minKey, balKey], (values, schema) => {
           const [minAmount, balance] = values as [Min, Bal];
           return withMin && !!minAmount
@@ -23,3 +25,9 @@ export const tokenShape = (withMin = true): SchemaShape<TWA> => ({
         })
   ),
 });
+
+export const optionType = ({ required } = { required: false }) =>
+  Yup.object<any, SchemaShape<OptionType<string>>>({
+    label: required ? requiredString : Yup.string(),
+    value: required ? requiredString : Yup.string(),
+  });

--- a/src/slices/donation/types.ts
+++ b/src/slices/donation/types.ts
@@ -1,7 +1,7 @@
 import { Country } from "types/countries";
 import { EstimatedTx, TokenWithAmount } from "types/tx";
+import { OptionType } from "types/utils";
 import { WalletState } from "contexts/WalletContext";
-import { OptionType } from "components/Selector";
 
 export type DonationRecipient = {
   id: number;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -8,4 +8,6 @@ export type SemiPartial<T, K extends keyof T> = { [key in K]: T[key] } & {
   [key in Exclude<keyof T, K>]?: T[key];
 };
 
+export type ValKey = string | number;
+
 export type OptionType<V> = { label: string; value: V };

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -7,3 +7,5 @@ export type Diff = [string, PrimitiveValue, PrimitiveValue];
 export type SemiPartial<T, K extends keyof T> = { [key in K]: T[key] } & {
   [key in Exclude<keyof T, K>]?: T[key];
 };
+
+export type OptionType<V> = { label: string; value: V };


### PR DESCRIPTION
## Explanation of the solution
[OptionType<V>](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/RC-v1.9/src/components/Selector/types.ts#L6) is a commonly used type in forms, for which we usually create ad-hoc Yup schemas.
This PR intends to create a reusable schema type to be (re)used in these forms.

Schema looks like:
```ts
export const optionType = ({ required } = { required: false }) =>
  Yup.object<any, SchemaShape<OptionType<string>>>({
    label: required ? requiredString : Yup.string(),
    value: required ? requiredString : Yup.string(),
  });
```
And is used like:
- `field: optionType({ required: true })` - a required field
- `field: optionType({ required: false })` - an optional field
- `field: optionType()` - same as previous, an optional field

It is assumed that `OptionType<>.value` is to be of type `string` even when the actual value is of type `number` for the following reasons:
- since we only need to check whether the value is present (i.e. required) we can allow for `number` to automatically be converted to `string` for this purpose (as any number including 0 (zero) is converted to a non-empty string)
- if the actual type should be `number`, the validation would still function and the final value would still be of type `number`
- all the above being the case, it makes the implementation cleaner and easier to write

The reason for wrapping the `required` option in an object is so that when it needs to be used, it makes the intention more explicit:
```ts
  // intention to make the field "required" is clear
  endowDesignation: optionType({ required: true })
  // ...

  // the function accepts some boolean value, purpose of the parameter is not immediately apparent
  endowDesignation: optionType(true)
  // ...
```
Also allows for adding more parameters in the future (doubtful if it'll be necessary, but the option is there).

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes