### PR TITLE
Prod user pool config

### DIFF
--- a/src/App/__tests__/App.test.tsx
+++ b/src/App/__tests__/App.test.tsx
@@ -101,8 +101,10 @@ describe("App.tsx tests", () => {
     );
     //registration is being lazy loaded
     expect(screen.getByTestId(loaderTestId)).toBeInTheDocument();
-    //registration auth is loading
-    expect(await screen.findByTestId("loader-ring")).toBeInTheDocument();
+    //registration auth is loaded
+    expect(
+      await screen.findByRole("tab", { name: /sign in/i })
+    ).toBeInTheDocument();
     expect(screen.queryByTestId(loaderTestId)).toBeNull();
 
     //user goes back to leaderboard

--- a/src/store/amplify-config.ts
+++ b/src/store/amplify-config.ts
@@ -1,0 +1,53 @@
+import type { OAuthConfig } from "@aws-amplify/core";
+import type { ResourcesConfig } from "aws-amplify";
+import { IS_TEST } from "constants/env";
+import { appRoutes } from "constants/routes";
+
+const common = IS_TEST ? {} : {};
+
+const oauth: OAuthConfig = {
+  domain: "gc8hpcg5cpes-dev.auth.us-east-1.amazoncognito.com",
+  scopes: [
+    "phone",
+    "email",
+    "openid",
+    "profile",
+    "aws.cognito.signin.user.admin",
+  ],
+  redirectSignIn: [window.location.origin + `${appRoutes.auth_redirector}/`],
+  redirectSignOut: [window.location.origin + "/"],
+  responseType: "code",
+  providers: ["Google"],
+};
+
+export const amplifyConfig: ResourcesConfig = {
+  Auth: {
+    Cognito: {
+      userPoolClientId: "14qre65ehhsh5f6899ikdhk2qj",
+      userPoolId: "us-east-1_WO32hDPz3",
+      signUpVerificationMethod: "code",
+      loginWith: {
+        oauth,
+        email: true,
+      },
+      userAttributes: {
+        email: { required: true },
+        given_name: { required: true },
+        family_name: { required: true },
+      },
+      mfa: {
+        status: "optional",
+      },
+      passwordFormat: {
+        minLength: 8,
+        requireLowercase: true,
+        requireUppercase: true,
+        requireNumbers: true,
+        requireSpecialCharacters: true,
+      },
+
+      //identity pool
+      identityPoolId: "",
+    },
+  },
+};

--- a/src/store/amplify-config.ts
+++ b/src/store/amplify-config.ts
@@ -3,10 +3,20 @@ import type { ResourcesConfig } from "aws-amplify";
 import { IS_TEST } from "constants/env";
 import { appRoutes } from "constants/routes";
 
-const common = IS_TEST ? {} : {};
+const common = IS_TEST
+  ? {
+      OAuthDomain: "gc8hpcg5cpes-dev.auth.us-east-1.amazoncognito.com",
+      clientID: "14qre65ehhsh5f6899ikdhk2qj",
+      userPoolID: "us-east-1_WO32hDPz3",
+    }
+  : {
+      OAuthDomain: "gc8hpcg5cpes-prod.auth.us-east-1.amazoncognito.com",
+      clientID: "405vqjgbmjj9kkghbomvj0vr39",
+      userPoolID: "us-east-1_ukOlQeQIM",
+    };
 
 const oauth: OAuthConfig = {
-  domain: "gc8hpcg5cpes-dev.auth.us-east-1.amazoncognito.com",
+  domain: common.OAuthDomain,
   scopes: [
     "phone",
     "email",
@@ -23,8 +33,8 @@ const oauth: OAuthConfig = {
 export const amplifyConfig: ResourcesConfig = {
   Auth: {
     Cognito: {
-      userPoolClientId: "14qre65ehhsh5f6899ikdhk2qj",
-      userPoolId: "us-east-1_WO32hDPz3",
+      userPoolClientId: common.clientID,
+      userPoolId: common.userPoolID,
       signUpVerificationMethod: "code",
       loginWith: {
         oauth,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -8,8 +8,7 @@ import { componentReducer } from "slices/components";
 import { donation } from "slices/donation";
 import gift from "slices/gift";
 import widget from "slices/widget";
-import { appRoutes } from "constants/routes";
-import config from "../aws-exports";
+import { amplifyConfig } from "./amplify-config";
 
 export const store = configureStore({
   reducer: {
@@ -25,10 +24,7 @@ export const store = configureStore({
     getDefaultMiddleware().concat([aws.middleware, apes.middleware]),
 });
 
-config.oauth.redirectSignIn =
-  window.location.origin + `${appRoutes.auth_redirector}/`;
-config.oauth.redirectSignOut = window.location.origin + "/";
-Amplify.configure(config);
+Amplify.configure(amplifyConfig);
 
 store.dispatch(loadSession());
 Hub.listen("auth", async ({ payload }) => {


### PR DESCRIPTION
Ticket(s):
-

## Explanation of the solution
* switch to literal config object instead of auto-generated `aws-exports` 
* test prod auth flow

 @SovereignAndrey 
need to add redirectURL `gc8hpcg5cpes-dev.auth.us-east-1.amazoncognito.com` in google developer console for oauth to work in prod

## Instructions on making this work
* set env `ENVIRONMENT=PRODUCTION` and try to register - should still work 

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes