### PR TITLE
AP-953: stripe doesn't work on widget

### DIFF
--- a/src/components/donation/Steps/DonateMethods/Stripe.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe.tsx
@@ -49,6 +49,10 @@ export default function Stripe({
               liquidSplitPct: fv.pctLiquidSplit.toString(),
             }).unwrap();
 
+            if (isInsideWidget) {
+              return window.open(session.url, "_blank");
+            }
+
             setIsRedirecting(true);
             window.location.href = session.url;
           } catch (err) {


### PR DESCRIPTION
Ticket(s):
-
* found that stripe checkout URL shoudn't be rendered inside widget
https://stripe.com/docs/checkout/embedded/quickstart#initialize-checkout-html

## Explanation of the solution
* if stripe form is inside widget - should not try to navigate within the i-frame but instead open a new tab 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes