### PR TITLE
Fix state.from in UserMenu > Link.state

### DIFF
--- a/src/App/Header/UserMenu/UserMenu.tsx
+++ b/src/App/Header/UserMenu/UserMenu.tsx
@@ -1,6 +1,7 @@
 import { Popover } from "@headlessui/react";
 import { useLocation } from "react-router-dom";
 import { Link } from "react-router-dom";
+import { SignInRouteState } from "types/routeStates";
 import Icon from "components/Icon";
 import { useGetter, useSetter } from "store/accessors";
 import { logout } from "slices/auth";
@@ -14,10 +15,11 @@ export default function UserMenu() {
   const location = useLocation();
 
   if (!user || user === "loading") {
+    const state: SignInRouteState = { from: location.pathname };
     return (
       <Link
         to={appRoutes.signin}
-        state={{ from: location }}
+        state={state}
         className="btn-orange px-3 h-10 rounded-lg text-sm"
         aria-disabled={user === "loading"}
       >


### PR DESCRIPTION
## Explanation of the solution
An error `to.pathname.includes is not a function` would occur when a user tried to create a new account using the "Login" button. This was due to a wrong `from` parameter being passed to the `Signin` route state.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- click "Login"
- create a new account
- **verify no error appears**