### PR TITLE
Make DonateMethods tabs appear in 2 rows on mobile

### DIFF
--- a/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
+++ b/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
@@ -25,7 +25,7 @@ export default function DonateMethods({ donaterConfig, state }: Props) {
       className="grid content-start mt-2"
       defaultIndex={state.details?.method === "crypto" ? 1 : 0}
     >
-      <Tab.List className="grid grid-flow-col sm:grid-cols-4 mb-6">
+      <Tab.List className="grid grid-cols-2 sm:grid-cols-4 mb-6">
         <Tab className={({ selected }) => tabClasses(selected)}>
           Credit/Debit
         </Tab>


### PR DESCRIPTION

## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
before:
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/19427053/1d342fd8-6f95-440b-a318-cc81a04534ac)

after
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/19427053/7c6fd146-eb89-4936-8626-a03d279caa58)