### PR TITLE
BG-987 Reg step progress indicators

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "preview": "rsbuild preview"
   },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -35,7 +35,7 @@ export default function ProgressIndicator({ step, classes = "" }: Props) {
       shouldCallOnResizeOnLoad: true,
       debounceTime: 150,
       ref: { isOpen: isOtherStepsShown, isDesktop },
-    }
+    },
   );
 
   /**
@@ -62,7 +62,7 @@ export default function ProgressIndicator({ step, classes = "" }: Props) {
 
   const topStep =
     isOtherStepsShown || currPath === 1 ? (
-      <Step isDone={step >= 1} isCurr={currPath === 1}>
+      <Step isDone={currPath > 1 || step > 1} isCurr={currPath === 1}>
         Contact Details
       </Step>
     ) : (
@@ -116,7 +116,7 @@ function Step({
       {/** line */}
       <div
         className={`h-[22px] border-l ${
-          isDone ? "border-orange" : "border-prim"
+          isDone || isCurr ? "border-orange" : "border-prim"
         } my-2 group-first:hidden`}
       />
       <div className="flex items-center">

--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -35,7 +35,7 @@ export default function ProgressIndicator({ step, classes = "" }: Props) {
       shouldCallOnResizeOnLoad: true,
       debounceTime: 150,
       ref: { isOpen: isOtherStepsShown, isDesktop },
-    },
+    }
   );
 
   /**


### PR DESCRIPTION
## Explanation of the solution
Registration progress indicator for Steps was mis-highlighting for the initial viewing of "Contact Details" step. 

## Instructions on making this work
1. Visit Registration page. 
2. Create NEW registration
3. Contact Details circle should be gray - Text should be orange
4. After completing the step, circle turns orange. Next Step's text turns orange. 

## UI changes for review
### Contact details now correctly show as grey circle when first seeing it
![image (1)](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/670cdc82-ab2d-4a65-a589-d0392336cabb)

### User comes back to a previously visited step after completing subsequent steps that circle shows orange still w/ orange text
![image (2)](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/11314751-900e-4640-8126-4aef41dca86e)

### Having lines highlighted to the next step (current, not done) in orange
Thought this helps lead user eyes down the progress steps better.
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/f0c7ab15-35d0-4707-8865-24f1d89d76c3)
