### PR TITLE
AP-896: multiselect focus

### DIFF
--- a/src/components/Selector/MultiSelector.tsx
+++ b/src/components/Selector/MultiSelector.tsx
@@ -65,7 +65,7 @@ export function MultiSelector<
           aria-invalid={!!get(errors, name)?.message}
           aria-disabled={isDisabled}
           as="div"
-          className={`${button} ${styles.selectorButton} p-1`}
+          className={`${button} ${styles.selectorButton} p-1 focus-within:border-gray-d1 focus-within:dark:border-blue-l2`}
         >
           {({ open }) => (
             <>
@@ -78,7 +78,7 @@ export function MultiSelector<
                     onChange={onSelectedChange}
                   />
                 ))}
-                {searchable && (
+                {searchable ? (
                   <div className="inline-flex items-center gap-2 text-gray-d1 dark:text-gray pl-3 bg-white/5 rounded">
                     <Icon type="Search" size={20} />
                     <Combobox.Input
@@ -87,6 +87,11 @@ export function MultiSelector<
                       onChange={(e) => setSearchText(e.target.value)}
                     />
                   </div>
+                ) : (
+                  <input
+                    aria-disabled={true}
+                    className="w-0 h-0 appearance-none"
+                  />
                 )}
               </span>
               <DrawerIcon

--- a/src/components/Selector/MultiSelector.tsx
+++ b/src/components/Selector/MultiSelector.tsx
@@ -88,6 +88,7 @@ export function MultiSelector<
                     />
                   </div>
                 ) : (
+                  //this will receive focus if search input is not rendered
                   <input
                     aria-disabled={true}
                     className="w-0 h-0 appearance-none"

--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -46,7 +46,7 @@ export function Selector<
           aria-invalid={!!get(errors, valuePath)?.message}
           aria-disabled={isDisabled}
           as="button"
-          className={`${button} ${styles.selectorButton}`}
+          className={`${button} ${styles.selectorButton} peer-focus:border-gray-d1 peer-focus:dark:border-blue-l2`}
         >
           {({ open }) => (
             <>

--- a/src/components/Selector/constants.ts
+++ b/src/components/Selector/constants.ts
@@ -4,7 +4,7 @@ export const valueKey: keyof OptionType<any> = "value";
 
 export const styles = {
   selectorButton:
-    "flex items-center field-input min-h-[3rem] justify-between peer-focus:border-gray-d1 peer-focus:dark:border-blue-l2 cursor-pointer",
+    "flex items-center field-input min-h-[3rem] justify-between cursor-pointer",
   error:
     "absolute -bottom-5 right-0 text-right text-xs text-red dark:text-red-l2",
   //FUTURE: import OptionRenderArg once available


### PR DESCRIPTION
Ticket(s):
-
* when multiselect is not searchable, there's no element to receive focus (unless something is already selected (rendered as button ))

## Explanation of the solution
* when multiselect is not searchable, replace search input with aria disabled input
* separate focus styling for selector and multiselector

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes