### PR TITLE
FIX: handle fiat chain id

### DIFF
--- a/src/pages/Admin/Charity/Donations/Table.tsx
+++ b/src/pages/Admin/Charity/Donations/Table.tsx
@@ -97,21 +97,19 @@ export default function Table({
                 <>{humanize(amount, 3)}</>
                 <>{humanize(amount * (+splitLiq / 100), 3)}</>
                 <>{humanize(amount * ((100 - +splitLiq) / 100), 3)}</>
-                <>
-                  {chainId === "staging" ? (
-                    <span className="text-gray-d1 dark:text-gray text-sm">
-                      &lt; TX Link &gt;
-                    </span>
-                  ) : (
-                    <ExtLink
-                      //default to ethereum for staging
-                      href={getTxUrl(chainId, hash)}
-                      className="text-center text-blue hover:text-blue-l2 cursor-pointer uppercase text-sm"
-                    >
-                      {maskAddress(hash)}
-                    </ExtLink>
-                  )}
-                </>
+
+                {chainId === "staging" || chainId === "fiat" ? (
+                  <>- - -</>
+                ) : (
+                  <ExtLink
+                    //default to ethereum for staging
+                    href={getTxUrl(chainId, hash)}
+                    className="text-center text-blue hover:text-blue-l2 cursor-pointer uppercase text-sm"
+                  >
+                    {maskAddress(hash)}
+                  </ExtLink>
+                )}
+
                 <td className="relative">
                   {!kycData ? (
                     <Icon

--- a/src/pages/Donations/Table.tsx
+++ b/src/pages/Donations/Table.tsx
@@ -116,16 +116,16 @@ export default function Table({
               <span className="font-body text-sm">{row.symbol}</span>
               <>{humanize(row.amount, 3)}</>
               <>{`$${humanize(row.usdValue, 2)}`}</>
-              <ExtLink
-                href={getTxUrl(
-                  //default to ethereum for staging
-                  row.chainId === "staging" ? "1" : row.chainId,
-                  row.hash
-                )}
-                className="text-center text-blue hover:text-blue-l2 cursor-pointer uppercase text-sm"
-              >
-                {row.hash}
-              </ExtLink>
+              {row.chainId === "fiat" || row.chainId === "staging" ? (
+                <>- - -</>
+              ) : (
+                <ExtLink
+                  href={getTxUrl(row.chainId, row.hash)}
+                  className="text-center text-blue hover:text-blue-l2 cursor-pointer uppercase text-sm"
+                >
+                  {row.hash}
+                </ExtLink>
+              )}
               <div className="text-center text-white">
                 <span
                   className={`${

--- a/src/types/aws/apes/donation.ts
+++ b/src/types/aws/apes/donation.ts
@@ -14,7 +14,7 @@ export type KYCData = {
 
 type DonationRecordBase = {
   amount: number;
-  chainId: ChainID | "staging";
+  chainId: ChainID | "staging" | "fiat";
   date: string;
   hash: string;
   symbol: string;


### PR DESCRIPTION
## Explanation of the solution
* add `fiat` to types
* update consumers, change placeholder from `< Tx Link >` to:
<img width="598" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/b402eaff-c561-46af-b565-a1f35f167c31">


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
