### PR TITLE
AP-882 Marketplace Card: bookmark btn removed

### DIFF
--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -2,7 +2,6 @@ import { useRef } from "react";
 import { Link } from "react-router-dom";
 import { EndowmentCard } from "types/aws";
 import { UNSDG_NUMS } from "types/lists";
-import BookmarkBtn from "components/BookmarkBtn";
 import Icon from "components/Icon";
 import Image from "components/Image";
 import Tooltip from "components/Tooltip";
@@ -30,7 +29,6 @@ export default function Card({
           {endow_designation}
         </p>
         {kyc_donors_only && <KYCIcon className="ml-auto" />}
-        <BookmarkBtn endowId={id} />
       </div>
       <Link
         to={`${appRoutes.marketplace}/${id}`}


### PR DESCRIPTION
## Explanation of the solution
Bookmark button snuck back into the code for Marketplace cards. Removed it.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/b1eac97c-b449-4d78-b81e-94c97be24fea)
