### PR TITLE
Towards BG-1121: After signing in and being redirected to Marketplace, the URL should be /marketplace and not /auth-redirect

### DIFF
--- a/src/pages/OAuthRedirector.tsx
+++ b/src/pages/OAuthRedirector.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from "react-router-dom";
 // To account for this slowness, we set a timeout and navigate to the desired page afterwards.
 const DELAY = 700;
 
-export default function OAUTHRedirector() {
+export default function OAuthRedirector() {
   const navigate = useNavigate();
 
   useEffect(() => {

--- a/src/pages/OAuthRedirector.tsx
+++ b/src/pages/OAuthRedirector.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "react-router-dom";
 // redirect causes the final URL to be of this page even though the rendered page is
 // completely different (Marketplace, Register etc.).
 // To account for this slowness, we set a timeout and navigate to the desired page afterwards.
-const DELAY = 300;
+const DELAY = 700;
 
 export default function OAUTHRedirector() {
   const navigate = useNavigate();


### PR DESCRIPTION
## Explanation of the solution
Delay time of 600ms was enough to avoid this issue.
Set the delay to 700ms just in case.
This delay before redirecting is barely noticeable in the overall sign-in + redirect flow.
