### PR TITLE
FIX: reg summary/dashboard not disabled after submission

### DIFF
--- a/src/pages/Registration/Steps/getRegistrationState.ts
+++ b/src/pages/Registration/Steps/getRegistrationState.ts
@@ -36,6 +36,7 @@ export function getRegistrationState(reg: SavedRegistration): {
           documentation: docs(r),
           banking: bankDetails(r),
           status: r.RegistrationStatus,
+          endowId: r.EndowmentId,
         },
       },
       nextStep: steps.summary,

--- a/src/types/aws/ap/registration.ts
+++ b/src/types/aws/ap/registration.ts
@@ -235,7 +235,12 @@ export function isDoneFSAInquiry(
 }
 
 export function isDoneDocs(data: SavedRegistration): data is DoneDocs {
-  return !!(data.Registration as TDocumentation).Documentation;
+  const reg = data.Registration as Partial<TDocumentation>;
+
+  if (reg.Documentation?.DocType === "FSA") {
+    return !!reg.Documentation.SignedFiscalSponsorshipAgreement;
+  }
+  return !!reg.Documentation;
 }
 
 export function isDoneBanking(data: SavedRegistration): data is DoneBanking {

--- a/src/types/aws/ap/registration.ts
+++ b/src/types/aws/ap/registration.ts
@@ -137,7 +137,7 @@ export type DoneFSAInquiry = Append<DoneOrgDetails, FSAInquiry, {}>;
 export type DoneDocs = Append<DoneFSAInquiry, TDocumentation, {}>;
 export type DoneBanking = Append<DoneDocs, BankingDetails, {}>;
 
-export type SubmissionDetails = { Email: string; EndowmentId: number };
+export type SubmissionDetails = { Email: string; EndowmentId?: number };
 
 export type InReview = Append<DoneBanking, SubmissionDetails, {}>;
 
@@ -243,5 +243,5 @@ export function isDoneBanking(data: SavedRegistration): data is DoneBanking {
 }
 
 export function isSubmitted(data: SavedRegistration): data is InReview {
-  return !!(data.Registration as SubmissionDetails).EndowmentId;
+  return !!(data.Registration as SubmissionDetails).Email;
 }


### PR DESCRIPTION
## Explanation of the solution
* changes in https://github.com/AngelProtocolFinance/devops/pull/394, not reflected in web-app
* since `EndowmentId` is not returned on `registration-submit` use `Email` instead as indicator that application is approved
https://github.com/AngelProtocolFinance/devops/blob/main/src/AP/lambdas/registration-submit/index.js#L37

* fix 2: check if user signed `FSA` (if applicable) before doc considered complete

TODO:
@jp-mariano, noticed that `EndowmentId` is no longer reflected on  registration record upon approval. Web-app still needs this attribute to redirect users to `profile/{endowId}` on successful registration prompt

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
