### PR TITLE
Fix: edge case - handle unfinished FSA

### DIFF
--- a/src/pages/Registration/Steps/getRegistrationState.ts
+++ b/src/pages/Registration/Steps/getRegistrationState.ts
@@ -63,9 +63,13 @@ export function getRegistrationState(reg: SavedRegistration): {
 
   if (isDoneDocs(reg)) {
     const { ContactPerson: c, Registration: r } = reg;
+    const isSignedFSA =
+      r.Documentation.DocType === "FSA"
+        ? !!r.Documentation.SignedFiscalSponsorshipAgreement
+        : true;
     return {
       state: {
-        step: 4,
+        step: (isSignedFSA ? 4 : 3) as 4,
         data: {
           init: initReg(c),
           contact: { ...c, orgName: r.OrganizationName },

--- a/src/pages/Registration/Steps/getRegistrationState.ts
+++ b/src/pages/Registration/Steps/getRegistrationState.ts
@@ -67,14 +67,17 @@ export function getRegistrationState(reg: SavedRegistration): {
       r.Documentation.DocType === "FSA"
         ? !!r.Documentation.SignedFiscalSponsorshipAgreement
         : true;
+
     return {
       state: {
+        //cast to 4 (type only) to conform to type `RegStep4` which accepts documentation
         step: (isSignedFSA ? 4 : 3) as 4,
         data: {
           init: initReg(c),
           contact: { ...c, orgName: r.OrganizationName },
           orgDetails: orgDetails(r),
           fsaInquiry: fsaInquiry(r),
+          //even step is has value of `3` user could still go to step 4 with documentation pre-filled from previous uploads
           documentation: docs(r),
         },
       },

--- a/src/types/aws/ap/registration.ts
+++ b/src/types/aws/ap/registration.ts
@@ -235,12 +235,7 @@ export function isDoneFSAInquiry(
 }
 
 export function isDoneDocs(data: SavedRegistration): data is DoneDocs {
-  const reg = data.Registration as Partial<TDocumentation>;
-
-  if (reg.Documentation?.DocType === "FSA") {
-    return !!reg.Documentation.SignedFiscalSponsorshipAgreement;
-  }
-  return !!reg.Documentation;
+  return !!(data.Registration as TDocumentation).Documentation;
 }
 
 export function isDoneBanking(data: SavedRegistration): data is DoneBanking {


### PR DESCRIPTION

`isDoneDocs` passes if FSA information (ids, proof of registration) is saved - even if FSA agreement is not signed. 

after
* #2595

`isDoneDocs` enforces FSA agreement to be signed before state is registered to be `4`. This caused saved FSA information to not be shown. 

As a middle ground - always show saved FSA information but don't allow going to banking details if not signed.

Expected edge case flow :
1. user registers and needs FSA
2. user generates signing URL agreement, and redirected there to sign
3. for some reason, user didn't sign the FSA and went back to registration
4. upon resuming, user will be directed first to step `3`(FSA Inquiry) and is free to go to step `4` (FSA docs) - which is prefilled with previously inputed data. However user can't go to step `5` (banking) as registration state is still `3`

5. since user already generated FSA signing URL - he will always be directed to this previous URL until he signs it. FSA url can be re-created if it times out or user explicitly opt out of FSA (clears FSA docs) and opt-in again. 







## Explanation of the solution


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
