### PR TITLE
Closes BG-1110: Fix breadcrumbs active link 

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -6,6 +6,7 @@ type Props = {
   items: {
     title: string;
     to: string;
+    end?: boolean;
   }[];
 };
 
@@ -16,6 +17,7 @@ export default function Breadcrumbs({ items, className = "" }: Props) {
         <Fragment key={i}>
           <NavLink
             to={item.to}
+            end={item.end}
             className={({ isActive }) =>
               `max-w-xs truncate ${
                 isActive

--- a/src/pages/Profile/Body/Body.tsx
+++ b/src/pages/Profile/Body/Body.tsx
@@ -18,7 +18,11 @@ export default function Body() {
         <Breadcrumbs
           className="font-body font-normal text-xs sm:text-sm lg:ml-52"
           items={[
-            { title: "Marketplace", to: `${appRoutes.marketplace}/` },
+            {
+              title: "Marketplace",
+              to: `${appRoutes.marketplace}/`,
+              end: true,
+            },
             { title: p.name, to: `${appRoutes.marketplace}/${p.id}` },
           ]}
         />


### PR DESCRIPTION
## Explanation of the solution
add `end` prop to `NavLink`
<img width="428" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/9e3c7072-8193-4b60-b29d-885824814360">


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
