### PR TITLE
Update Split.tsx to handle 'stocks' separately when reading amount+symbol

### DIFF
--- a/src/components/donation/Steps/Splits/Splits.tsx
+++ b/src/components/donation/Steps/Splits/Splits.tsx
@@ -24,6 +24,10 @@ export default function Split({
         const { amount, symbol } = details.token;
         return [amount, symbol];
       }
+      case "stocks": {
+        const { numShares, symbol } = details;
+        return [numShares, symbol];
+      }
       default:
         const { amount, currency } = details;
         return [amount, currency.code.toUpperCase()];


### PR DESCRIPTION
Fixing build errors in *Split.tsx*:
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/19427053/c64963a5-9330-4e49-a020-0807902da0d2)
