### PR TITLE
Closes AP-887,AP-943: save form data when changing estimated monthly donations value

### DIFF
--- a/src/components/BankDetails/BankDetails.tsx
+++ b/src/components/BankDetails/BankDetails.tsx
@@ -90,6 +90,7 @@ export default function BankDetails({
             <RecipientDetails
               // we need this key to tell React that when currency code changes,
               // it needs to reset its state by re-rendering the whole component.
+              key={targetCurrency.code}
               isLoading={isDebouncing}
               targetCurrency={targetCurrency.code}
               expectedMontlyDonations={expectedMontlyDonations}

--- a/src/components/BankDetails/BankDetails.tsx
+++ b/src/components/BankDetails/BankDetails.tsx
@@ -87,24 +87,16 @@ export default function BankDetails({
         <>
           <Divider />
           <div className="min-h-[20rem]">
-            {isDebouncing ? (
-              <div className="flex items-center gap-2">
-                <LoaderRing thickness={10} classes="w-6" /> Loading...
-              </div>
-            ) : (
-              <RecipientDetails
-                // we need this key to tell React that when any of the fields passed to this component changes,
-                // it needs to reset its state by re-rendering the whole component.
-                // This way the `react-hook-form` reruns the `useForm` initializer function with the new requirements
-                // that will get loaded due to changed target currency and expected montly donation (in Wise terms: source amount).
-                key={`${targetCurrency.code}${expectedMontlyDonations}`}
-                targetCurrency={targetCurrency.code}
-                expectedMontlyDonations={expectedMontlyDonations}
-                isSubmitting={isSubmitting}
-                onSubmit={onSubmit}
-                FormButtons={FormButtons}
-              />
-            )}
+            <RecipientDetails
+              // we need this key to tell React that when currency code changes,
+              // it needs to reset its state by re-rendering the whole component.
+              isLoading={isDebouncing}
+              targetCurrency={targetCurrency.code}
+              expectedMontlyDonations={expectedMontlyDonations}
+              isSubmitting={isSubmitting}
+              onSubmit={onSubmit}
+              FormButtons={FormButtons}
+            />
           </div>
         </>
       )}

--- a/src/components/BankDetails/RecipientDetails/AccountRequirementsSelector.tsx
+++ b/src/components/BankDetails/RecipientDetails/AccountRequirementsSelector.tsx
@@ -1,37 +1,39 @@
-import { AccountRequirements } from "types/aws";
+import { RequirementsData } from "./types";
 import { Label } from "components/form";
 
 type Props = {
-  accountRequirements: AccountRequirements[];
-  className?: string;
-  currentIndex: number | undefined;
+  requirementsDataArray: RequirementsData[];
+  className: string;
+  selectedType: string | undefined;
   disabled: boolean;
-  onChange: (index: number) => void;
+  onChange: (requirementsType: RequirementsData) => void;
 };
 
 export default function AccountRequirementsSelector({
-  accountRequirements,
   className = "",
-  currentIndex,
   disabled,
   onChange,
+  requirementsDataArray,
+  selectedType,
 }: Props) {
   return (
     <div className={`grid gap-2 ${className}`}>
       <Label>Choose a transfer type:</Label>
       <div className="flex flex-wrap gap-2">
-        {accountRequirements.map((accountRequirements, index) => (
+        {requirementsDataArray.map((x) => (
           <button
-            key={accountRequirements.type}
+            key={x.accountRequirements.type}
             type="button"
-            onClick={() => onChange(index)}
+            onClick={() => onChange(x)}
             className={`${
-              index === currentIndex ? "btn-blue" : "btn-outline"
+              x.accountRequirements.type === selectedType
+                ? "btn-blue"
+                : "btn-outline"
             } text-xs sm:text-sm w-32 sm:w-48`}
             disabled={disabled}
             aria-disabled={disabled}
           >
-            {accountRequirements.title}
+            {x.accountRequirements.title}
           </button>
         ))}
       </div>

--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -37,13 +37,13 @@ export default function RecipientDetails({
   onSubmit,
 }: Props) {
   const {
-    activeRequirements,
+    requirementsDataArray,
     handleSubmit,
     isError,
     isLoading: isLoadingRequirements,
     refreshRequirements,
-    selectedIndex,
-    setSelectedIndex,
+    selectedRequirementsData,
+    changeSelectedType,
     updateDefaultValues,
   } = useRecipientDetails(
     isLoading,
@@ -67,7 +67,7 @@ export default function RecipientDetails({
 
   // requirements *can* be empty, check the following example when source currency is USD and target is ALL (Albanian lek):
   // https://api.sandbox.transferwise.tech/v1/account-requirements?source=USD&target=ALL&sourceAmount=1000
-  if (isEmpty(activeRequirements)) {
+  if (isEmpty(requirementsDataArray)) {
     return (
       <span>
         Target currency not supported. Please use a bank account with a
@@ -76,10 +76,8 @@ export default function RecipientDetails({
     );
   }
 
-  const requirements = activeRequirements.at(selectedIndex);
-
   // should never happen as `selectedIndex === 0` by default and can only be set to value smaller than `activeRequirements.length`
-  if (!requirements) {
+  if (!selectedRequirementsData) {
     return (
       <span>
         Non-existent requirements type selected. Please reload the page and try
@@ -91,13 +89,11 @@ export default function RecipientDetails({
   return (
     <>
       <AccountRequirementsSelector
-        accountRequirements={activeRequirements.map(
-          (x) => x.accountRequirements
-        )}
-        currentIndex={selectedIndex}
-        disabled={isSubmitting}
-        onChange={setSelectedIndex}
         className="mb-6"
+        disabled={isSubmitting}
+        onChange={changeSelectedType}
+        requirementsDataArray={requirementsDataArray}
+        selectedType={selectedRequirementsData?.accountRequirements.type}
       />
       <RecipientDetailsForm
         // since all fields need to be rerendered when new requirements type is chosen,
@@ -106,12 +102,14 @@ export default function RecipientDetails({
         //
         // Reason for using `requirements.accountRequirements.fields.length` to set the component key is that upo
         // refreshing the requirements, the number of fields will change, thus causing the whole form to be recreated
-        key={`form-${requirements.accountRequirements.type}-${requirements.accountRequirements.fields.length}`}
-        accountRequirements={requirements.accountRequirements}
-        defaultValues={requirements.currentFormValues}
+        key={`form-${selectedRequirementsData.accountRequirements.type}-${selectedRequirementsData.accountRequirements.fields.length}`}
+        accountRequirements={selectedRequirementsData.accountRequirements}
+        defaultValues={selectedRequirementsData.currentFormValues}
         disabled={isSubmitting}
-        refreshRequired={requirements.refreshRequired}
-        newRequirementsAdded={requirements.refreshedRequirementsAdded}
+        refreshRequired={selectedRequirementsData.refreshRequired}
+        newRequirementsAdded={
+          selectedRequirementsData.refreshedRequirementsAdded
+        }
         onUpdateValues={updateDefaultValues}
         onSubmit={handleSubmit}
         onRefresh={refreshRequirements}

--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -11,6 +11,7 @@ import RecipientDetailsForm from "./RecipientDetailsForm";
 import useRecipientDetails from "./useRecipientDetails";
 
 type Props = {
+  isLoading: boolean;
   isSubmitting: boolean;
   targetCurrency: string;
   expectedMontlyDonations: number;
@@ -23,6 +24,7 @@ type Props = {
 };
 
 export default function RecipientDetails({
+  isLoading,
   isSubmitting,
   targetCurrency,
   expectedMontlyDonations,
@@ -32,15 +34,20 @@ export default function RecipientDetails({
   const {
     handleSubmit,
     isError,
-    isLoading,
+    isLoading: isLoadingRequirements,
     refreshRequirements,
     requirementsDataArray,
     selectedIndex,
     setSelectedIndex,
     updateDefaultValues,
-  } = useRecipientDetails(targetCurrency, expectedMontlyDonations, onSubmit);
+  } = useRecipientDetails(
+    isLoading,
+    targetCurrency,
+    expectedMontlyDonations,
+    onSubmit
+  );
 
-  if (isLoading) {
+  if (isLoading || isLoadingRequirements) {
     return (
       <div className="flex items-center gap-2">
         <LoaderRing thickness={10} classes="w-6" /> Loading...

--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -14,7 +14,7 @@ type Props = {
   /**
    * The flag is used to display a loading indicator (e.g. when debouncing `expectedMontlyDonations`) without
    * having to unmount the component itself - this way the current form state gets stored between form loads
-   * and we are able to prefill the form fields
+   * even when new form requirements are being loaded (when "expectedMontlyDonations" value changes)
    */
   isLoading: boolean;
   isSubmitting: boolean;

--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -111,7 +111,7 @@ export default function RecipientDetails({
         defaultValues={requirements.currentFormValues}
         disabled={isSubmitting}
         refreshRequired={requirements.refreshRequired}
-        newRequirementsAdded={requirements.newRequirementsAdded}
+        newRequirementsAdded={requirements.refreshedRequirementsAdded}
         onUpdateValues={updateDefaultValues}
         onSubmit={handleSubmit}
         onRefresh={refreshRequirements}

--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -37,11 +37,11 @@ export default function RecipientDetails({
   onSubmit,
 }: Props) {
   const {
+    activeRequirements,
     handleSubmit,
     isError,
     isLoading: isLoadingRequirements,
     refreshRequirements,
-    requirementsDataArray,
     selectedIndex,
     setSelectedIndex,
     updateDefaultValues,
@@ -67,7 +67,7 @@ export default function RecipientDetails({
 
   // requirements *can* be empty, check the following example when source currency is USD and target is ALL (Albanian lek):
   // https://api.sandbox.transferwise.tech/v1/account-requirements?source=USD&target=ALL&sourceAmount=1000
-  if (isEmpty(requirementsDataArray)) {
+  if (isEmpty(activeRequirements)) {
     return (
       <span>
         Target currency not supported. Please use a bank account with a
@@ -76,9 +76,9 @@ export default function RecipientDetails({
     );
   }
 
-  const requirements = requirementsDataArray.at(selectedIndex);
+  const requirements = activeRequirements.at(selectedIndex);
 
-  // should never happen as `selectedIndex === 0` by default and can only be set to value smaller than `requirementsDataArray.length`
+  // should never happen as `selectedIndex === 0` by default and can only be set to value smaller than `activeRequirements.length`
   if (!requirements) {
     return (
       <span>
@@ -91,7 +91,7 @@ export default function RecipientDetails({
   return (
     <>
       <AccountRequirementsSelector
-        accountRequirements={requirementsDataArray.map(
+        accountRequirements={activeRequirements.map(
           (x) => x.accountRequirements
         )}
         currentIndex={selectedIndex}

--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -11,6 +11,11 @@ import RecipientDetailsForm from "./RecipientDetailsForm";
 import useRecipientDetails from "./useRecipientDetails";
 
 type Props = {
+  /**
+   * The flag is used to display a loading indicator (e.g. when debouncing `expectedMontlyDonations`) without
+   * having to unmount the component itself - this way the current form state gets stored between form loads
+   * and we are able to prefill the form fields
+   */
   isLoading: boolean;
   isSubmitting: boolean;
   targetCurrency: string;
@@ -47,7 +52,8 @@ export default function RecipientDetails({
     onSubmit
   );
 
-  if (isLoading || isLoadingRequirements) {
+  // no need to check `isLoading` too, as it already affects the value of `isLoadingRequirements`
+  if (isLoadingRequirements) {
     return (
       <div className="flex items-center gap-2">
         <LoaderRing thickness={10} classes="w-6" /> Loading...

--- a/src/components/BankDetails/RecipientDetails/helpers/index.ts
+++ b/src/components/BankDetails/RecipientDetails/helpers/index.ts
@@ -2,3 +2,4 @@ export * from "./dot";
 export * from "./getDefaultValues";
 export * from "./isCountry";
 export * from "./isTextType";
+export * from "./mergeRequirements";

--- a/src/components/BankDetails/RecipientDetails/helpers/index.ts
+++ b/src/components/BankDetails/RecipientDetails/helpers/index.ts
@@ -1,5 +1,3 @@
 export * from "./dot";
-export * from "./getDefaultValues";
 export * from "./isCountry";
 export * from "./isTextType";
-export * from "./mergeRequirements";

--- a/src/components/BankDetails/RecipientDetails/helpers/mergeRequirements.ts
+++ b/src/components/BankDetails/RecipientDetails/helpers/mergeRequirements.ts
@@ -1,0 +1,105 @@
+import { FormValues, RequirementsData } from "../types";
+import { AccountRequirements } from "types/aws";
+import { isEmpty } from "helpers";
+import { addRequirementGroup, getDefaultValues } from "./getDefaultValues";
+
+export function mergeRequirements(
+  prev: RequirementsData[],
+  updatedRequirements: AccountRequirements[],
+  targetCurrency: string
+): RequirementsData[] {
+  const activeRequirementsDataArray: RequirementsData[] = [];
+  const inactiveRequirementsDataArray: RequirementsData[] = [];
+
+  prev.forEach((prevReqData) => {
+    const existingReqData = updatedRequirements.find(
+      (x) => x.type === prevReqData.accountRequirements.type
+    );
+    if (!existingReqData) {
+      inactiveRequirementsDataArray.push({
+        ...prevReqData,
+        active: false,
+      });
+    } else {
+      activeRequirementsDataArray.push({
+        ...prevReqData,
+        active: true,
+      });
+    }
+  });
+
+  return inactiveRequirementsDataArray.concat(
+    updatedRequirements.map((updReq) => {
+      // Should be undefined when loading for the first time or changing target currency/expected monthly donations.
+      // Should always be found when refreshing << but not 100% sure how Wise behaves in all cases >>.
+      const existingReqData = activeRequirementsDataArray.find(
+        (x) => x.accountRequirements.type === updReq.type
+      );
+
+      // requirement type is loaded for the first time, use default values
+      if (!existingReqData) {
+        return {
+          active: true,
+          accountRequirements: updReq,
+          currentFormValues: getDefaultValues(updReq, targetCurrency),
+          refreshedRequirementsAdded: false,
+          refreshRequired: isRefreshRequired(updReq),
+        };
+      }
+
+      // requirement type is among the previously loaded requirements, update the form fields
+      return getUpdatedRequirementsData(existingReqData, updReq);
+    })
+  );
+}
+
+/**
+ * Checks whether there are any new requirements to add to the form and if so, adds them and sets them
+ * to the appropriate default value.
+ *
+ * @param currReqData current requirements data
+ * @param updatedReq updated requirements that might include new requirement groups
+ * @returns object containing previous form values with the new requirements included and set to appropriate default values AND
+ * a flag indicating whether any new requirements were added to the form
+ */
+function getUpdatedRequirementsData(
+  currReqData: RequirementsData,
+  updatedReq: AccountRequirements
+): RequirementsData {
+  // get current requirement groups
+  const currGroups = currReqData.accountRequirements.fields.flatMap(
+    (field) => field.group
+  );
+
+  // get only new requirement groups
+  const newGroups = updatedReq.fields
+    .flatMap((field) => field.group)
+    .filter((ng) => !currGroups.find((cg) => cg.key === ng.key));
+
+  // add new requirement groups (if any) to the current requirements
+  const newRequirements: FormValues["requirements"] = newGroups.reduce(
+    (curr, group) => addRequirementGroup(curr, group),
+    { ...currReqData.currentFormValues.requirements }
+  );
+
+  // update default form values
+  const newFormValues: FormValues = {
+    ...currReqData.currentFormValues,
+    requirements: newRequirements,
+  };
+
+  const data: RequirementsData = {
+    active: true,
+    accountRequirements: updatedReq,
+    currentFormValues: newFormValues,
+    refreshedRequirementsAdded: !isEmpty(newGroups),
+    refreshRequired: isRefreshRequired(updatedReq),
+  };
+  return data;
+}
+
+function isRefreshRequired(requirements: AccountRequirements): boolean {
+  return requirements.fields.some((field) =>
+    field.group.some((group) => group.refreshRequirementsOnChange)
+  );
+}

--- a/src/components/BankDetails/RecipientDetails/types.ts
+++ b/src/components/BankDetails/RecipientDetails/types.ts
@@ -1,6 +1,5 @@
-import { CreateRecipientRequest } from "types/aws";
-import { FileDropzoneAsset, OptionType } from "types/components";
-import { Country } from "types/components";
+import { AccountRequirements, CreateRecipientRequest } from "types/aws";
+import { Country, FileDropzoneAsset, OptionType } from "types/components";
 
 export type FormValues = Omit<
   CreateRecipientRequest,
@@ -15,4 +14,16 @@ export type FormValues = Omit<
 > & {
   bankStatementFile: FileDropzoneAsset;
   requirements: Record<string, null | string | OptionType<string> | Country>;
+};
+
+export type RequirementsData = {
+  active: boolean;
+  accountRequirements: AccountRequirements;
+  currentFormValues: FormValues;
+  refreshedRequirementsAdded: boolean;
+  /**
+   * Indicates whether requirements refresh is necessary.
+   * See https://docs.wise.com/api-docs/api-reference/recipient#account-requirements
+   */
+  refreshRequired: boolean;
 };

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails.ts
@@ -60,6 +60,9 @@ export default function useRecipientDetails(
 
         if (isEmpty(updatedRequirements)) {
           setError(true);
+          setRequirementsDataArray((prev) =>
+            mergeRequirements(prev, [], targetCurrency)
+          );
           return handleError(
             "Target currency not supported. Please use a bank account with a different currency."
           );

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails.ts
@@ -56,12 +56,8 @@ export default function useRecipientDetails(
 
   useEffect(() => {
     (async () => {
-      if (isError) {
-        setError(false);
-      }
-      if (!isLoading) {
-        setLoading(true);
-      }
+      setError(false);
+      setLoading(true);
 
       try {
         const newQuote = await createQuote({

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails.ts
@@ -25,7 +25,7 @@ type RequirementsData = {
 };
 
 export default function useRecipientDetails(
-  isDebouncing: boolean,
+  isParentLoading: boolean,
   targetCurrency: string,
   expectedMontlyDonations: number,
   onSubmit: (
@@ -49,10 +49,10 @@ export default function useRecipientDetails(
   const [postAccountRequirements] = usePostAccountRequirementsMutation();
 
   useEffect(() => {
-    if (isDebouncing && !isLoading) {
+    if (isParentLoading && !isLoading) {
       setLoading(true);
     }
-  }, [isDebouncing, isLoading]);
+  }, [isParentLoading, isLoading]);
 
   useEffect(() => {
     (async () => {

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails.ts
@@ -16,7 +16,7 @@ import { addRequirementGroup, getDefaultValues } from "./helpers";
 type RequirementsData = {
   accountRequirements: AccountRequirements;
   currentFormValues: FormValues;
-  newRequirementsAdded: boolean;
+  refreshedRequirementsAdded: boolean;
   /**
    * Indicates whether requirements refresh is necessary.
    * See https://docs.wise.com/api-docs/api-reference/recipient#account-requirements
@@ -78,16 +78,13 @@ export default function useRecipientDetails(
 
         setRequirementsDataArray((prev) =>
           newRequirements.map((item) => {
-            const { formValues, newRequirementsAdded } = getRefreshedFormValues(
-              prev,
-              item,
-              targetCurrency
-            );
+            const { formValues, refreshedRequirementsAdded } =
+              getRefreshedFormValues(prev, item, targetCurrency);
 
             const data: RequirementsData = {
               accountRequirements: item,
               currentFormValues: formValues,
-              newRequirementsAdded: newRequirementsAdded,
+              refreshedRequirementsAdded,
               refreshRequired: item.fields.some((field) =>
                 field.group.some((group) => group.refreshRequirementsOnChange)
               ),
@@ -151,16 +148,13 @@ export default function useRecipientDetails(
 
       setRequirementsDataArray((prev) => {
         const updated: RequirementsData[] = newRequirements.map((newReq) => {
-          const { formValues, newRequirementsAdded } = getRefreshedFormValues(
-            prev,
-            newReq,
-            targetCurrency
-          );
+          const { formValues, refreshedRequirementsAdded } =
+            getRefreshedFormValues(prev, newReq, targetCurrency);
 
           return {
             accountRequirements: newReq,
             currentFormValues: formValues,
-            newRequirementsAdded,
+            refreshedRequirementsAdded,
             refreshRequired:
               prev[selectedIndex].accountRequirements.type === newReq.type
                 ? false // just finished checking requirements for selected type, so no need to do it again
@@ -220,7 +214,7 @@ function getRefreshedFormValues(
   newReq: AccountRequirements,
   targetCurrency: string
 ): {
-  newRequirementsAdded: boolean;
+  refreshedRequirementsAdded: boolean;
   formValues: FormValues;
 } {
   // should be undefined when loading for the first time or changing target currency/expected monthly donations
@@ -232,7 +226,7 @@ function getRefreshedFormValues(
   if (!currReqData) {
     return {
       formValues: getDefaultValues(newReq, targetCurrency),
-      newRequirementsAdded: false, // these are technically new requirements
+      refreshedRequirementsAdded: false, // these are technically not refreshed requirements
     };
   }
 
@@ -260,6 +254,6 @@ function getRefreshedFormValues(
 
   return {
     formValues: newFormValues,
-    newRequirementsAdded: !isEmpty(newGroups),
+    refreshedRequirementsAdded: !isEmpty(newGroups),
   };
 }

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/getDefaultValues.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/getDefaultValues.ts
@@ -2,7 +2,7 @@ import { FormValues } from "../types";
 import { AccountRequirements, Field, Group } from "types/aws";
 import { Country } from "types/components";
 import { asset } from "components/FileDropzone";
-import { isCountry, isTextType, undot } from ".";
+import { isCountry, isTextType, undot } from "../helpers";
 
 /**
  * Creates a FormValues object based on the passed requirements,
@@ -22,7 +22,7 @@ export function getDefaultValues(
     type: accountRequirements.type,
     requirements: accountRequirements.fields.reduce<FormValues["requirements"]>(
       (defaultValues, field) => {
-        const updated = addRequirementField(defaultValues, field);
+        const updated = populateRequirementField(defaultValues, field);
         return updated;
       },
       {}
@@ -37,12 +37,12 @@ export function getDefaultValues(
  * @param field requirement field to add
  * @returns current form requirements with the new req. field added
  */
-function addRequirementField(
+function populateRequirementField(
   currFormValues: FormValues["requirements"],
   field: Field
 ): FormValues["requirements"] {
   const result = field.group.reduce(
-    (curr, group) => addRequirementGroup(curr, group),
+    (curr, group) => populateRequirementGroup(curr, group),
     { ...currFormValues }
   );
 
@@ -56,7 +56,7 @@ function addRequirementField(
  * @param group requirement group to add
  * @returns current form requirements with the new req. group added
  */
-export function addRequirementGroup(
+export function populateRequirementGroup(
   currFormValues: FormValues["requirements"],
   group: Group
 ): FormValues["requirements"] {

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/index.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./useRecipientDetails";

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/useReducer.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/useReducer.ts
@@ -1,0 +1,95 @@
+import { useReducer as useReactReducer } from "react";
+import { FormValues, RequirementsData } from "../types";
+import { AccountRequirements, Quote } from "types/aws";
+import { UnexpectedStateError } from "errors/errors";
+import mergeRequirements from "./mergeRequirements";
+
+type State = {
+  quote: Quote | undefined; // store quote to use to refresh requirements
+  activeRequirementsDataArray: RequirementsData[];
+  requirementsDataArray: RequirementsData[];
+  selectedRequirementsData: RequirementsData | undefined;
+};
+
+type ChangeSelectedRequirementsData = {
+  type: "CHANGE_SELECTED_REQUIREMENTS_DATA";
+  payload: RequirementsData;
+};
+
+type UpdateFormValues = {
+  type: "UPDATE_FORM_VALUES";
+  payload: FormValues;
+};
+
+type UpdateRequirements = {
+  type: "UPDATE_REQUIREMENTS";
+  payload: {
+    quote?: Quote;
+    requirements: AccountRequirements[];
+    targetCurrency: string;
+    isRefreshing?: boolean;
+  };
+};
+
+type Action =
+  | ChangeSelectedRequirementsData
+  | UpdateFormValues
+  | UpdateRequirements;
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "CHANGE_SELECTED_REQUIREMENTS_DATA": {
+      return { ...state, selectedRequirementsData: action.payload };
+    }
+    case "UPDATE_FORM_VALUES": {
+      const updated = [...state.requirementsDataArray];
+      const toUpdate = updated.find(
+        (x) => x.accountRequirements.type === action.payload.type
+      );
+
+      if (!!toUpdate) {
+        toUpdate.currentFormValues = action.payload;
+        return { ...state, requirementsDataArray: updated };
+      }
+
+      throw new UnexpectedStateError(
+        `Trying to update a non existent requirements type: ${action.payload.type}`
+      );
+    }
+    case "UPDATE_REQUIREMENTS": {
+      const quote = action.payload.quote ?? state.quote;
+      const requirementsDataArray = mergeRequirements(
+        [...state.requirementsDataArray],
+        action.payload.requirements,
+        action.payload.targetCurrency,
+        action.payload.isRefreshing
+      );
+      const activeRequirementsDataArray = requirementsDataArray.filter(
+        (x) => x.active
+      );
+      const selectedRequirementsData =
+        activeRequirementsDataArray.find(
+          (x) =>
+            x.accountRequirements.type ===
+            state.selectedRequirementsData?.accountRequirements.type
+        ) ?? activeRequirementsDataArray.at(0);
+
+      return {
+        ...state,
+        activeRequirementsDataArray,
+        quote,
+        requirementsDataArray,
+        selectedRequirementsData,
+      };
+    }
+  }
+}
+
+export default function useReducer() {
+  return useReactReducer(reducer, {
+    quote: undefined,
+    activeRequirementsDataArray: [],
+    requirementsDataArray: [],
+    selectedRequirementsData: undefined,
+  });
+}


### PR DESCRIPTION
## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- register if necessary
- start registration process
- get to step 5 Banking
- input data:
   - currency: PHP
   - (estimated monthly donation) amount: 123
   - choose E-WALLET
   - input any data into the form
   - change amount to: 123444
   - wait for new form type(s) to load
   - **verify the newly selected bank details type by default is "LOCAL BANK ACCOUNT" (this is fix for AP-943)**
   - input any data in the form
   - change amount back to: 123
   - **verify the select bank details type is still "LOCAL BANK ACCOUNT"**
   - **verify the previously input form data is still present**
   - click on "E-WALLET" type button
   - **verify the initial form data is still present**