### PR TITLE
BG-1077 Decimals adjust

### DIFF
--- a/src/components/donation/Steps/Result/Success/index.tsx
+++ b/src/components/donation/Steps/Result/Success/index.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import ExtLink from "components/ExtLink";
 import Icon from "components/Icon";
 import { TxStep } from "slices/donation";
-import { getTxUrl, humanize } from "helpers";
+import { condenseToNum, getTxUrl, humanize } from "helpers";
 import { appRoutes } from "constants/routes";
 import Share, { SocialMedia } from "./Share";
 
@@ -22,7 +22,10 @@ export default function Success({
       <h3 className="text-2xl sm:text-3xl mb-4 sm:mb-12 text-center leading-relaxed">
         Thank you for your donation of{" "}
         <span className="font-extrabold">
-          {token.symbol} {humanize(token.amount)}
+          {token.symbol}{" "}
+          {token.amount < 0.01
+            ? condenseToNum(token.amount)
+            : humanize(token.amount)}
         </span>{" "}
         to <span className="font-extrabold">{name}</span>!
       </h3>

--- a/src/components/donation/Steps/Result/Success/index.tsx
+++ b/src/components/donation/Steps/Result/Success/index.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import ExtLink from "components/ExtLink";
 import Icon from "components/Icon";
 import { TxStep } from "slices/donation";
-import { condenseToNum, getTxUrl, humanize } from "helpers";
+import { getTxUrl, humanize } from "helpers";
 import { appRoutes } from "constants/routes";
 import Share, { SocialMedia } from "./Share";
 
@@ -23,9 +23,7 @@ export default function Success({
         Thank you for your donation of{" "}
         <span className="font-extrabold">
           {token.symbol}{" "}
-          {parseFloat(token.amount) < 0.01
-            ? condenseToNum(token.amount)
-            : humanize(token.amount)}
+          {humanize(token.amount, parseFloat(token.amount) < 0.01 ? 4 : 2)}
         </span>{" "}
         to <span className="font-extrabold">{name}</span>!
       </h3>

--- a/src/components/donation/Steps/Result/Success/index.tsx
+++ b/src/components/donation/Steps/Result/Success/index.tsx
@@ -23,7 +23,7 @@ export default function Success({
         Thank you for your donation of{" "}
         <span className="font-extrabold">
           {token.symbol}{" "}
-          {token.amount < 0.01
+          {parseFloat(token.amount) < 0.01
             ? condenseToNum(token.amount)
             : humanize(token.amount)}
         </span>{" "}


### PR DESCRIPTION
## Explanation of the solution
Minor bug: Smaller donation amounts used "humanized" conversion to two decimals. This works for all fiat and most crpyto donations. Higher valued crypto such as ETH and BTC, however would support donations of amounts less than 0.01 and would thus show `0.00` on the success donation screen. 
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/c56c7232-18d2-42f6-a850-8974fb84f716)

Solution: Adds simple check if amount is less than 0.01 and uses 4 decimal precision with standard 2 places as a fallback. 

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
