### PR TITLE
AP-914: `FileDropzone` should not open "Select File" window when disabled

### DIFF
--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
@@ -69,6 +69,7 @@ export default function Form(props: Props) {
         <FileDropzone<FormValues, "bankStatementFile">
           name="bankStatementFile"
           specs={{ mbLimit: MB_LIMIT, mimeTypes: VALID_MIME_TYPES }}
+          disabled={props.disabled}
         />
       </div>
 

--- a/src/components/FileDropzone/FileDropzone.tsx
+++ b/src/components/FileDropzone/FileDropzone.tsx
@@ -30,7 +30,7 @@ export default function FileDropzone<
   specs: { mbLimit: number; mimeTypes: MIMEType[] };
 }) {
   const filesId: any = `${props.name}.${filesKey}`;
-  const previewsId = `${props.name}.${previewsKey}` as Path<T>;
+  const previewsId = `${props.name}.${previewsKey}` as K;
 
   const {
     getValues,
@@ -43,12 +43,14 @@ export default function FileDropzone<
     name: filesId,
   });
 
+  const disabled = props.disabled || isSubmitting;
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop: (files: File[]) => {
       onFilesChange(files);
     },
     multiple: props.multiple,
-    disabled: props.disabled,
+    disabled: disabled,
   });
 
   return (
@@ -61,7 +63,7 @@ export default function FileDropzone<
               ? "border-gray-d1 dark:border-gray"
               : "border-prim focus:border-orange-l2 focus:dark:border-blue-d1"
           } ${
-            isSubmitting || props.disabled
+            disabled
               ? "cursor-default bg-gray-l5 dark:bg-bluegray-d1"
               : "bg-gray-l6 dark:bg-blue-d5 cursor-pointer"
           } ${props.className ?? ""} dropzone`,
@@ -83,7 +85,7 @@ export default function FileDropzone<
           .join(", ")}
         . File should be less than {props.specs.mbLimit} MB{" "}
         <ErrorMessage
-          name={filesId as any}
+          name={filesId}
           errors={errors}
           as="span"
           className="text-red dark:text-red-l2 text-xs before:content-['('] before:mr-0.5 after:content-[')'] after:ml-0.5 empty:before:hidden empty:after:hidden"


### PR DESCRIPTION
## Explanation of the solution
It seems `FileDropzone` was opening the "select file" window due to:
- missing a `disabled` prop assignment in Bank Details form
- missing to set the field as "disabled" while the form submitting

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- disable authorization checks in `Auth.tsx` and `Context.tsx`
- go to http://localhost:4200/admin/8/banking
- update bank details
- click "check requirements" button
- while the form is submitting, click on the bank statement file dropzone
- it no longer opens the "Select File" window 

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes