### PR TITLE
BG-1011: download url in success page

### DIFF
--- a/src/pages/Registration/SigningResult/SigningResult.tsx
+++ b/src/pages/Registration/SigningResult/SigningResult.tsx
@@ -15,7 +15,7 @@ export default function SignResult({ classes = "" }) {
         " grid padded-container max-w-lg justify-items-center content-start"
       }
     >
-      {isSuccess(params) ? <Success /> : <ErrorPage {...params} />}
+      {isSuccess(params) ? <Success {...params} /> : <ErrorPage {...params} />}
     </div>
   );
 }

--- a/src/pages/Registration/SigningResult/Success.tsx
+++ b/src/pages/Registration/SigningResult/Success.tsx
@@ -1,12 +1,22 @@
 import { useNavigate } from "react-router-dom";
+import { SignerCompleteQueryParams } from "./types";
 import { useLazyRegQuery } from "services/aws/registration";
 import Icon from "components/Icon";
 import { getSavedRegistrationReference } from "helpers";
+import { IS_TEST } from "constants/env";
 import { appRoutes } from "constants/routes";
 import { getRegistrationState } from "../Steps/getRegistrationState";
 import routes from "../routes";
 
-export default function Success() {
+const proxyFunctionURL =
+  "https://h247dsayjkdwlheiboq54r2gxu0htegs.lambda-url.us-east-1.on.aws";
+const downloadZipURL = (eid: string) =>
+  //lambda function URL - function URLs can have streaming response
+  proxyFunctionURL + (IS_TEST ? "/staging" : "") + `?eid=${eid}`;
+
+export default function Success({
+  documentGroupEid,
+}: SignerCompleteQueryParams) {
   const [checkPrevRegistration, { isLoading }] = useLazyRegQuery();
   const navigate = useNavigate();
 
@@ -32,6 +42,19 @@ export default function Success() {
         Fiscal Sponsorship Agreement signature was successfully saved!
       </h1>
 
+      <a
+        href={downloadZipURL(documentGroupEid)}
+        className="text-blue hover:text-blue-d1 active:text-blue-d2 mb-4 inline-block"
+      >
+        <Icon
+          type="FileDownload"
+          size={18}
+          className="inline bottom-px relative mr-1"
+        />
+        <span className="uppercase text-sm font-semibold font-work">
+          download
+        </span>
+      </a>
       <button
         disabled={isLoading}
         className="w-full max-w-[26.25rem] btn-orange btn-reg mt-4"

--- a/src/pages/Registration/SigningResult/Success.tsx
+++ b/src/pages/Registration/SigningResult/Success.tsx
@@ -11,7 +11,6 @@ import routes from "../routes";
 const proxyFunctionURL =
   "https://h247dsayjkdwlheiboq54r2gxu0htegs.lambda-url.us-east-1.on.aws";
 const downloadZipURL = (eid: string) =>
-  //lambda function URL - function URLs can have streaming response
   proxyFunctionURL + (IS_TEST ? "/staging" : "") + `?eid=${eid}`;
 
 export default function Success({

--- a/src/pages/Registration/SigningResult/types.ts
+++ b/src/pages/Registration/SigningResult/types.ts
@@ -7,7 +7,7 @@ type BaseQueryParams = {
   etchPacketEid: string;
 };
 
-type SignerCompleteQueryParams = BaseQueryParams & {
+export type SignerCompleteQueryParams = BaseQueryParams & {
   action: "signerComplete";
   signerStatus: "completed";
 };


### PR DESCRIPTION
## Explanation of the solution
add doc proxy url link
<img width="759" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/a6c784d1-ed60-4fb6-b610-239986d69d53">



## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
