### PR TITLE
Remove unused Marketplace `hits` query parameter

### DIFF
--- a/src/pages/Marketplace/Cards/useCards.ts
+++ b/src/pages/Marketplace/Cards/useCards.ts
@@ -28,7 +28,6 @@ export default function useCards() {
       query: searchText,
       sort: sort ? `${sort.key}+${sort.direction}` : undefined,
       page: 1, // always starts at page 1
-      hits: 15,
       published: "true",
       sdgs: sdgs.join(","),
       ..._params,

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -103,7 +103,6 @@ export type EndowmentsQueryParams = {
   sdgs?: string; // comma separated sdg values.
   kyc_only?: string; // comma separated boolean values
   countries?: string; //comma separated country names
-  hits?: number; // Number of items to be returned per request. If not provided, API defaults to return all
   published: "true";
 };
 


### PR DESCRIPTION
## Explanation of the solution
Remove unused Marketplace `hits` query parameter

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Marketplace queries should still work as usual

## UI changes for review
None