### PR TITLE
Fix: wise recipient id should be number

### DIFF
--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -72,7 +72,7 @@ export type EndowmentProfile = EndowmentBase & {
   };
   street_address?: string;
   url?: string;
-  wise_recipient_id: string;
+  wise_recipient_id: number;
 } & EndowmentBalances;
 
 export type EndowmentCard = EndowmentBase & {


### PR DESCRIPTION
## Explanation of the solution

## Instructions on making this work

* in registration, id is parsed as number (would be reflected on devops types on banking pr) , this is later on used to create `endowment_v2` entry

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
