### PR TITLE
AP-907 Protected user donations page & POC user header menu

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -67,8 +67,12 @@ export default function App() {
           />
 
           <Route
-            path={`${appRoutes.donations}/:address`}
-            element={<Donations />}
+            path={appRoutes.donations}
+            element={
+              <Protected>
+                <Donations />
+              </Protected>
+            }
           />
           <Route path={`${appRoutes.donate}/:id`} element={<Donate />} />
           <Route

--- a/src/App/Header/UserMenu/Menu.tsx
+++ b/src/App/Header/UserMenu/Menu.tsx
@@ -1,9 +1,12 @@
 import { WithAuthenticatorProps } from "@aws-amplify/ui-react";
+import { Link } from "react-router-dom";
+import { appRoutes } from "constants/routes";
 
 type Props = Required<WithAuthenticatorProps> & {
   classes?: string;
   isLoading: boolean;
 };
+
 export default function Menu({
   classes = "",
   isLoading,
@@ -15,8 +18,9 @@ export default function Menu({
       className={`${classes} bg-white dark:bg-blue-d6 w-max rounded overflow-hidden`}
     >
       <p className="text-sm p-2 text-gray-d1 dark:text-gray">
-        {user?.attributes?.email}
+        Welcome, {user?.attributes?.given_name}!
       </p>
+      <Link to={appRoutes.donations}>My Donations</Link>
       <button
         disabled={isLoading}
         type="button"

--- a/src/App/Header/UserMenu/Menu.tsx
+++ b/src/App/Header/UserMenu/Menu.tsx
@@ -21,6 +21,18 @@ export default function Menu({
         Welcome, {user?.attributes?.given_name}!
       </p>
       <Link to={appRoutes.donations}>My Donations</Link>
+      {user.attributes?.endowments ? (
+        <Link to={`${appRoutes.admin}/${user?.attributes?.endowments}`}>
+          Endowment Dashboard
+        </Link>
+      ) : (
+        <></>
+      )}
+      {user.attributes?.admin ? (
+        <Link to={appRoutes.applications}>Applications Review</Link>
+      ) : (
+        <></>
+      )}
       <button
         disabled={isLoading}
         type="button"

--- a/src/App/Header/UserMenu/Menu.tsx
+++ b/src/App/Header/UserMenu/Menu.tsx
@@ -18,7 +18,7 @@ export default function Menu({
       className={`${classes} bg-white dark:bg-blue-d6 w-max rounded overflow-hidden`}
     >
       <p className="text-sm p-2 text-gray-d1 dark:text-gray">
-        Welcome, {user?.attributes?.given_name}!
+        Welcome, {user?.attributes?.given_name || user?.attributes?.email}!
       </p>
       <Link to={appRoutes.donations}>My Donations</Link>
       {user.attributes?.endowments && (

--- a/src/App/Header/UserMenu/Menu.tsx
+++ b/src/App/Header/UserMenu/Menu.tsx
@@ -18,7 +18,11 @@ export default function Menu({
       className={`${classes} bg-white dark:bg-blue-d6 w-max rounded overflow-hidden`}
     >
       <p className="text-sm p-2 text-gray-d1 dark:text-gray">
-        Welcome, {user?.attributes?.given_name || user?.attributes?.email}!
+        {user?.attributes?.given_name
+          ? `Welcome, ${user.attributes.given_name}!`
+          : user?.attributes?.email
+          ? `Welcome, ${user.attributes.email}!`
+          : "Welcome!"}
       </p>
       <Link to={appRoutes.donations}>My Donations</Link>
       {user.attributes?.endowments && (

--- a/src/App/Header/UserMenu/Menu.tsx
+++ b/src/App/Header/UserMenu/Menu.tsx
@@ -21,17 +21,13 @@ export default function Menu({
         Welcome, {user?.attributes?.given_name}!
       </p>
       <Link to={appRoutes.donations}>My Donations</Link>
-      {user.attributes?.endowments ? (
-        <Link to={`${appRoutes.admin}/${user?.attributes?.endowments}`}>
+      {user.attributes?.endowments && (
+        <Link to={`${appRoutes.admin}/${user.attributes.endowments}`}>
           Endowment Dashboard
         </Link>
-      ) : (
-        <></>
       )}
-      {user.attributes?.admin ? (
+      {user.attributes?.admin && (
         <Link to={appRoutes.applications}>Applications Review</Link>
-      ) : (
-        <></>
       )}
       <button
         disabled={isLoading}

--- a/src/pages/Donations/Filter/Form.tsx
+++ b/src/pages/Donations/Filter/Form.tsx
@@ -34,8 +34,8 @@ const Form: FC<Props> = ({ onReset, submit, classes = "" }) => {
         <DateInput<FV> name="endDate" />
       </div>
 
-      <NetworkDropdown classes="px-4 lg:px-6" />
-      <CurrencyDropdown classes="px-4 lg:px-6" />
+      {/*<NetworkDropdown classes="px-4 lg:px-6" />*/}
+      {/*<CurrencyDropdown classes="px-4 lg:px-6" />*/}
       <DonationStatusDropdown classes="px-4 lg:px-6 max-lg:mb-4" />
 
       <div className="max-lg:row-start-2 flex gap-x-4 items-center justify-between max-lg:px-4 max-lg:py-3 p-6 lg:mt-2 bg-orange-l6 dark:bg-blue-d7 border-y lg:border-t border-prim">

--- a/src/pages/Donations/Filter/Form.tsx
+++ b/src/pages/Donations/Filter/Form.tsx
@@ -3,9 +3,10 @@ import { FC, FormEventHandler } from "react";
 import { FormValues as FV } from "./types";
 import Icon from "components/Icon";
 import { DateInput } from "components/form";
-import CurrencyDropdown from "./CurrencyDropdown";
 import DonationStatusDropdown from "./DonationStatusDropdown";
-import NetworkDropdown from "./NetworkDropdown";
+
+// import CurrencyDropdown from "./CurrencyDropdown";
+// import NetworkDropdown from "./NetworkDropdown";
 
 type Props = {
   submit: FormEventHandler<HTMLFormElement>;

--- a/src/pages/Donations/NoDonations.tsx
+++ b/src/pages/Donations/NoDonations.tsx
@@ -12,8 +12,8 @@ export default function NoDonations({ classes = "" }) {
       />
       <h3 className="text-lg self-end">No donations found.</h3>
       <p className="self-start text-gray-d1 dark:text-gray">
-        Sorry! We coudn't find any donations. Try connecting a different wallet
-        ( or adjust any filters applied ).
+        Sorry! We couldn't find any donations. Try to adjust any filters applied
+        or connect with a different user.
       </p>
     </div>
   );

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -1,3 +1,4 @@
+import { useAuthenticator } from "@aws-amplify/ui-react";
 import { useParams } from "react-router-dom";
 import { DonationMadeByDonor } from "types/aws";
 import { usePaginatedDonationRecords } from "services/apes";
@@ -11,7 +12,8 @@ import NoDonations from "./NoDonations";
 import Table from "./Table";
 
 export default function Donations() {
-  const { address: donorAddress = "" } = useParams<{ address: string }>();
+  const { user } = useAuthenticator((context) => [context.user]);
+  const donorAddress = user.attributes ? user.attributes?.email : "";
   const {
     data,
     hasMore,
@@ -29,7 +31,7 @@ export default function Donations() {
   return (
     <div className="grid grid-cols-[1fr_auto] content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container pt-8 lg:pt-20 pb-8">
       <h1 className="text-3xl max-lg:font-work max-lg:text-center max-lg:col-span-full max-lg:mb-4">
-        My donations
+        My Donations
       </h1>
       <CsvExporter
         aria-disabled={isLoadingOrError || !data?.Items || isEmpty(data.Items)}

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -12,7 +12,7 @@ import Table from "./Table";
 
 export default function Donations() {
   const { user } = useAuthenticator((context) => [context.user]);
-  const donorAddress = user.attributes ? user.attributes?.email : "";
+  const donorAddress = user.attributes?.email ?? "";
   const {
     data,
     hasMore,

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -1,5 +1,4 @@
 import { useAuthenticator } from "@aws-amplify/ui-react";
-import { useParams } from "react-router-dom";
 import { DonationMadeByDonor } from "types/aws";
 import { usePaginatedDonationRecords } from "services/apes";
 import CsvExporter from "components/CsvExporter";


### PR DESCRIPTION
Ticket(s):
- N/A

## Explanation of the solution
**Proof of Concept to:**
1. start moving us towards a more usable header user menu
     - Welcome message w/ user's first name
     - Show "My Donations Link" 
2. auth protects user donations page for logged in users only. 

The quick and dirty work-around at play here is that the web app passes the user `email` string to the AWS GET `/donations` endpoint now instead of the donor's wallet address string like it. In short, this won't fetch anything without changes from AWS to pull donation records by the User's email.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
### User's Donations w/ results 
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/2b4df23f-2770-4489-9712-5853a6dc00f2)

### No donations 
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/20d598fb-5cc7-4825-8fd6-73eb419f7275)