### PR TITLE
Placeholder Other tab

### DIFF
--- a/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
+++ b/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
@@ -8,6 +8,14 @@ type Props = {
   donaterConfig: DonaterConfigFromWidget | null;
   state: FormStep;
 };
+
+const tabClasses = (selected: boolean) =>
+  `${
+    selected
+      ? "border-orange text-orange"
+      : "border-gray-l3 dark:border-bluegray"
+  } uppercase p-2 border-b-4 hover:text-orange-l1 hover:border-orange-l1`;
+
 export default function DonateMethods({ donaterConfig, state }: Props) {
   return (
     <Tab.Group
@@ -15,25 +23,12 @@ export default function DonateMethods({ donaterConfig, state }: Props) {
       className="grid content-start mt-2"
       defaultIndex={state.details?.method === "crypto" ? 1 : 0}
     >
-      <Tab.List as="div" className="grid grid-cols-2 mb-6">
-        <Tab
-          className={({ selected }) =>
-            `${
-              selected ? "border-orange" : "border-gray-l3 dark:border-bluegray"
-            } uppercase p-2 border-b-4 hover:text-orange-l1`
-          }
-        >
+      <Tab.List as="div" className="grid grid-cols-3 mb-6">
+        <Tab className={({ selected }) => tabClasses(selected)}>
           Credit/Debit
         </Tab>
-        <Tab
-          className={({ selected }) =>
-            `${
-              selected ? "border-orange" : "border-gray-l3 dark:border-bluegray"
-            } uppercase p-2 border-b-4 hover:text-orange-l1`
-          }
-        >
-          Crypto
-        </Tab>
+        <Tab className={({ selected }) => tabClasses(selected)}>Crypto</Tab>
+        <Tab className={({ selected }) => tabClasses(selected)}>Other</Tab>
       </Tab.List>
       <Tab.Panels>
         <Tab.Panel className="grid">
@@ -47,6 +42,14 @@ export default function DonateMethods({ donaterConfig, state }: Props) {
         </Tab.Panel>
         <Tab.Panel className="grid">
           <Donater {...state} config={donaterConfig} />
+        </Tab.Panel>
+        <Tab.Panel className="grid">
+          <div>
+            <p className="text-gray-d1 text-sm text-center">
+              Coming Soon! Watch here for donation options with Stock
+              contributions and DAFs.
+            </p>
+          </div>
         </Tab.Panel>
       </Tab.Panels>
     </Tab.Group>


### PR DESCRIPTION
Ticket(s): None

## Explanation of the solution
Some minor fixes to CSS and prep-work for new Tab ticket:
- Adds a placeholder Other tab (with some dummy text)
- Switch Tabs.Group from 2 >> 3 cols to accommodate 
- DRY up the CSS class setting for tabs + make text Orange on active tabs (not just hover)

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
### New "Other" tab
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/15c1a036-2c00-4847-818a-1fb771a81d06)

### CSS changes for hovering on tab
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/720ecb37-e975-4fd3-b171-66ebf7c87ae1)
