### PR TITLE
AP-942: After clicking "Check Requirements", non-selected requirement type forms should not be in error state

### DIFF
--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -106,19 +106,14 @@ export default function RecipientDetails({
         // component key is that upon refreshing the requirements, the number of fields will change,
         // thus causing the whole form to be recreated (reinitiating the whole form with `react-hook-form > useForm`)
         key={`form-${selectedRequirementsData.accountRequirements.type}-${selectedRequirementsData.accountRequirements.fields.length}`}
-        accountRequirements={selectedRequirementsData.accountRequirements}
         currency={currency}
-        defaultValues={selectedRequirementsData.currentFormValues}
         disabled={isSubmitting}
         focusNewRequirements={focusNewRequirements}
-        refreshRequired={selectedRequirementsData.refreshRequired}
-        refreshedRequirementsAdded={
-          selectedRequirementsData.refreshedRequirementsAdded
-        }
-        onUpdateValues={updateDefaultValues}
-        onSubmit={handleSubmit}
-        onRefresh={refreshRequirements}
         FormButtons={FormButtons}
+        requirementsData={selectedRequirementsData}
+        onRefresh={refreshRequirements}
+        onSubmit={handleSubmit}
+        onUpdateValues={updateDefaultValues}
       />
     </>
   );

--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -38,13 +38,14 @@ export default function RecipientDetails({
   onSubmit,
 }: Props) {
   const {
-    requirementsDataArray,
-    handleSubmit,
+    focusNewRequirements,
     isError,
     isLoading: isLoadingRequirements,
-    refreshRequirements,
+    requirementsDataArray,
     selectedRequirementsData,
     changeSelectedType,
+    handleSubmit,
+    refreshRequirements,
     updateDefaultValues,
   } = useRecipientDetails(
     isLoading,
@@ -109,6 +110,7 @@ export default function RecipientDetails({
         currency={currency}
         defaultValues={selectedRequirementsData.currentFormValues}
         disabled={isSubmitting}
+        focusNewRequirements={focusNewRequirements}
         refreshRequired={selectedRequirementsData.refreshRequired}
         refreshedRequirementsAdded={
           selectedRequirementsData.refreshedRequirementsAdded

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
@@ -15,6 +15,7 @@ type Props = {
   accountRequirements: AccountRequirements;
   currency: Currency;
   disabled: boolean;
+  focusNewRequirements: boolean;
   refreshedRequirementsAdded: boolean;
   refreshRequired: boolean;
   FormButtons: ComponentType<FormButtonsProps>;
@@ -49,10 +50,10 @@ export default function Form(props: Props) {
   // and immediately validate all the newly added fields, clearly marking all the
   // invalid ones to make it easier for the user to notice them
   useEffect(() => {
-    if (props.refreshedRequirementsAdded && form.current) {
+    if (props.focusNewRequirements && form.current) {
       form.current.requestSubmit();
     }
-  }, [props.refreshedRequirementsAdded]);
+  }, [props.focusNewRequirements]);
 
   return (
     <form onSubmit={handleSubmission} ref={form} className="grid gap-6">

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
@@ -1,8 +1,8 @@
 import { ComponentType, useEffect, useRef } from "react";
 import { useFormContext } from "react-hook-form";
 import { FormButtonsProps } from "../../types";
-import { FormValues } from "../types";
-import { AccountRequirements, CreateRecipientRequest } from "types/aws";
+import { FormValues, RequirementsData } from "../types";
+import { CreateRecipientRequest } from "types/aws";
 import { FileDropzoneAsset } from "types/components";
 import FileDropzone from "components/FileDropzone";
 import { Label } from "components/form";
@@ -12,13 +12,11 @@ import { MB_LIMIT, VALID_MIME_TYPES } from "./constants";
 import formToCreateRecipientRequest from "./formToCreateRecipientRequest";
 
 type Props = {
-  accountRequirements: AccountRequirements;
   currency: Currency;
   disabled: boolean;
   focusNewRequirements: boolean;
-  refreshedRequirementsAdded: boolean;
-  refreshRequired: boolean;
   FormButtons: ComponentType<FormButtonsProps>;
+  requirementsData: RequirementsData;
   onRefresh: (request: CreateRecipientRequest) => Promise<void>;
   onSubmit: (
     request: CreateRecipientRequest,
@@ -29,6 +27,16 @@ type Props = {
 
 export default function Form(props: Props) {
   const {
+    currency,
+    disabled,
+    focusNewRequirements,
+    requirementsData,
+    FormButtons,
+    onRefresh,
+    onSubmit,
+  } = props;
+
+  const {
     handleSubmit,
     formState: { isSubmitting, isDirty },
   } = useFormContext<FormValues>();
@@ -38,10 +46,10 @@ export default function Form(props: Props) {
   const handleSubmission = handleSubmit(async (formValues) => {
     const { bankStatementFile, ...bankDetails } = formValues;
     const request = formToCreateRecipientRequest(bankDetails);
-    if (props.refreshRequired) {
-      await props.onRefresh(request);
+    if (requirementsData.refreshRequired) {
+      await onRefresh(request);
     } else {
-      await props.onSubmit(request, bankStatementFile, isDirty);
+      await onSubmit(request, bankStatementFile, isDirty);
     }
   });
 
@@ -50,22 +58,22 @@ export default function Form(props: Props) {
   // and immediately validate all the newly added fields, clearly marking all the
   // invalid ones to make it easier for the user to notice them
   useEffect(() => {
-    if (props.focusNewRequirements && form.current) {
+    if (focusNewRequirements && form.current) {
       form.current.requestSubmit();
     }
-  }, [props.focusNewRequirements]);
+  }, [focusNewRequirements]);
 
   return (
     <form onSubmit={handleSubmission} ref={form} className="grid gap-6">
-      {props.accountRequirements.fields
+      {requirementsData.accountRequirements.fields
         .flatMap((field) => field.group)
         .map((requirements) => (
           <RequirementField
             key={requirements.key}
-            currency={props.currency}
+            currency={currency}
             data={requirements}
-            disabled={props.disabled}
-            requirementsType={props.accountRequirements.type}
+            disabled={disabled}
+            requirementsType={requirementsData.accountRequirements.type}
           />
         ))}
 
@@ -74,15 +82,15 @@ export default function Form(props: Props) {
         <FileDropzone<FormValues, "bankStatementFile">
           name="bankStatementFile"
           specs={{ mbLimit: MB_LIMIT, mimeTypes: VALID_MIME_TYPES }}
-          disabled={props.disabled}
+          disabled={disabled}
         />
       </div>
 
-      <props.FormButtons
-        disabled={props.disabled}
+      <FormButtons
+        disabled={disabled}
         isSubmitting={isSubmitting}
-        refreshedRequirementsAdded={props.refreshedRequirementsAdded}
-        refreshRequired={props.refreshRequired}
+        refreshedRequirementsAdded={requirementsData.refreshedRequirementsAdded}
+        refreshRequired={requirementsData.refreshRequired}
       />
     </form>
   );

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -1,38 +1,35 @@
 import { ComponentType, useEffect } from "react";
 import { FormProvider } from "react-hook-form";
 import { FormButtonsProps } from "../../types";
-import { FormValues } from "../types";
-import { AccountRequirements, CreateRecipientRequest } from "types/aws";
+import { FormValues, RequirementsData } from "../types";
+import { CreateRecipientRequest } from "types/aws";
 import { FileDropzoneAsset } from "types/components";
 import { Currency } from "../../CurrencySelector";
 import Form from "./Form";
 import useRecipientDetailsForm from "./useRecipientDetailsForm";
 
 type Props = {
-  accountRequirements: AccountRequirements;
   currency: Currency;
-  defaultValues: FormValues;
   disabled: boolean;
   focusNewRequirements: boolean;
-  refreshedRequirementsAdded: boolean;
-  refreshRequired: boolean;
   FormButtons: ComponentType<FormButtonsProps>;
-  onUpdateValues: (formValues: FormValues) => void;
+  requirementsData: RequirementsData;
   onRefresh: (request: CreateRecipientRequest) => Promise<void>;
   onSubmit: (
     request: CreateRecipientRequest,
     bankStatementFile: FileDropzoneAsset,
     isDirty: boolean
   ) => Promise<void>;
+  onUpdateValues: (formValues: FormValues) => void;
 };
 
 export default function RecipientDetailsForm(props: Props) {
   const methods = useRecipientDetailsForm(
-    props.accountRequirements,
-    props.defaultValues
+    props.requirementsData.accountRequirements,
+    props.requirementsData.currentFormValues
   );
 
-  const { onUpdateValues } = props;
+  const { onUpdateValues, onRefresh, ...rest } = props;
   const { getValues } = methods;
 
   // save current form values so that they can be preloaded
@@ -43,23 +40,13 @@ export default function RecipientDetailsForm(props: Props) {
     };
   }, [getValues, onUpdateValues]);
 
+  const handleRefresh = async (request: CreateRecipientRequest) => {
+    onUpdateValues(getValues()); // update current form values prior to refreshing the form (which loads new fields)
+    await onRefresh(request);
+  };
   return (
     <FormProvider {...methods}>
-      <Form
-        accountRequirements={props.accountRequirements}
-        currency={props.currency}
-        disabled={props.disabled}
-        focusNewRequirements={props.focusNewRequirements}
-        refreshedRequirementsAdded={props.refreshedRequirementsAdded}
-        refreshRequired={props.refreshRequired}
-        onRefresh={async (request) => {
-          // update current form values prior to refreshing the form (loads new fields)
-          onUpdateValues(getValues());
-          await props.onRefresh(request);
-        }}
-        onSubmit={props.onSubmit}
-        FormButtons={props.FormButtons}
-      />
+      <Form onRefresh={handleRefresh} {...rest} />
     </FormProvider>
   );
 }

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -13,6 +13,7 @@ type Props = {
   currency: Currency;
   defaultValues: FormValues;
   disabled: boolean;
+  focusNewRequirements: boolean;
   refreshedRequirementsAdded: boolean;
   refreshRequired: boolean;
   FormButtons: ComponentType<FormButtonsProps>;
@@ -48,6 +49,7 @@ export default function RecipientDetailsForm(props: Props) {
         accountRequirements={props.accountRequirements}
         currency={props.currency}
         disabled={props.disabled}
+        focusNewRequirements={props.focusNewRequirements}
         refreshedRequirementsAdded={props.refreshedRequirementsAdded}
         refreshRequired={props.refreshRequired}
         onRefresh={async (request) => {

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/useRecipientDetails.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/useRecipientDetails.ts
@@ -148,13 +148,14 @@ export default function useRecipientDetails(
   };
 
   return {
-    handleSubmit,
+    focusNewRequirements: state.focusNewRequirements,
     isError,
     isLoading: isLoading || isParentLoading,
-    refreshRequirements,
     requirementsDataArray: state.requirementsDataArray.filter((x) => x.active),
     selectedRequirementsData: state.selectedRequirementsData,
     changeSelectedType,
+    handleSubmit,
+    refreshRequirements,
     updateDefaultValues,
   };
 }

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/useStateReducer.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/useStateReducer.ts
@@ -6,8 +6,9 @@ import { Currency } from "../../CurrencySelector";
 import mergeRequirements from "./mergeRequirements";
 
 type State = {
-  quote: Quote | undefined; // store quote to use to refresh requirements
   activeRequirementsDataArray: RequirementsData[];
+  focusNewRequirements: boolean;
+  quote: Quote | undefined; // store quote to use to refresh requirements
   requirementsDataArray: RequirementsData[];
   selectedRequirementsData: RequirementsData | undefined;
 };
@@ -40,7 +41,11 @@ type Action =
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case "CHANGE_SELECTED_REQUIREMENTS_DATA": {
-      return { ...state, selectedRequirementsData: action.payload };
+      return {
+        ...state,
+        selectedRequirementsData: action.payload,
+        focusNewRequirements: false,
+      };
     }
     case "UPDATE_FORM_VALUES": {
       const updated = [...state.requirementsDataArray];
@@ -58,12 +63,18 @@ function reducer(state: State, action: Action): State {
       );
     }
     case "UPDATE_REQUIREMENTS": {
-      const quote = action.payload.quote ?? state.quote;
+      const {
+        currency,
+        isRefreshed = false,
+        quote = state.quote,
+        requirements,
+      } = action.payload;
+
       const requirementsDataArray = mergeRequirements(
         [...state.requirementsDataArray],
-        action.payload.requirements,
-        action.payload.currency,
-        action.payload.isRefreshed
+        requirements,
+        currency,
+        isRefreshed
       );
       const activeRequirementsDataArray = requirementsDataArray.filter(
         (x) => x.active
@@ -78,6 +89,7 @@ function reducer(state: State, action: Action): State {
       return {
         ...state,
         activeRequirementsDataArray,
+        focusNewRequirements: isRefreshed,
         quote,
         requirementsDataArray,
         selectedRequirementsData,
@@ -91,10 +103,12 @@ function reducer(state: State, action: Action): State {
  * the selected requirement data item
  */
 export default function useStateReducer() {
-  return useReducer(reducer, {
+  const state: State = {
     activeRequirementsDataArray: [],
+    focusNewRequirements: false,
     quote: undefined,
     requirementsDataArray: [],
     selectedRequirementsData: undefined,
-  });
+  };
+  return useReducer(reducer, state);
 }

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/useStateReducer.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/useStateReducer.ts
@@ -8,6 +8,8 @@ import mergeRequirements from "./mergeRequirements";
 type State = {
   activeRequirementsDataArray: RequirementsData[];
   focusNewRequirements: boolean;
+  isError: boolean;
+  isLoading: boolean;
   quote: Quote | undefined; // store quote to use to refresh requirements
   requirementsDataArray: RequirementsData[];
   selectedRequirementsData: RequirementsData | undefined;
@@ -16,6 +18,16 @@ type State = {
 type ChangeSelectedRequirementsData = {
   type: "CHANGE_SELECTED_REQUIREMENTS_DATA";
   payload: RequirementsData;
+};
+
+type SetError = {
+  type: "ERROR";
+  payload: boolean;
+};
+
+type SetLoading = {
+  type: "LOADING";
+  payload: boolean;
 };
 
 type UpdateFormValues = {
@@ -35,6 +47,8 @@ type UpdateRequirements = {
 
 type Action =
   | ChangeSelectedRequirementsData
+  | SetError
+  | SetLoading
   | UpdateFormValues
   | UpdateRequirements;
 
@@ -45,6 +59,18 @@ function reducer(state: State, action: Action): State {
         ...state,
         selectedRequirementsData: action.payload,
         focusNewRequirements: false,
+      };
+    }
+    case "ERROR": {
+      return {
+        ...state,
+        isError: action.payload,
+      };
+    }
+    case "LOADING": {
+      return {
+        ...state,
+        isLoading: action.payload,
       };
     }
     case "UPDATE_FORM_VALUES": {
@@ -106,6 +132,8 @@ export default function useStateReducer() {
   const state: State = {
     activeRequirementsDataArray: [],
     focusNewRequirements: false,
+    isError: false,
+    isLoading: true,
     quote: undefined,
     requirementsDataArray: [],
     selectedRequirementsData: undefined,


### PR DESCRIPTION
## Explanation of the solution
- fulfilled the requirements
- update `RecipientDetails`'s children's props to accept `RequirementsData` instead of its fields

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- sign in with an account that has an endowment tied to it
- get to http://localhost:4200/admin/{{ENDOW_ID}}/banking (replace `{{ENDOW_ID}}` with your endow ID)
- **to get valid bank details use the following:**
   - currency: USD
   - amount:  1<=X<=10000
   - type: ACH
   - name: whatever
   - routing number: 325181015
   - account number: 000123456
   - country: USA
   - city: whatever
   - resident address: whatever
   - postcode: 90001
- click "Check Requirements"
- **verify a new field "State" is in error state (no pun intended)**
- click on "WIRE" bank details form type
- **verify fields are NOT in error state**
