### PR TITLE
AP-905 No dark theme

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,6 @@ import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 import Loader from "components/Loader";
 import { store } from "store/store";
-import { initTheme } from "helpers";
 import ErrorBoundary from "errors/ErrorBoundary";
 import { appRoutes } from "constants/routes";
 import config from "./aws-exports";
@@ -15,7 +14,8 @@ import "./index.css";
 import reportWebVitals from "./reportWebVitals";
 
 //set theme immediately, so even suspense loaders and can use it
-initTheme();
+// NOTE: Turning off option for Dark theme for now
+// initTheme();
 
 const App = lazy(() => import("./App/App"));
 


### PR DESCRIPTION
Ticket(s):
- https://linear.app/angel-protocol/issue/AP-905/only-show-light-theme

## Explanation of the solution
Disable dark theme check on initial page load. The idea is to temporarily turn off any possibility for dark mode to be used. This PR finishes up dark theme related changes that were started by removing the theme toggle UI component from the header in #2478.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
None