### PR TITLE
BG-1078 remove leaderboard footer link

### DIFF
--- a/lint-staged.js
+++ b/lint-staged.js
@@ -4,5 +4,5 @@ module.exports = {
     "react-app-rewired test --bail --watchAll=false --findRelatedTests --passWithNoTests",
     () => "tsc-files --noEmit",
   ],
-  "*.{js,jsx,ts,tsx,json,css,js}": ["prettier --write"],
+  "*.{js,jsx,ts,tsx}": ["prettier --write"],
 };

--- a/src/App/constants.ts
+++ b/src/App/constants.ts
@@ -1,5 +1,5 @@
 import { Link, LinkGroup, SocialMediaLink } from "./types";
-import { BASE_URL, DAPP_URL } from "constants/env";
+import { BASE_URL } from "constants/env";
 import { appRoutes } from "constants/routes";
 import {
   PRIVACY_POLICY,
@@ -45,7 +45,6 @@ export const CHARITY_LINKS: LINKS = {
           text: "Giving Partners (CSR)",
           href: `${BASE_URL}/giving-partners-csr/`,
         },
-        // { text: "Impact Board", href: `${DAPP_URL}/leaderboard/` },
       ],
     },
     {

--- a/src/App/constants.ts
+++ b/src/App/constants.ts
@@ -45,7 +45,7 @@ export const CHARITY_LINKS: LINKS = {
           text: "Giving Partners (CSR)",
           href: `${BASE_URL}/giving-partners-csr/`,
         },
-        { text: "Impact Board", href: `${DAPP_URL}/leaderboard/` },
+        // { text: "Impact Board", href: `${DAPP_URL}/leaderboard/` },
       ],
     },
     {


### PR DESCRIPTION
## Explanation of the solution
- Need to remove leaderboard page from footer link until it's ready for prime time
- fix for husky lint-staged

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- confirm "impact board" no longer appears in the footer

## UI changes for review
N/A