### PR TITLE
BG-1087 Profile title break

### DIFF
--- a/src/pages/Profile/Body/Body.tsx
+++ b/src/pages/Profile/Body/Body.tsx
@@ -27,7 +27,7 @@ export default function Body() {
         <div className="order-2 lg:order-3 lg:col-span-2 flex flex-col gap-8 w-full items-center font-body">
           <div className="flex flex-col items-center lg:items-start w-full gap-2 text-center lg:text-left">
             <div className="flex max-sm:flex-col items-center gap-3">
-              <h3 className="font-header text-3xl w-full max-w-2xl break-all sm:break-words">
+              <h3 className="font-header text-3xl w-full max-w-2xl break-words">
                 {p.name}
               </h3>
               <BookmarkBtn endowId={p.id} />


### PR DESCRIPTION
## Explanation of the solution
Fix profile page titles breaking mid-word on desktop view.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/a78cd924-1fd1-4061-a1b0-28e0b81130c3)
