### PR TITLE
AP-946 Nonprofit wording consistency

### DIFF
--- a/src/App/constants.ts
+++ b/src/App/constants.ts
@@ -15,7 +15,7 @@ type LINKS = {
 
 export const CHARITY_LINKS: LINKS = {
   HEADER_LINKS: [
-    { title: "For Non-Profits", href: BASE_URL, external: true },
+    { title: "For nonprofits", href: BASE_URL, external: true },
     {
       title: "Marketplace",
       href: appRoutes.marketplace,
@@ -38,7 +38,7 @@ export const CHARITY_LINKS: LINKS = {
       title: "How We Can Help",
       links: [
         {
-          text: "Non-profits",
+          text: "nonprofits",
           href: BASE_URL,
         },
         {

--- a/src/components/donation/Steps/DonateMethods/Stocks.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stocks.tsx
@@ -33,7 +33,7 @@ export default function Stocks({ state }: Props) {
       </div>
       <p> You may also need the following information:</p>
       <span className="rounded bg-gray-l5 dark:bg-bluegray-d1 p-2">
-        Better.Giving is a non-profit with 501(c)(3) tax-exempt status, Federal
+        Better.Giving is a nonprofit with 501(c)(3) tax-exempt status, Federal
         ID #: 87-3758939.
       </span>
       {/* build email form */}
@@ -75,8 +75,8 @@ export default function Stocks({ state }: Props) {
       </p>
       <p>
         You avoid paying both capital gains tax and stock sales commissions.
-        When you give appreciated stocks directly to charity, your gift can be
-        up to 20% larger because you avoid the taxes you'd incur from selling
+        When you give appreciated stocks directly to a nonprofit, your gift can
+        be up to 20% larger because you avoid the taxes you'd incur from selling
         and donating the cash.
       </p>
     </div>

--- a/src/components/donation/Steps/Result/Success/Share.tsx
+++ b/src/components/donation/Steps/Result/Success/Share.tsx
@@ -62,7 +62,7 @@ function Prompt({ type, iconSize, recipient: { name } }: Props) {
         I just donated to <span className="font-bold">{name}</span> on{" "}
         <span className="font-bold">"@angelgiving_</span>!{" "}
         {`Every gift is
-        invested to provide sustainable funding for non-profits: Give once, give
+        invested to provide sustainable funding for nonprofits: Give once, give
         forever. Help join the cause: ${DAPP_URL}`}
       </p>
       <ExtLink

--- a/src/pages/Admin/Charity/Dashboard/Dashboard.tsx
+++ b/src/pages/Admin/Charity/Dashboard/Dashboard.tsx
@@ -18,7 +18,7 @@ export default function Dashboard() {
         queryState={queryState}
         messages={{
           loading: <LoaderSkeleton />,
-          error: "Failed to get non-profit organisation info",
+          error: "Failed to get nonprofit organisation info",
         }}
       >
         {({

--- a/src/pages/Admin/Charity/Widget/Configurer/Form.tsx
+++ b/src/pages/Admin/Charity/Widget/Configurer/Form.tsx
@@ -19,7 +19,7 @@ export default function Form({
       onReset={onReset}
       className={`${className} grid content-start gap-6 text-sm font-body`}
     >
-      <label className="-mb-4">Non-profit name:</label>
+      <label className="-mb-4">nonprofit name:</label>
       <EndowmentSelector />
 
       <CheckField<FV> name="isDescriptionTextHidden">Hide text</CheckField>

--- a/src/pages/Admin/Charity/Widget/Preview/Preview.tsx
+++ b/src/pages/Admin/Charity/Widget/Preview/Preview.tsx
@@ -6,7 +6,7 @@ import DonateMethods from "./DonateMethods";
 export default function Preview({ classes = "" }) {
   const widgetConfig = useGetter((state) => state.widget);
   const { endowment, isDescriptionTextShown } = widgetConfig;
-  const endowName = endowment.name ?? "Non-profit name";
+  const endowName = endowment.name ?? "nonprofit name";
   return (
     <section className={classes + " @container/preview pb-4"}>
       <h2 className="text-lg @4xl/widget:text-2xl text-center @4xl/widget:text-left mb-3">
@@ -17,7 +17,7 @@ export default function Preview({ classes = "" }) {
         {isDescriptionTextShown && (
           <>
             <p className="px-6 @xl/preview:px-10 font-body text-sm mb-4 text-center @xl/preview:text-left">
-              Donate today to {possesiveForm(endowName)} non-profit. Your
+              Donate today to {possesiveForm(endowName)} nonprofit. Your
               donation will be protected and compounded in perpetuity to provide{" "}
               {endowName} with a long-term, sustainable runway. Give once, give
               forever!

--- a/src/pages/Admin/Charity/Widget/Widget.tsx
+++ b/src/pages/Admin/Charity/Widget/Widget.tsx
@@ -11,7 +11,7 @@ export default function Widget() {
   return (
     <div className="grid @4xl:grid-cols-2 @4xl:gap-x-10 w-full h-full group @container/widget">
       <Seo
-        title={`Widget Configuration for Non-profit ${id}`}
+        title={`Widget Configuration for nonprofit ${id}`}
         url={`${adminRoutes.widget_config}`}
       />
       <h1 className="text-lg @4xl/widget:text-2xl text-center @4xl/widget:text-left mb-3 @4xl/widget:col-span-2">

--- a/src/pages/Application/Loaded.tsx
+++ b/src/pages/Application/Loaded.tsx
@@ -47,7 +47,7 @@ export default function Loaded(props: ApplicationDetails) {
         </span>
       </div>
 
-      <Container title="Non-Profit application">
+      <Container title="nonprofit application">
         <div className="grid sm:grid-cols-[auto_auto_1fr]">
           {doc.DocType === "FSA" ? (
             <Row label="Registration No.">{doc.RegistrationNumber}</Row>

--- a/src/pages/Donate/index.tsx
+++ b/src/pages/Donate/index.tsx
@@ -24,8 +24,8 @@ export default function Donate() {
       <QueryLoader
         queryState={queryState}
         messages={{
-          loading: "Getting non-profit info..",
-          error: "Failed to get non-profit info",
+          loading: "Getting nonprofit info..",
+          error: "Failed to get nonprofit info",
         }}
         classes={{ container: "justify-self-center text-center mt-8" }}
       >

--- a/src/pages/DonateFiatThanks/index.tsx
+++ b/src/pages/DonateFiatThanks/index.tsx
@@ -10,7 +10,7 @@ export default function DonateFiatThanks() {
         Thank you for your donation using one of our fiat on-ramp providers!
       </h3>
       <p className="text-center mb-4">
-        We'll process your donation to the Non-profit you specified as soon as
+        We'll process your donation to the nonprofit you specified as soon as
         the payment has cleared. You can safely navigate away using the button
         below.
       </p>

--- a/src/pages/DonateWidget/DonateWidget.tsx
+++ b/src/pages/DonateWidget/DonateWidget.tsx
@@ -33,7 +33,7 @@ export default function DonateWidget() {
           loading: (
             <LoaderRing thickness={12} classes="w-28 place-self-center" />
           ),
-          error: "Failed to get non-profit info",
+          error: "Failed to get nonprofit info",
         }}
         classes={{ container: "grid place-items-center h-full w-full" }}
       >

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -41,7 +41,7 @@ export default function Card({
           onError={(e) => e.currentTarget.classList.add("bg-blue-l3")}
         />
         <div className="flex flex-col p-3 pb-4 gap-3">
-          {/* NON-PROFIT NAME */}
+          {/* nonprofit NAME */}
           <h3 className="text-ellipsis line-clamp-2">{name}</h3>
           {/* TAGLINE */}
           {tagline && tagline !== PLACEHOLDER_TAGLINE ? (

--- a/src/pages/Profile/PageError.tsx
+++ b/src/pages/Profile/PageError.tsx
@@ -6,7 +6,7 @@ export default function PageError() {
   return (
     <section className="flex flex-col items-center justify-center w-full h-screen gap-2 bg-blue dark:bg-blue-d5 text-red-l4 dark:text-red-l2">
       <Icon type="Warning" size={30} />
-      <p className="text-lg text-center">Failed to load non-profit profile</p>
+      <p className="text-lg text-center">Failed to load nonprofit profile</p>
       <Link
         to={`${appRoutes.marketplace}`}
         className="text-blue-l5 hover:text-blue text-sm"

--- a/src/pages/Profile/Unpublished.tsx
+++ b/src/pages/Profile/Unpublished.tsx
@@ -7,7 +7,7 @@ export default function Unpublished() {
     <section className="flex flex-col items-center justify-center w-full h-screen gap-2 bg-blue dark:bg-blue-d5 text-red-l4 dark:text-red-l2">
       <Icon type="ExclamationCircleFill" size={30} />
       <p className="text-lg text-center">
-        This Non-profit has no public profile
+        This nonprofit has no public profile
       </p>
       <Link
         to={appRoutes.marketplace}

--- a/src/pages/Registration/Steps/Dashboard/EndowmentStatus.tsx
+++ b/src/pages/Registration/Steps/Dashboard/EndowmentStatus.tsx
@@ -33,7 +33,7 @@ export default function EndowmentStatus({
               size={20}
             />
             <span className="max-sm:text-center">
-              Your non-profit's application has been rejected.
+              Your nonprofit's application has been rejected.
             </span>
           </p>
           <button

--- a/src/pages/Registration/Steps/OrgDetails/Form/index.tsx
+++ b/src/pages/Registration/Steps/OrgDetails/Form/index.tsx
@@ -46,7 +46,7 @@ export default function Form() {
       </Label>
       <MultiSelector<FV, "UN_SDG", number> name="UN_SDG" options={sdgOptions} />
       <Label className="mb-2 mt-6" required>
-        Non-profit Designation
+        nonprofit Designation
       </Label>
       <Selector<FV, "EndowDesignation", string>
         name="EndowDesignation"

--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -50,7 +50,7 @@ export default function ProgressIndicator({ step, classes = "" }: Props) {
       Organization
     </Step>,
     <Step isDone={step >= 3} isCurr={currPath === 3} key={3}>
-      Non-Profit Status
+      nonprofit Status
     </Step>,
     <Step isDone={step >= 4} isCurr={currPath === 4} key={4}>
       Documentation

--- a/src/slices/widget.ts
+++ b/src/slices/widget.ts
@@ -4,7 +4,7 @@ import { WidgetConfig } from "types/widget";
 type State = WidgetConfig;
 
 const initialState: State = {
-  endowment: { id: 0, name: "Non-profit name" },
+  endowment: { id: 0, name: "nonprofit name" },
   isDescriptionTextShown: true,
   advancedOptions: {
     display: "expanded",


### PR DESCRIPTION
Ticket(s):
- https://linear.app/angel-protocol/issue/AP-946/change-non-profit-nonprofit-and-ensure-charity-and-nonprofit-not-used

## Explanation of the solution
- Changes `non-profit` >> `nonprofit`
- `Charity` wording use removed in place of `nonprofit`

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
N/A