### PR TITLE
Endow-auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # generate source-maps to use in "yarn analyze"
-GENERATE_SOURCEMAP=<TRUE | FALSE>
+GENERATE_SOURCEMAP=<true | false>
 
 # port to use for serving the application on (defaults to 3000)
 PORT=<port number>

--- a/src/pages/Admin/Context.tsx
+++ b/src/pages/Admin/Context.tsx
@@ -1,16 +1,30 @@
 import { PropsWithChildren, createContext, useContext } from "react";
 import { useParams } from "react-router-dom";
 import { AdminParams } from "./types";
+import { AuthenticatedUser } from "types/auth";
+import Icon from "components/Icon";
 import { idParamToNum } from "helpers";
 
-type AdminContext = { id: number };
+type AdminContext = { id: number; user: AuthenticatedUser };
 
-export function Context(props: PropsWithChildren) {
+export function Context({
+  children,
+  user,
+}: PropsWithChildren<{ user: AuthenticatedUser }>) {
   const { id } = useParams<AdminParams>();
 
+  if (!user.endowments.includes(idParamToNum(id))) {
+    return (
+      <div className="grid content-start place-items-center py-20">
+        <Icon type="ExclamationCircleFill" size={80} className="text-red" />
+        <p className="text-xl mt-8 font-work ">Unauthorized</p>
+      </div>
+    );
+  }
+
   return (
-    <context.Provider value={{ id: idParamToNum(id) }}>
-      {props.children}
+    <context.Provider value={{ id: idParamToNum(id), user }}>
+      {children}
     </context.Provider>
   );
 }

--- a/src/pages/Admin/index.tsx
+++ b/src/pages/Admin/index.tsx
@@ -3,9 +3,9 @@ import ModalContext from "contexts/ModalContext";
 import Charity from "./Charity";
 import { Context } from "./Context";
 
-export default withAuth(function Admin() {
+export default withAuth(function Admin({ user }) {
   return (
-    <Context>
+    <Context user={user}>
       <ModalContext>
         <Charity />
       </ModalContext>

--- a/src/slices/auth.ts
+++ b/src/slices/auth.ts
@@ -33,14 +33,19 @@ export const loadSession = createAsyncThunk<User, AuthUser | undefined>(
       ]);
 
       //possible state is [] | undefined
-      const { endowments = [], "cognito:groups": groups = [] } =
-        session.tokens.accessToken.payload;
+      const { endows, "cognito:groups": groups = [] } =
+        session.tokens.idToken?.payload || {};
+
       const token = session.tokens.accessToken.toString();
+      const endowments =
+        typeof endows === "string" && endows !== ""
+          ? endows.split(",").map(Number)
+          : [];
 
       return {
         token,
         groups: groups as string[], //AWS generated so there's a level of safety
-        endowments: endowments as number[],
+        endowments: endowments,
         /**
          * email is guaranteed as it is the primary verifcation mechanism,
          * and is always retrieved from federated signin

--- a/src/slices/auth.ts
+++ b/src/slices/auth.ts
@@ -32,7 +32,6 @@ export const loadSession = createAsyncThunk<User, AuthUser | undefined>(
         user ? Promise.resolve(user) : getCurrentUser(),
       ]);
 
-      //possible state is [] | undefined
       const { endows, "cognito:groups": groups = [] } =
         session.tokens.idToken?.payload || {};
 

--- a/src/slices/auth.ts
+++ b/src/slices/auth.ts
@@ -36,10 +36,10 @@ export const loadSession = createAsyncThunk<User, AuthUser | undefined>(
         session.tokens.idToken?.payload || {};
 
       const token = session.tokens.accessToken.toString();
+
       const endowments =
-        typeof endows === "string" && endows !== ""
-          ? endows.split(",").map(Number)
-          : [];
+        //either none or correctly formatted string
+        (endows as string | undefined)?.split(",").map(Number) || [];
 
       return {
         token,


### PR DESCRIPTION
Ticket(s):
- related to https://github.com/AngelProtocolFinance/devops/pull/392

## Explanation of the solution
* parse `endows` claim
* add authorization check on `/admin`

accessing `admin/24` gives error, as my account has only access to endow `32`
<img width="1361" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/077452c5-8bd9-4817-9b17-5163e62bf8ec">




## Instructions on making this work
* in `Users` table add `endowments: number[]` attribute 

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes