### PR TITLE
AP-934: Marketplace cards layout

### DIFF
--- a/src/pages/Marketplace/Cards/index.tsx
+++ b/src/pages/Marketplace/Cards/index.tsx
@@ -23,7 +23,7 @@ export default function Cards({ classes = "" }: { classes?: string }) {
     >
       {(endowments) => (
         <div
-          className={`${classes} w-full grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 content-start`}
+          className={`${classes} w-full grid min-[600px]:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 content-start`}
         >
           {endowments.map((endow) => (
             <Card {...endow} key={endow.id} />

--- a/src/pages/Marketplace/Cards/index.tsx
+++ b/src/pages/Marketplace/Cards/index.tsx
@@ -23,11 +23,7 @@ export default function Cards({ classes = "" }: { classes?: string }) {
     >
       {(endowments) => (
         <div
-          className={`${classes} w-full grid ${
-            endowments.length < 3
-              ? "grid-cols-[repeat(auto-fill,minmax(255px,1fr))]"
-              : "grid-cols-[repeat(auto-fit,minmax(245px,1fr))]"
-          } gap-4 content-start`}
+          className={`${classes} w-full grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 content-start`}
         >
           {endowments.map((endow) => (
             <Card {...endow} key={endow.id} />

--- a/src/pages/Marketplace/Cards/index.tsx
+++ b/src/pages/Marketplace/Cards/index.tsx
@@ -23,7 +23,7 @@ export default function Cards({ classes = "" }: { classes?: string }) {
     >
       {(endowments) => (
         <div
-          className={`${classes} w-full grid min-[600px]:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 content-start`}
+          className={`${classes} w-full grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 content-start`}
         >
           {endowments.map((endow) => (
             <Card {...endow} key={endow.id} />


### PR DESCRIPTION
Ticket(s):
-

## Explanation of the solution
* move from card-centric layout  (`255px + leftover-over space`) , to column-centric layout , 

with [breakpoints](https://tailwindcss.com/docs/responsive-design):
                  - 1 column (` up to 640px per card (before sm`)
`sm: 640px`   -  2 column (`~300px - 384px (before md)` per card)
`md: 768px`   -  3 column ( `~256px -  341px (before lg) ` per card)
`lg: 1024px` - 4 column (`~256px  - 320px (before xl)` per card)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes