### PR TITLE
AP-889: Bank Details: Disable form while submission operations are running

### DIFF
--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -22,7 +22,7 @@ type Props = {
     request: CreateRecipientRequest,
     bankStatementFile: FileDropzoneAsset,
     isDirty: boolean
-  ) => Promise<any>;
+  ) => Promise<void>;
 };
 
 export default function RecipientDetails({

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
@@ -22,12 +22,12 @@ type Props = {
     isSubmitting: boolean,
     refreshRequired: boolean
   ) => ReactNode;
-  onRefresh: (request: CreateRecipientRequest) => void;
+  onRefresh: (request: CreateRecipientRequest) => Promise<void>;
   onSubmit: (
     request: CreateRecipientRequest,
     bankStatementFile: FileDropzoneAsset,
     isDirty: boolean
-  ) => void;
+  ) => Promise<void>;
 };
 
 export default function Form(props: Props) {
@@ -36,13 +36,13 @@ export default function Form(props: Props) {
     formState: { isSubmitting, isDirty },
   } = useFormContext<FormValues>();
 
-  const handleSubmission = handleSubmit((formValues) => {
+  const handleSubmission = handleSubmit(async (formValues) => {
     const { bankStatementFile, ...bankDetails } = formValues;
     const request = formToCreateRecipientRequest(bankDetails);
     if (props.refreshRequired) {
-      props.onRefresh(request);
+      await props.onRefresh(request);
     } else {
-      props.onSubmit(request, bankStatementFile, isDirty);
+      await props.onSubmit(request, bankStatementFile, isDirty);
     }
   });
 

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -17,12 +17,12 @@ type Props = {
     refreshRequired: boolean
   ) => ReactNode;
   onUpdateValues: (formValues: FormValues) => void;
-  onRefresh: (request: CreateRecipientRequest) => void;
+  onRefresh: (request: CreateRecipientRequest) => Promise<void>;
   onSubmit: (
     request: CreateRecipientRequest,
     bankStatementFile: FileDropzoneAsset,
     isDirty: boolean
-  ) => void;
+  ) => Promise<void>;
 };
 
 export default function RecipientDetailsForm(props: Props) {
@@ -48,10 +48,10 @@ export default function RecipientDetailsForm(props: Props) {
         accountRequirements={props.accountRequirements}
         disabled={props.disabled}
         refreshRequired={props.refreshRequired}
-        onRefresh={(request) => {
+        onRefresh={async (request) => {
           // update current form values prior to refreshing the form (loads new fields)
           onUpdateValues(getValues());
-          props.onRefresh(request);
+          await props.onRefresh(request);
         }}
         onSubmit={props.onSubmit}
         formButtons={props.formButtons}


### PR DESCRIPTION

## Explanation of the solution
The problem was in types for `onSubmit` and `onRefresh` being inaccurate - they were set to "synchronous" instead of "asynchronous" functions. 
Updating the type(s) and awaiting the function calls fixed the issue.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- register if necessary
- start registration process
- get to step 5 Banking
- **to get valid bank details use the following:**
   - currency: USD
   - amount:  1<=X<=10000
   - type: ACH
   - name: whatever
   - routing number: 325181015
   - account number: 000123456
   - country: USA
   - city: whatever
   - resident address: whatever
   - postcode: 90001
   - (post "check requirements") state: California