### PR TITLE
Closes BG-1108,BG-1109: email not prefilled in paypal

### DIFF
--- a/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
+++ b/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
@@ -19,7 +19,7 @@ const tabIdx = (method?: DonationDetails["method"]) => {
     case "crypto":
       return 4;
     case "paypal":
-      return 2;
+      return 1;
     case "stripe":
       return 0;
     //other methods doesn't have donate methods yet

--- a/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
+++ b/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
@@ -17,11 +17,12 @@ type Props = {
 const tabIdx = (method?: DonationDetails["method"]) => {
   switch (method) {
     case "crypto":
-      return 1;
-    case "paypal":
       return 4;
+    case "paypal":
+      return 2;
     case "stripe":
       return 0;
+    //other methods doesn't have donate methods yet
     default:
       return 0;
   }

--- a/src/slices/donation/donation.ts
+++ b/src/slices/donation/donation.ts
@@ -30,7 +30,7 @@ const donation = createSlice({
           details: payload,
           kyc: kyc
             ? kyc
-            : payload.method === "stripe" && payload.email
+            : (payload.method === "stripe" || payload.method === "paypal") && payload.email
               ? { kycEmail: payload.email }
               : undefined,
         };

--- a/src/slices/donation/donation.ts
+++ b/src/slices/donation/donation.ts
@@ -30,7 +30,8 @@ const donation = createSlice({
           details: payload,
           kyc: kyc
             ? kyc
-            : (payload.method === "stripe" || payload.method === "paypal") && payload.email
+            : (payload.method === "stripe" || payload.method === "paypal") &&
+                payload.email
               ? { kycEmail: payload.email }
               : undefined,
         };


### PR DESCRIPTION
## Explanation of the solution
* include paypal when setting email
* update tab persistence order

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
