### PR TITLE
BG-1002: update network param `testnet | mainnet` to `staging | production`

### DIFF
--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -1,5 +1,4 @@
 import isMobile from "is-mobile";
-import { NetworkType } from "types/lists";
 
 export const IS_MOBILE = isMobile();
 
@@ -16,6 +15,3 @@ export const AWS_S3_PUBLIC_BUCKET = "https://endow-profiles.s3.amazonaws.com";
 const ENV = process.env.REACT_APP_ENVIRONMENT;
 
 export const IS_TEST = ENV === "STAGING";
-export const EXPECTED_NETWORK_TYPE: NetworkType = IS_TEST
-  ? "testnet"
-  : "mainnet";

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -1,5 +1,4 @@
-import { chainIds } from "constants/chainIds";
-import { EMAIL_SUPPORT, EXPECTED_NETWORK_TYPE } from "constants/env";
+import { EMAIL_SUPPORT } from "constants/env";
 
 export const AP_ERROR_DISCRIMINATOR = "AP_ERROR_DISCRIMINATOR";
 
@@ -48,24 +47,6 @@ export class WalletDisconnectedError extends APError {
 export class UnexpectedStateError extends APError {
   constructor(message = "App is in unexpected state") {
     super("UnexpectedStateError", message);
-  }
-}
-
-export class WrongNetworkError extends APError {
-  constructor() {
-    super(
-      "WrongNetworkError",
-      `Please connect to ${EXPECTED_NETWORK_TYPE} network and reload the page.`
-    );
-  }
-}
-
-export class UnsupportedChainError extends APError {
-  constructor(unsupportedChainId: string) {
-    super(
-      "UnsupportedChainError",
-      `The chain you are connected to (ID: ${unsupportedChainId}) is not supported. Valid networks are ${EXPECTED_NETWORK_TYPE} ones on: Juno (${chainIds.juno}), Polygon (${chainIds.polygon}), Terra (${chainIds.terra}), Binance (${chainIds.binance}) and Ethereum (${chainIds.ethereum}). Please switch to one of those and reload the page.`
-    );
   }
 }
 

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -3,7 +3,7 @@ import { Token } from "types/aws";
 import { ChainID } from "types/chain";
 import { appRoutes } from "constants/routes";
 import { APIs } from "constants/urls";
-import { network } from "../constants";
+import { apiEnv } from "../constants";
 import { version as v } from "../helpers";
 import { tags } from "./tags";
 
@@ -27,7 +27,7 @@ export const apes = createApi({
     stripeSessionURL: builder.mutation<{ url: string }, StripeSessionURLParams>(
       {
         query: ({ endowId, liquidSplitPct }) => ({
-          url: `${v(1)}/fiat/stripe-proxy/apes/${network}`,
+          url: `${v(1)}/fiat/stripe-proxy/apes/${apiEnv}`,
           method: "POST",
           body: JSON.stringify({
             endowmentId: endowId,

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -22,7 +22,7 @@ import {
   Program,
   WalletProfile,
 } from "types/aws";
-import { network } from "services/constants";
+import { apiEnv } from "services/constants";
 import { RootState } from "store/store";
 import { logger } from "helpers";
 import { TEMP_JWT } from "constants/auth";
@@ -30,7 +30,7 @@ import { APIs } from "constants/urls";
 import { version as v } from "../helpers";
 
 const getWalletProfileQuery = (walletAddr: string) =>
-  `/${v(2)}/profile/${network}/user/${walletAddr}`;
+  `/${v(2)}/profile/${apiEnv}/user/${walletAddr}`;
 
 const awsBaseQuery = retry(
   fetchBaseQuery({
@@ -73,7 +73,7 @@ export const aws = createApi({
       providesTags: ["endowments"],
       query: (params) => {
         return {
-          url: `/${v(5)}/endowments/${network}`,
+          url: `/${v(5)}/endowments/${apiEnv}`,
           params: { ...params, return: endowCardFields },
         };
       },
@@ -82,7 +82,7 @@ export const aws = createApi({
       providesTags: ["endowments"],
       query: (params) => {
         return {
-          url: `/${v(5)}/endowments/${network}`,
+          url: `/${v(5)}/endowments/${apiEnv}`,
           params: { ...params, return: endowSelectorOptionFields },
         };
       },
@@ -135,7 +135,7 @@ export const aws = createApi({
     program: builder.query<Program, { endowId: number; programId: string }>({
       providesTags: ["profile", "program"],
       query: ({ endowId, programId }) =>
-        `/${v(1)}/profile/${network}/program/${endowId}/${programId}`,
+        `/${v(1)}/profile/${apiEnv}/program/${endowId}/${programId}`,
     }),
     editProfile: builder.mutation<
       EndowmentProfile,

--- a/src/services/aws/leaderboard.ts
+++ b/src/services/aws/leaderboard.ts
@@ -1,5 +1,5 @@
 import { AWSQueryRes, LeaderboardEntry, Update } from "types/aws";
-import { EXPECTED_NETWORK_TYPE } from "constants/env";
+import { apiEnv } from "services/constants";
 import { aws } from "./aws";
 
 interface LeaderBoardQueryRes<T> extends AWSQueryRes<T> {
@@ -9,7 +9,7 @@ const leaderboard_api = aws.injectEndpoints({
   endpoints: (builder) => ({
     leaderboards: builder.query<Update, unknown>({
       //TODO:refactor this query pattern - how?
-      query: () => `v2/endowments/leaderboard/${EXPECTED_NETWORK_TYPE}`,
+      query: () => `v2/endowments/leaderboard/${apiEnv}`,
       //transform response before saving to cache for easy lookup by component
       transformResponse: (res: LeaderBoardQueryRes<LeaderboardEntry[]>) => {
         return { endowments: res.Items, last_update: res.LastUpdate };

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -1,4 +1,4 @@
-import { NetworkType } from "types/lists";
+import { APIEnvironment } from "types/lists";
 import { IS_TEST } from "constants/env";
 
-export const network: NetworkType = IS_TEST ? "testnet" : "mainnet";
+export const apiEnv: APIEnvironment = IS_TEST ? "staging" : "production";

--- a/src/slices/donation/sendDonation/index.ts
+++ b/src/slices/donation/sendDonation/index.ts
@@ -3,7 +3,7 @@ import { DonateArgs, TxStatus } from "../types";
 import { KYCData, TxLogPayload } from "types/aws";
 import { isTxResultError } from "types/tx";
 import { invalidateApesTags } from "services/apes";
-import { network } from "services/constants";
+import { apiEnv } from "services/constants";
 import { version as v } from "services/helpers";
 import { logger } from "helpers";
 import { sendTx } from "helpers/tx";
@@ -74,7 +74,7 @@ export const sendDonation = createAsyncThunk<void, DonateArgs>(
           ...payload,
           ...payload.kycData,
           //helps AWS determine which txs are testnet and mainnet without checking all chainIDs
-          network,
+          network: apiEnv,
         }),
       });
 

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -1,4 +1,4 @@
-import { EndowmentType, NetworkType, UNSDG_NUMS } from "../../lists";
+import { APIEnvironment, EndowmentType, UNSDG_NUMS } from "../../lists";
 
 export type EndowmentTierNum = 1 | 2 | 3;
 
@@ -166,7 +166,7 @@ export type EndowmentBookmark = {
 
 export type WalletProfile = {
   wallet: string;
-  network: NetworkType;
+  network: APIEnvironment;
   admin: EndowmentBookmark[];
   bookmarks: EndowmentBookmark[];
 };

--- a/src/types/lists.ts
+++ b/src/types/lists.ts
@@ -1,4 +1,4 @@
-export type NetworkType = "mainnet" | "testnet";
+export type APIEnvironment = "staging" | "production";
 export type UserTypes = "charity-owner" | "angelprotocol-web-app" | "app-user";
 export type Chains = "terra" | "juno" | "ethereum" | "binance" | "polygon";
 export type UNSDG_NUMS =


### PR DESCRIPTION
reflects: 
* https://github.com/AngelProtocolFinance/devops/pull/417

## Explanation of the solution
* replace `network` with `apiEnv`
- [x] test endpoints in use that is changed to use `apiEnv` to still work

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
