### PR TITLE
FIX: client side vaildation not running

### DIFF
--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/Form.tsx
@@ -1,0 +1,15 @@
+import { FormHTMLAttributes } from "react";
+
+export default function Form({
+  isSubmitting,
+  children,
+  ...props
+}: FormHTMLAttributes<HTMLFormElement> & { isSubmitting: boolean }) {
+  return (
+    <form {...props}>
+      <fieldset className="contents" disabled={isSubmitting}>
+        {children}
+      </fieldset>
+    </form>
+  );
+}

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -12,6 +12,7 @@ import { useErrorContext } from "contexts/ErrorContext";
 import { Label } from "components/form";
 import { isEmpty } from "helpers";
 import { GENERIC_ERROR_MESSAGE } from "constants/common";
+import Form from "./Form";
 
 type Props = {
   fields: Group[];
@@ -41,7 +42,7 @@ export default function RecipientDetailsForm({
     setError,
     setFocus,
     formState: { errors, isSubmitting },
-  } = useForm({ disabled });
+  } = useForm({ disabled, shouldUnregister: true });
 
   const { handleError } = useErrorContext();
   const [updateRequirements] = useNewRequirementsMutation();
@@ -65,7 +66,8 @@ export default function RecipientDetailsForm({
   }
 
   return (
-    <form
+    <Form
+      isSubmitting={isSubmitting}
       onSubmit={handleSubmit(async (fv) => {
         try {
           const { accountHolderName, bankStatement, ...details } = fv;
@@ -129,8 +131,6 @@ export default function RecipientDetailsForm({
                 {...register(f.key, {
                   required: f.required ? "required" : false,
                   onChange: f.refreshRequirementsOnChange ? refresh : undefined,
-                  shouldUnregister: true,
-                  disabled: isSubmitting,
                 })}
                 aria-required={f.required}
                 id={f.key}
@@ -174,8 +174,6 @@ export default function RecipientDetailsForm({
                         onChange: f.refreshRequirementsOnChange
                           ? refresh
                           : undefined,
-                        shouldUnregister: true,
-                        disabled: isSubmitting,
                       })}
                     />
                     <label
@@ -237,8 +235,6 @@ export default function RecipientDetailsForm({
                     : undefined,
                   //onBlur only as text input changes rapidly
                   onBlur: f.refreshRequirementsOnChange ? refresh : undefined,
-                  shouldUnregister: true,
-                  disabled: isSubmitting,
                 })}
               />
               <ErrorMessage
@@ -270,8 +266,6 @@ export default function RecipientDetailsForm({
                       }
                     : undefined,
                   onBlur: f.refreshRequirementsOnChange ? refresh : undefined,
-                  shouldUnregister: true,
-                  disabled: isSubmitting,
                 })}
               />
               <ErrorMessage
@@ -300,8 +294,6 @@ export default function RecipientDetailsForm({
           type="file"
           className="disabled:bg-gray-l5 text-sm rounded w-full border border-prim file:border-none file:border-r file:border-prim file:py-3 file:px-4 file:bg-blue-l4 file:text-gray-d2 text-gray-d1"
           {...register("bankStatement", {
-            disabled: isSubmitting,
-            shouldUnregister: true,
             validate(value?: FileList) {
               //multile:false
               const file = value?.item(0);
@@ -332,6 +324,6 @@ export default function RecipientDetailsForm({
       </div>
 
       <FormButtons disabled={disabled} isSubmitting={isSubmitting} />
-    </form>
+    </Form>
   );
 }


### PR DESCRIPTION
turned out setting `register.options.disabled` also turns off validation

## Explanation of the solution
* instead of disabled each field, set disable in `<fieldset/>`, alternative would be `readOnly` 

### Others
* create form with fieldset to avoid nesting which affects diff view
* move individual `shouldUnregister` to central `useForm`

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
