### PR TITLE
AP-961,AP-951: Enforce https + registration fixes

### DIFF
--- a/src/pages/Registration/Steps/ContactDetails/constants.ts
+++ b/src/pages/Registration/Steps/ContactDetails/constants.ts
@@ -18,7 +18,7 @@ export const roles: { [key in ContactRoles]: string } = {
 };
 export const referralMethods: { [key in ReferralMethods]: string } = {
   "": "",
-  "angel-alliance": "Angel Alliance",
+  "better-giving-alliance": "Better Giving Alliance",
   discord: "Discord",
   facebook: "Facebook",
   linkedin: "Linkedin",

--- a/src/pages/Registration/Steps/ContactDetails/index.tsx
+++ b/src/pages/Registration/Steps/ContactDetails/index.tsx
@@ -23,7 +23,11 @@ function ContactDetails() {
           ...contact,
           PK: init.reference,
           Role: toRoleOption(contact.Role),
-          ReferralMethod: toReferralOption(contact.ReferralMethod),
+          ReferralMethod: toReferralOption(
+            contact.ReferralMethod === "angel-alliance"
+              ? "better-giving-alliance"
+              : contact.ReferralMethod
+          ),
           OrganizationName: contact.orgName,
         }
       : {

--- a/src/pages/Registration/Steps/OrgDetails/schema.ts
+++ b/src/pages/Registration/Steps/OrgDetails/schema.ts
@@ -1,13 +1,13 @@
-import { ObjectSchema, array, object, string } from "yup";
+import { ObjectSchema, array, object } from "yup";
 import { FormValues } from "./types";
 import { SchemaShape } from "schemas/types";
 import { Country } from "types/components";
 import { optionType } from "schemas/shape";
-import { requiredString } from "schemas/string";
+import { requiredString, url } from "schemas/string";
 import { MAX_SDGS } from "constants/unsdgs";
 
 export const schema = object<any, SchemaShape<FormValues>>({
-  Website: string().required("required").url("invalid url"),
+  Website: url.required("required"),
   UN_SDG: array()
     .min(1, "required")
     .max(MAX_SDGS, `maximum ${MAX_SDGS} selections allowed`),

--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -50,7 +50,7 @@ export default function ProgressIndicator({ step, classes = "" }: Props) {
       Organization
     </Step>,
     <Step isDone={step >= 3} isCurr={currPath === 3} key={3}>
-      nonprofit Status
+      Nonprofit Status
     </Step>,
     <Step isDone={step >= 4} isCurr={currPath === 4} key={4}>
       Documentation

--- a/src/schemas/__tests__/string.test.ts
+++ b/src/schemas/__tests__/string.test.ts
@@ -4,31 +4,36 @@ import { url } from "../string";
 describe("string schemas tests", () => {
   describe("url", () => {
     const cases = [
-      { input: null, expected: true }, // value is empty
-      { input: undefined, expected: true }, // value is empty
-      { input: "", expected: true }, // value is empty
+      { input: null, expected: true }, // not initially set and not required
+      { input: undefined, expected: true }, // not initially set and not required
+      { input: "", expected: true }, // empty and not required
+
       { input: ".", expected: false },
       { input: ".@%#%&(!", expected: false },
-      { input: "a.", expected: true },
-      { input: ".a", expected: true },
-      { input: ".a.", expected: true },
+      { input: "a.", expected: false },
+      { input: ".a", expected: false },
+      { input: ".a.", expected: false },
       { input: "http:/", expected: false },
       { input: "http://", expected: false },
       { input: "https:/", expected: false },
       { input: "https://", expected: false },
-      { input: "ftp://www.example.com", expected: false },
-      { input: "mailto://www.example.com", expected: false },
-      // special case, domain name can contain only top-level domain
-      // see https://stackoverflow.com/questions/69614892/can-a-domain-consist-of-only-tld-top-level-domain#:~:text=D%20in%20TLD%20means%20domain,so%20yes%20it%20is%20valid.
-      { input: "fdasfasda", expected: true },
-      { input: "1", expected: true },
-      { input: "example.com", expected: true },
-      { input: "example.org", expected: true },
-      { input: "www.example.com", expected: true },
-      { input: "http://www.example.com", expected: true },
+      { input: "ftp://www.example.com", expected: false }, //we enforce https on input links
+      { input: "mailto://www.example.com", expected: false }, //we enforce https on input links
+
+      /** though top level domains are valid, saving them on this format
+       * and later used on link tags `<a/>` could prove problematic:
+       * e.g. `<a href="google.com"/>`. would not magically go to desired `https://google.com`
+       * that is on the assumption that google.com is intended to be of `https`
+       */
+      { input: "fdasfasda", expected: false },
+      { input: "1", expected: false },
+      { input: "example.com", expected: false },
+      { input: "example.org", expected: false },
+      { input: "tiktok.com/@betterme.org", expected: false },
+      { input: "www.example.com", expected: false },
+
+      //sample valid urls
       { input: "https://www.example.com", expected: true },
-      { input: "tiktok.com/@betterme.org", expected: true },
-      { input: "www.tiktok.com/@betterme.org", expected: true },
       { input: "https://www.tiktok.com/@betterme.org", expected: true },
     ];
 

--- a/src/schemas/string.ts
+++ b/src/schemas/string.ts
@@ -27,9 +27,9 @@ export const url = Yup.string()
   .transform((str?: string) => (str || "").replace(/^(http|ftp):\/\//, "_")) //send an invalid value to parser
   .url(({ value }) => {
     //only check for https as http and ftp are filtered out
-    return /^https:\/\//.test(value)
-      ? "invalid url"
-      : "should start with https://";
+    if (!/^https:\/\//.test(value)) return "should start with https://";
+    if (value === "https://") return "incomplete url";
+    return "invalid url";
   });
 
 export function walletAddrPatten(chainId: ChainID) {

--- a/src/types/aws/ap/registration.ts
+++ b/src/types/aws/ap/registration.ts
@@ -14,7 +14,7 @@ export type BankVerificationStatus = "Not Submitted" | "Under Review";
 export type ReferralMethods =
   | ""
   | "referral"
-  | "angel-alliance"
+  | "better-giving-alliance"
   | "discord"
   | "facebook"
   | "linkedin"
@@ -75,7 +75,7 @@ export type ContactDetails = {
   Goals: string;
   Role: ContactRoles;
   OtherRole: string;
-  ReferralMethod: ReferralMethods;
+  ReferralMethod: ReferralMethods | "angel-alliance"; //legacy
   ReferralCode: string; //when ReferralMethod is "referral"
   OtherReferralMethod: string; //when ReferralMethod is "other"
 };


### PR DESCRIPTION
Ticket(s):
- also complishes part of `ap-9-5-1` (would be tagged to PR completing it)

## Explanation of the solution
* registration website url error (same for edit-profile)
<img width="706" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/90b9c42b-c68e-4f45-94b4-f39a3dd3eb00">
<img width="722" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/3b237ce2-d8cf-4e03-9fca-2751f7ba34e7">
<img width="902" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/b38170df-9104-4de4-bae1-6aafed3bd47b">
<img width="887" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/1b2e12a7-5715-45eb-9bcb-027602068be6">


*angel alliance to better giving alliance
<img width="774" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/6f177fbe-6b11-4738-9f78-6a766d692333">

* not profit status capitalize
<img width="440" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/8f246355-56bc-42f2-84fd-ba0942413eeb">



## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes