### PR TITLE
FIX: amplify button no color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+@import "tailwindcss/base";
+@import "./styles/base";
+
 @import "../node_modules/quill/dist/quill.snow.css";
 @import "./styles/richtext.css";
 
@@ -5,9 +8,6 @@
 
 @import "../node_modules/@aws-amplify/ui-react/dist/styles.css";
 @import "./styles/amplify.css";
-
-@import "tailwindcss/base";
-@import "./styles/base";
 
 @import "tailwindcss/components";
 @import "./styles/components";


### PR DESCRIPTION

<img width="587" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/2ea70653-28c0-41cd-a437-29a4ca5808d8">

## Explanation of the solution
* move base styles on top so can be overriden by those below


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
