### PR TITLE
AP-960: Bank Details: remove USA as country options when requirements type is SWIFT and target currency is USD

### DIFF
--- a/src/components/BankDetails/BankDetails.tsx
+++ b/src/components/BankDetails/BankDetails.tsx
@@ -99,7 +99,7 @@ function Content({
               // it needs to reset its state by re-rendering the whole component.
               key={targetCurrency.code}
               isLoading={isDebouncing}
-              targetCurrency={targetCurrency.code}
+              currency={targetCurrency}
               expectedMontlyDonations={expectedMontlyDonations}
               isSubmitting={isSubmitting}
               onSubmit={onSubmit}

--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -6,6 +6,7 @@ import LoaderRing from "components/LoaderRing";
 import { isEmpty } from "helpers";
 import { GENERIC_ERROR_MESSAGE } from "constants/common";
 import { EMAIL_SUPPORT } from "constants/env";
+import { Currency } from "../CurrencySelector";
 import AccountRequirementsSelector from "./AccountRequirementsSelector";
 import RecipientDetailsForm from "./RecipientDetailsForm";
 import useRecipientDetails from "./useRecipientDetails";
@@ -18,7 +19,7 @@ type Props = {
    */
   isLoading: boolean;
   isSubmitting: boolean;
-  targetCurrency: string;
+  currency: Currency;
   expectedMontlyDonations: number;
   FormButtons: ComponentType<FormButtonsProps>;
   onSubmit: (
@@ -31,7 +32,7 @@ type Props = {
 export default function RecipientDetails({
   isLoading,
   isSubmitting,
-  targetCurrency,
+  currency,
   expectedMontlyDonations,
   FormButtons,
   onSubmit,
@@ -47,7 +48,7 @@ export default function RecipientDetails({
     updateDefaultValues,
   } = useRecipientDetails(
     isLoading,
-    targetCurrency,
+    currency,
     expectedMontlyDonations,
     onSubmit
   );
@@ -105,7 +106,7 @@ export default function RecipientDetails({
         // thus causing the whole form to be recreated (reinitiating the whole form with `react-hook-form > useForm`)
         key={`form-${selectedRequirementsData.accountRequirements.type}-${selectedRequirementsData.accountRequirements.fields.length}`}
         accountRequirements={selectedRequirementsData.accountRequirements}
-        currency={targetCurrency}
+        currency={currency}
         defaultValues={selectedRequirementsData.currentFormValues}
         disabled={isSubmitting}
         refreshRequired={selectedRequirementsData.refreshRequired}

--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -105,6 +105,7 @@ export default function RecipientDetails({
         // thus causing the whole form to be recreated (reinitiating the whole form with `react-hook-form > useForm`)
         key={`form-${selectedRequirementsData.accountRequirements.type}-${selectedRequirementsData.accountRequirements.fields.length}`}
         accountRequirements={selectedRequirementsData.accountRequirements}
+        currency={targetCurrency}
         defaultValues={selectedRequirementsData.currentFormValues}
         disabled={isSubmitting}
         refreshRequired={selectedRequirementsData.refreshRequired}

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
@@ -1,7 +1,7 @@
 import { ComponentType, useEffect, useRef } from "react";
 import { useFormContext } from "react-hook-form";
+import { FormButtonsProps } from "../../types";
 import { FormValues } from "../types";
-import { FormButtonsProps } from "components/BankDetails/types";
 import { AccountRequirements, CreateRecipientRequest } from "types/aws";
 import { FileDropzoneAsset } from "types/components";
 import FileDropzone from "components/FileDropzone";

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
@@ -6,13 +6,14 @@ import { AccountRequirements, CreateRecipientRequest } from "types/aws";
 import { FileDropzoneAsset } from "types/components";
 import FileDropzone from "components/FileDropzone";
 import { Label } from "components/form";
+import { Currency } from "../../CurrencySelector";
 import RequirementField from "./RequirementField";
 import { MB_LIMIT, VALID_MIME_TYPES } from "./constants";
 import formToCreateRecipientRequest from "./formToCreateRecipientRequest";
 
 type Props = {
   accountRequirements: AccountRequirements;
-  currency: string;
+  currency: Currency;
   disabled: boolean;
   refreshedRequirementsAdded: boolean;
   refreshRequired: boolean;

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
@@ -12,6 +12,7 @@ import formToCreateRecipientRequest from "./formToCreateRecipientRequest";
 
 type Props = {
   accountRequirements: AccountRequirements;
+  currency: string;
   disabled: boolean;
   refreshedRequirementsAdded: boolean;
   refreshRequired: boolean;
@@ -59,8 +60,10 @@ export default function Form(props: Props) {
         .map((requirements) => (
           <RequirementField
             key={requirements.key}
+            currency={props.currency}
             data={requirements}
             disabled={props.disabled}
+            requirementsType={props.accountRequirements.type}
           />
         ))}
 

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -1,15 +1,16 @@
 import { ComponentType, useEffect } from "react";
 import { FormProvider } from "react-hook-form";
+import { FormButtonsProps } from "../../types";
 import { FormValues } from "../types";
-import { FormButtonsProps } from "components/BankDetails/types";
 import { AccountRequirements, CreateRecipientRequest } from "types/aws";
 import { FileDropzoneAsset } from "types/components";
+import { Currency } from "../../CurrencySelector";
 import Form from "./Form";
 import useRecipientDetailsForm from "./useRecipientDetailsForm";
 
 type Props = {
   accountRequirements: AccountRequirements;
-  currency: string;
+  currency: Currency;
   defaultValues: FormValues;
   disabled: boolean;
   refreshedRequirementsAdded: boolean;

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -9,6 +9,7 @@ import useRecipientDetailsForm from "./useRecipientDetailsForm";
 
 type Props = {
   accountRequirements: AccountRequirements;
+  currency: string;
   defaultValues: FormValues;
   disabled: boolean;
   refreshedRequirementsAdded: boolean;
@@ -44,6 +45,7 @@ export default function RecipientDetailsForm(props: Props) {
     <FormProvider {...methods}>
       <Form
         accountRequirements={props.accountRequirements}
+        currency={props.currency}
         disabled={props.disabled}
         refreshedRequirementsAdded={props.refreshedRequirementsAdded}
         refreshRequired={props.refreshRequired}

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RequirementField.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RequirementField.tsx
@@ -7,10 +7,11 @@ import CountrySelector from "components/CountrySelector";
 import { Selector } from "components/Selector";
 import { Field, Label } from "components/form";
 import { isEmpty } from "helpers";
+import { Currency } from "../../CurrencySelector";
 import { isCountry, undot } from "../helpers";
 
 type Props = {
-  currency: string;
+  currency: Currency;
   data: Group;
   disabled?: boolean; // need this only for CountrySelector
   requirementsType: string;
@@ -105,12 +106,12 @@ export default function RequirementField({
 function isAllowed(
   country: Country,
   requirementsType: string,
-  currency: string
+  currency: Currency
 ): boolean {
   return (
     // SWIFT transfers are not allowed inside USA or US territories, see https://wise.com/help/articles/2932150/guide-to-usd-transfers
     !country.name.includes("United States") ||
     requirementsType !== "swift_code" ||
-    currency !== "USD"
+    currency.code !== "USD"
   );
 }

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/getDefaultValues.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/getDefaultValues.ts
@@ -1,6 +1,7 @@
 import { FormValues } from "../types";
 import { AccountRequirements, Field, Group } from "types/aws";
 import { Country } from "types/components";
+import { Currency } from "components/BankDetails/CurrencySelector";
 import { asset } from "components/FileDropzone";
 import { isCountry, isTextType, undot } from "../helpers";
 
@@ -9,16 +10,16 @@ import { isCountry, isTextType, undot } from "../helpers";
  * with all fields set to appropriate default values.
  *
  * @param accountRequirements requirements to process
- * @param targetCurrency target currency
+ * @param currency target currency
  * @returns FormValues object with all fields set to appropriate default values
  */
 export function getDefaultValues(
   accountRequirements: AccountRequirements,
-  targetCurrency: string
+  currency: Currency
 ): FormValues {
   return {
     bankStatementFile: asset([]),
-    currency: targetCurrency,
+    currency: currency.code,
     type: accountRequirements.type,
     requirements: accountRequirements.fields.reduce<FormValues["requirements"]>(
       (defaultValues, field) => {

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/getDefaultValues.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/getDefaultValues.ts
@@ -1,8 +1,8 @@
 import { FormValues } from "../types";
 import { AccountRequirements, Field, Group } from "types/aws";
 import { Country } from "types/components";
-import { Currency } from "components/BankDetails/CurrencySelector";
 import { asset } from "components/FileDropzone";
+import { Currency } from "../../CurrencySelector";
 import { isCountry, isTextType, undot } from "../helpers";
 
 /**

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/mergeRequirements.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/mergeRequirements.ts
@@ -1,7 +1,7 @@
 import { FormValues, RequirementsData } from "../types";
 import { AccountRequirements } from "types/aws";
-import { Currency } from "components/BankDetails/CurrencySelector";
 import { isEmpty } from "helpers";
+import { Currency } from "../../CurrencySelector";
 import { getDefaultValues, populateRequirementGroup } from "./getDefaultValues";
 
 /**

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/mergeRequirements.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/mergeRequirements.ts
@@ -1,5 +1,6 @@
 import { FormValues, RequirementsData } from "../types";
 import { AccountRequirements } from "types/aws";
+import { Currency } from "components/BankDetails/CurrencySelector";
 import { isEmpty } from "helpers";
 import { getDefaultValues, populateRequirementGroup } from "./getDefaultValues";
 
@@ -11,14 +12,14 @@ import { getDefaultValues, populateRequirementGroup } from "./getDefaultValues";
  *
  * @param requirementsDataArray current array of requirements data containing all previously input form state
  * @param updatedRequirements updated requirements based on newly selected currency and expected monthly donation amount
- * @param targetCurrency target currency for which requirements were loaded
+ * @param currency target currency for which requirements were loaded
  * @param isRefreshed flag indicating whether the fields are being processed after refreshing the requirements
  * @returns updated requirements data array
  */
 export default function mergeRequirements(
   requirementsDataArray: RequirementsData[],
   updatedRequirements: AccountRequirements[],
-  targetCurrency: string,
+  currency: Currency,
   isRefreshed = false
 ): RequirementsData[] {
   // separate requirements data array into active and inactive ones based on whether
@@ -44,7 +45,7 @@ export default function mergeRequirements(
         return {
           active: true,
           accountRequirements: updReq,
-          currentFormValues: getDefaultValues(updReq, targetCurrency),
+          currentFormValues: getDefaultValues(updReq, currency),
           refreshedRequirementsAdded: false,
           refreshRequired: isRefreshRequired(updReq),
         };

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/useRecipientDetails.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/useRecipientDetails.ts
@@ -11,11 +11,12 @@ import { useErrorContext } from "contexts/ErrorContext";
 import { isEmpty } from "helpers";
 import { UnexpectedStateError } from "errors/errors";
 import { GENERIC_ERROR_MESSAGE } from "constants/common";
+import { Currency } from "../../CurrencySelector";
 import useStateReducer from "./useStateReducer";
 
 export default function useRecipientDetails(
   isParentLoading: boolean,
-  targetCurrency: string,
+  currency: Currency,
   expectedMontlyDonations: number,
   onSubmit: (
     request: CreateRecipientRequest,
@@ -55,7 +56,7 @@ export default function useRecipientDetails(
 
         const quote = await createQuote({
           sourceAmount: expectedMontlyDonations,
-          targetCurrency: targetCurrency,
+          targetCurrency: currency.code,
         }).unwrap();
 
         const requirements = await getAccountRequirements(quote.id).unwrap();
@@ -70,7 +71,7 @@ export default function useRecipientDetails(
 
         dispatch({
           type: "UPDATE_REQUIREMENTS",
-          payload: { quote, requirements, targetCurrency },
+          payload: { quote, requirements, currency },
         });
       } catch (error) {
         handleError(error, GENERIC_ERROR_MESSAGE);
@@ -82,7 +83,7 @@ export default function useRecipientDetails(
   }, [
     isParentLoading,
     expectedMontlyDonations,
-    targetCurrency,
+    currency,
     createQuote,
     dispatch,
     getAccountRequirements,
@@ -118,7 +119,7 @@ export default function useRecipientDetails(
 
       dispatch({
         type: "UPDATE_REQUIREMENTS",
-        payload: { targetCurrency, requirements, isRefreshed: true },
+        payload: { currency: currency, requirements, isRefreshed: true },
       });
     } catch (error) {
       handleError(error, GENERIC_ERROR_MESSAGE);

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/useStateReducer.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/useStateReducer.ts
@@ -1,6 +1,7 @@
 import { useReducer } from "react";
 import { FormValues, RequirementsData } from "../types";
 import { AccountRequirements, Quote } from "types/aws";
+import { Currency } from "components/BankDetails/CurrencySelector";
 import { UnexpectedStateError } from "errors/errors";
 import mergeRequirements from "./mergeRequirements";
 
@@ -24,10 +25,10 @@ type UpdateFormValues = {
 type UpdateRequirements = {
   type: "UPDATE_REQUIREMENTS";
   payload: {
+    currency: Currency;
+    isRefreshed?: boolean;
     quote?: Quote;
     requirements: AccountRequirements[];
-    targetCurrency: string;
-    isRefreshed?: boolean;
   };
 };
 
@@ -61,7 +62,7 @@ function reducer(state: State, action: Action): State {
       const requirementsDataArray = mergeRequirements(
         [...state.requirementsDataArray],
         action.payload.requirements,
-        action.payload.targetCurrency,
+        action.payload.currency,
         action.payload.isRefreshed
       );
       const activeRequirementsDataArray = requirementsDataArray.filter(

--- a/src/components/BankDetails/RecipientDetails/useRecipientDetails/useStateReducer.ts
+++ b/src/components/BankDetails/RecipientDetails/useRecipientDetails/useStateReducer.ts
@@ -1,8 +1,8 @@
 import { useReducer } from "react";
 import { FormValues, RequirementsData } from "../types";
 import { AccountRequirements, Quote } from "types/aws";
-import { Currency } from "components/BankDetails/CurrencySelector";
 import { UnexpectedStateError } from "errors/errors";
+import { Currency } from "../../CurrencySelector";
 import mergeRequirements from "./mergeRequirements";
 
 type State = {


### PR DESCRIPTION

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- start endowment registration
- go to step 5 bank details
- select target currency: USD
- input amount: 123
- select SWIFT type
- click on "Country" selector
- **verify USA and its territories no longer appear as options**

## UI changes for review

before:
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/19427053/266e88e7-0718-4bf6-8a55-76c11e570883)

after:
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/19427053/586c3367-f6b1-4da6-8c57-5c60ad011b33)
