### PR TITLE
Fix: edit profile selected file preview not showing

### DIFF
--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
@@ -9,10 +9,6 @@ import RequirementField from "./RequirementField";
 import { MB_LIMIT, VALID_MIME_TYPES } from "./constants";
 import formToCreateRecipientRequest from "./formToCreateRecipientRequest";
 
-const fileTooltip = `Valid types are: ${VALID_MIME_TYPES.join(
-  ", "
-)}. File should be less than ${MB_LIMIT}MB.`;
-
 type Props = {
   accountRequirements: AccountRequirements;
   disabled: boolean;
@@ -76,7 +72,7 @@ export default function Form(props: Props) {
         <Label required>Please provide your Bank Statement</Label>
         <FileDropzone<FormValues, "bankStatementFile">
           name="bankStatementFile"
-          tooltip={fileTooltip}
+          specs={{ mbLimit: MB_LIMIT, mimeTypes: VALID_MIME_TYPES }}
         />
       </div>
 

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/constants.ts
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/constants.ts
@@ -1,5 +1,5 @@
-import { MIMEType } from "schemas/file";
+import { ApplicationMIMEType } from "types/lists";
 
 export const MB_LIMIT = 6;
 
-export const VALID_MIME_TYPES: MIMEType[] = ["PDF"];
+export const VALID_MIME_TYPES: ApplicationMIMEType[] = ["application/pdf"];

--- a/src/components/FileDropzone/FileDropzone.tsx
+++ b/src/components/FileDropzone/FileDropzone.tsx
@@ -8,6 +8,7 @@ import {
   useFormContext,
 } from "react-hook-form";
 import { FileDropzoneAsset } from "types/components";
+import { MIMEType } from "types/lists";
 import ExtLink from "components/ExtLink";
 import Icon from "components/Icon";
 import { isEmpty } from "helpers";
@@ -26,7 +27,7 @@ export default function FileDropzone<
   multiple?: true;
   disabled?: boolean;
   className?: string;
-  tooltip: string;
+  specs: { mbLimit: number; mimeTypes: MIMEType[] };
 }) {
   const filesId: any = `${props.name}.${filesKey}`;
   const previewsId = `${props.name}.${previewsKey}` as Path<T>;
@@ -76,7 +77,11 @@ export default function FileDropzone<
         />
       </div>
       <p className="text-xs text-gray-d1 dark:text-gray mt-2">
-        {props.tooltip}{" "}
+        Valid types are:
+        {props.specs.mimeTypes
+          .map((m) => m.split("/")[1].toUpperCase())
+          .join(", ")}
+        . File should be less than {props.specs.mbLimit} MB{" "}
         <ErrorMessage
           name={filesId as any}
           errors={errors}

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -106,7 +106,8 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
       </div>
       <p className="text-xs text-gray-d1 dark:text-gray mt-2">
         <span>
-          Valid types are: {accept.join(", ")}.{" "}
+          Valid types are:{" "}
+          {accept.map((m) => m.split("/")[1].toUpperCase()).join(", ")}.{" "}
           {maxSize ? (
             <>
               Image should be less than {maxSize / BYTES_IN_MB}MB in size.

--- a/src/components/ImgEditor/types.ts
+++ b/src/components/ImgEditor/types.ts
@@ -1,6 +1,6 @@
 import { FieldValues, Path, PathValue } from "react-hook-form";
 import { FileObject } from "types/aws";
-import { MIMEType } from "schemas/file";
+import { ImageMIMEType } from "types/lists";
 
 export type ImgLink = FileObject & {
   file?: File;
@@ -15,7 +15,7 @@ export type Props<T extends FieldValues, K extends Path<T>> = {
   // which are only props from T
   // (Path<T> returns all possible paths through T)
   name: PathValue<T, K> extends ImgLink ? K : never;
-  accept: MIMEType[];
+  accept: ImageMIMEType[];
   classes?: Classes;
   aspect: [number, number];
   /**

--- a/src/pages/Admin/Charity/EditProfile/schema.ts
+++ b/src/pages/Admin/Charity/EditProfile/schema.ts
@@ -1,13 +1,19 @@
 import { ObjectSchema, array, object } from "yup";
 import { FV } from "./types";
 import { SchemaShape } from "schemas/types";
+import { ImageMIMEType } from "types/lists";
 import { ImgLink } from "components/ImgEditor";
-import { MIMEType, genFileSchema } from "schemas/file";
+import { genFileSchema } from "schemas/file";
 import { optionType } from "schemas/shape";
 import { requiredString, url } from "schemas/string";
 import { MAX_SDGS } from "constants/unsdgs";
 
-export const VALID_MIME_TYPES: MIMEType[] = ["JPEG", "PNG", "WEBP", "SVG"];
+export const VALID_MIME_TYPES: ImageMIMEType[] = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/svg",
+];
 
 export const MAX_SIZE_IN_BYTES = 1e6;
 

--- a/src/pages/Admin/Charity/ProgramEditor/schema.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/schema.ts
@@ -1,11 +1,17 @@
 import { ObjectSchema, array, date, object, string } from "yup";
 import { FV, FormMilestone } from "./types";
 import { SchemaShape } from "schemas/types";
+import { ImageMIMEType } from "types/lists";
 import { ImgLink } from "components/ImgEditor";
-import { MIMEType, genFileSchema } from "schemas/file";
+import { genFileSchema } from "schemas/file";
 import { requiredString } from "schemas/string";
 
-export const VALID_MIME_TYPES: MIMEType[] = ["JPEG", "PNG", "WEBP", "SVG"];
+export const VALID_MIME_TYPES: ImageMIMEType[] = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/svg",
+];
 
 const MAX_SIZE_IN_BYTES = 1e6;
 export const MAX_CHARS = 500;

--- a/src/pages/Registration/Steps/Documentation/FSA/Form/index.tsx
+++ b/src/pages/Registration/Steps/Documentation/FSA/Form/index.tsx
@@ -22,7 +22,7 @@ export default function Form(props: Props) {
       </Label>
       <FileDropzone<FV, "ProofOfIdentity">
         name="ProofOfIdentity"
-        tooltip={fileTooltip}
+        specs={{ mbLimit: MB_LIMIT, mimeTypes: VALID_MIME_TYPES }}
       />
 
       <Field<FV>
@@ -38,7 +38,7 @@ export default function Form(props: Props) {
       </Label>
       <FileDropzone<FV, "ProofOfRegistration">
         name="ProofOfRegistration"
-        tooltip={fileTooltip}
+        specs={{ mbLimit: MB_LIMIT, mimeTypes: VALID_MIME_TYPES }}
       />
 
       <Field<FV>
@@ -94,7 +94,3 @@ export default function Form(props: Props) {
     </form>
   );
 }
-
-const fileTooltip = `Valid types are: ${VALID_MIME_TYPES.join(
-  ", "
-)}. File should be less than ${MB_LIMIT}MB.`;

--- a/src/pages/Registration/Steps/Documentation/FSA/schema.ts
+++ b/src/pages/Registration/Steps/Documentation/FSA/schema.ts
@@ -1,13 +1,19 @@
 import { ObjectSchema, object } from "yup";
 import { FormValues } from "./types";
 import { SchemaShape } from "schemas/types";
-import { MIMEType, fileDropzoneAssetShape } from "schemas/file";
+import { MIMEType } from "types/lists";
+import { fileDropzoneAssetShape } from "schemas/file";
 import { requiredString } from "schemas/string";
 import { BYTES_IN_MB } from "constants/common";
 
 export const MB_LIMIT = 6;
 
-export const VALID_MIME_TYPES: MIMEType[] = ["JPEG", "PNG", "PDF", "WEBP"];
+export const VALID_MIME_TYPES: MIMEType[] = [
+  "image/jpeg",
+  "image/png",
+  "application/pdf",
+  "image/webp",
+];
 
 const assetShape = fileDropzoneAssetShape(
   MB_LIMIT * BYTES_IN_MB,

--- a/src/schemas/file.ts
+++ b/src/schemas/file.ts
@@ -1,17 +1,8 @@
 import * as Yup from "yup";
 import { FileObject } from "types/aws";
 import { FileDropzoneAsset } from "types/components";
+import { MIMEType } from "types/lists";
 import { isEmpty } from "helpers";
-
-const MIME_TYPES = {
-  JPEG: "image/jpeg",
-  PNG: "image/png",
-  PDF: "application/pdf",
-  WEBP: "image/webp",
-  SVG: "image/svg",
-};
-
-export type MIMEType = keyof typeof MIME_TYPES;
 
 const previewsKey: keyof FileDropzoneAsset = "previews";
 
@@ -41,8 +32,7 @@ export const genFileSchema = (maxSize: number, mimeTypes: MIMEType[]) =>
     .test({
       name: "must be of correct type",
       message: "invalid file type",
-      test: (file) =>
-        !file || !!mimeTypes.find((type) => MIME_TYPES[type] === file.type),
+      test: (file) => !file || !!mimeTypes.find((type) => type === file.type),
     })
     .test({
       name: "must be less than size limit",

--- a/src/types/lists.ts
+++ b/src/types/lists.ts
@@ -23,6 +23,7 @@ export type UNSDG_NUMS =
 export type TransactionStatus = "open" | "approved" | "expired";
 export type EndowmentType = "charity" | "ast" | "daf";
 
+//https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
 type ImageSubType = "svg" | "jpeg" | "png" | "webp";
 type ApplicationSubType = "pdf";
 

--- a/src/types/lists.ts
+++ b/src/types/lists.ts
@@ -22,3 +22,11 @@ export type UNSDG_NUMS =
 
 export type TransactionStatus = "open" | "approved" | "expired";
 export type EndowmentType = "charity" | "ast" | "daf";
+
+type ImageSubType = "svg" | "jpeg" | "png" | "webp";
+type ApplicationSubType = "pdf";
+
+export type ImageMIMEType = `image/${ImageSubType}`;
+export type ApplicationMIMEType = `application/${ApplicationSubType}`;
+
+export type MIMEType = ImageMIMEType | ApplicationMIMEType;


### PR DESCRIPTION
Ticket(s):
- https://discord.com/channels/834976399228010527/1098542651218866208/1179079645786812436

x is not of format `type/subtype` but of abstracted `SUBTYPE` e.g. `JPEG | PNG`
```ts
//useImgEditor.ts
      //preview & crop valid formats only
      if (!!accept.find((x) => x === newFile.type)) {
```

## Explanation of the solution
* mime type lists usage now refers to bare `type/subtype` format (created type for autocompletion)

## Others
* `Filedropzone` now creates tooltip internally by accepting props: file size , and valid mimetypes


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes