### PR TITLE
Closes BG-1132: Fix donation validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,18 +8,13 @@
     "build": "tsc && rsbuild build",
     "start": "rsbuild dev",
     "test": "vitest",
-    "format": "biome format --write src",
-    "lint": "biome lint ./src",
-    "check": "biome check --apply src",
-    "check-unsafe": "biome check --apply-unsafe src",
+    "lint": "biome check ./src",
+    "format": "biome check --apply src",
+    "format-unsafe": "biome check --apply-unsafe src",
     "preview": "rsbuild preview"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.2%", "not dead", "not op_mini all"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/src/components/donation/Steps/DonateMethods/ChariotConnect/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/ChariotConnect/Form.tsx
@@ -3,10 +3,10 @@ import CurrencySelector from "components/CurrencySelector";
 import { CheckField, Field } from "components/form";
 import { FormProvider, useForm } from "react-hook-form";
 import { schema, stringNumber } from "schemas/shape";
+import { requiredString } from "schemas/string";
 import { setDetails } from "slices/donation";
 import { useGetter, useSetter } from "store/accessors";
 import { userIsSignedIn } from "types/auth";
-import { string } from "yup";
 import { FormValues as FV, Props } from "./types";
 
 // Chariot accepts only USD.
@@ -37,7 +37,7 @@ export default function Form({ recipient, widgetConfig, details }: Props) {
           (s) => s.required("required"),
           (n) => n.positive("must be greater than 0")
         ),
-        email: string().required("required").email("invalid"),
+        email: requiredString.email("invalid email"),
       })
     ),
   });

--- a/src/components/donation/Steps/DonateMethods/Crypto/Crypto.tsx
+++ b/src/components/donation/Steps/DonateMethods/Crypto/Crypto.tsx
@@ -2,11 +2,12 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { mumbai, polygon } from "constants/chains";
 import { IS_TEST } from "constants/env";
 import { FormProvider, useForm } from "react-hook-form";
+import { schema, tokenShape } from "schemas/shape";
 import { CryptoFormStep } from "slices/donation";
 import { DonaterConfigFromWidget } from "types/widget";
+import { object } from "yup";
 import Form from "./Form";
 import { initToken } from "./constants";
-import { schema } from "./schema";
 import { DonateValues } from "./types";
 
 type Props = CryptoFormStep & {
@@ -25,7 +26,12 @@ export default function Crypto({ config, ...state }: Props) {
 
   const methods = useForm<DonateValues>({
     values: state.details || initial,
-    resolver: yupResolver(schema),
+    resolver: yupResolver(
+      schema<DonateValues>({
+        token: object(tokenShape()),
+        //no need to validate split, restricted by slider
+      })
+    ),
   });
   return (
     <FormProvider {...methods}>

--- a/src/components/donation/Steps/DonateMethods/Crypto/schema.ts
+++ b/src/components/donation/Steps/DonateMethods/Crypto/schema.ts
@@ -1,9 +1,0 @@
-import { tokenShape } from "schemas/shape";
-import { SchemaShape } from "schemas/types";
-import { ObjectSchema, object } from "yup";
-import { DonateValues as DV } from "./types";
-
-export const schema = object<any, SchemaShape<DV>>({
-  token: object(tokenShape()),
-  //no need to validate split, restricted by slider
-}) as ObjectSchema<DV>;

--- a/src/components/donation/Steps/DonateMethods/PayPal/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/PayPal/Form.tsx
@@ -1,13 +1,15 @@
+import { yupResolver } from "@hookform/resolvers/yup";
 import CurrencySelector from "components/CurrencySelector";
 import { CheckField, Field } from "components/form";
 import { FormProvider, useController, useForm } from "react-hook-form";
+import { schema, stringNumber } from "schemas/shape";
 import { requiredString } from "schemas/string";
 import { usePaypalCurrenciesQuery } from "services/apes";
 import { setDetails } from "slices/donation";
 import { useGetter, useSetter } from "store/accessors";
 import { userIsSignedIn } from "types/auth";
 import { Currency } from "types/components";
-import { FormValues, Props } from "./types";
+import { FormValues as FV, Props } from "./types";
 
 const USD_CODE = "usd";
 
@@ -18,7 +20,7 @@ export default function Form({ recipient, details, widgetConfig }: Props) {
 
   const currencies = usePaypalCurrenciesQuery(null);
 
-  const initial: FormValues = {
+  const initial: FV = {
     source: widgetConfig ? "bg-widget" : "bg-marketplace",
     amount: "",
     currency: { code: USD_CODE, min: 1 },
@@ -26,14 +28,31 @@ export default function Form({ recipient, details, widgetConfig }: Props) {
     userOptForKYC: false,
   };
 
-  const methods = useForm<FormValues>({
+  const currencyKey: keyof FV = "currency";
+  const methods = useForm<FV>({
     defaultValues: details || initial,
+    resolver: yupResolver(
+      schema<FV>({
+        email: requiredString.email("invalid email"),
+        amount: stringNumber(
+          (s) => s.required("required"),
+          (n) =>
+            n
+              .positive("must be greater than 0")
+              .when(currencyKey, (values, schema) => {
+                const [currency] = values as [Currency | undefined];
+                return currency?.min
+                  ? schema.min(currency.min, "less than min")
+                  : schema;
+              })
+        ),
+      })
+    ),
   });
   const { control, handleSubmit } = methods;
-
   const {
     field: { value: currency, onChange: onCurrencyChange },
-  } = useController({
+  } = useController<FV, "currency">({
     control: control,
     name: "currency",
   });
@@ -59,44 +78,24 @@ export default function Form({ recipient, details, widgetConfig }: Props) {
           value={currency}
           required
         />
-        <Field<FormValues>
+        <Field<FV>
           name="amount"
           label="Donation amount"
           classes={{ label: "font-semibold" }}
           required
-          // validation must be dynamicly set depending on which exact currency is selected
-          registerOptions={{
-            required: "required",
-            min: currency.min
-              ? {
-                  value: currency.min,
-                  message: `must be greater than ${currency.min}`,
-                }
-              : undefined,
-            pattern: {
-              value: /^[1-9]\d*$/,
-              message: "invalid",
-            },
-            shouldUnregister: true,
-          }}
           tooltip={createTooltip(currency)}
         />
         {!authUserEmail && (
-          <Field<FormValues>
+          <Field<FV>
             name="email"
             label="Email"
             classes={{ label: "font-semibold" }}
             required
-            registerOptions={{
-              required: "required",
-              validate: (value) =>
-                requiredString.email().isValidSync(value) || "invalid email",
-            }}
           />
         )}
         {!recipient.isKYCRequired && (
           // if KYC is required, the checkbox is redundant
-          <CheckField<FormValues>
+          <CheckField<FV>
             name="userOptForKYC"
             classes={{
               container: "text-sm",

--- a/src/components/donation/Steps/DonateMethods/PayPal/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/PayPal/Form.tsx
@@ -74,8 +74,8 @@ export default function Form({ recipient, details, widgetConfig }: Props) {
                 }
               : undefined,
             pattern: {
-              value: /[0-9]+/,
-              message: "must be a number",
+              value: /^[1-9]\d*$/,
+              message: "invalid",
             },
             shouldUnregister: true,
           }}

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -1,13 +1,15 @@
+import { yupResolver } from "@hookform/resolvers/yup";
 import CurrencySelector from "components/CurrencySelector";
 import { CheckField, Field } from "components/form";
 import { FormProvider, useController, useForm } from "react-hook-form";
+import { schema, stringNumber } from "schemas/shape";
 import { requiredString } from "schemas/string";
 import { useStripeCurrenciesQuery } from "services/apes";
 import { setDetails } from "slices/donation";
 import { useGetter, useSetter } from "store/accessors";
 import { userIsSignedIn } from "types/auth";
 import { Currency } from "types/components";
-import { FormValues, Props } from "./types";
+import { FormValues as FV, Props } from "./types";
 
 const USD_CODE = "usd";
 
@@ -18,7 +20,7 @@ export default function Form({ recipient, widgetConfig, details }: Props) {
 
   const currencies = useStripeCurrenciesQuery(null);
 
-  const initial: FormValues = {
+  const initial: FV = {
     source: widgetConfig ? "bg-widget" : "bg-marketplace",
     amount: "",
     currency: { code: USD_CODE, min: 1 },
@@ -26,14 +28,32 @@ export default function Form({ recipient, widgetConfig, details }: Props) {
     userOptForKYC: false,
   };
 
-  const methods = useForm<FormValues>({
+  const currencyKey: keyof FV = "currency";
+  const methods = useForm<FV>({
     defaultValues: details || initial,
+    resolver: yupResolver(
+      schema<FV>({
+        email: requiredString.email("invalid email"),
+        amount: stringNumber(
+          (s) => s.required("required"),
+          (n) =>
+            n
+              .positive("must be greater than 0")
+              .when(currencyKey, (values, schema) => {
+                const [currency] = values as [Currency | undefined];
+                return currency?.min
+                  ? schema.min(currency.min, "less than min")
+                  : schema;
+              })
+        ),
+      })
+    ),
   });
   const { control, handleSubmit } = methods;
 
   const {
     field: { value: currency, onChange: onCurrencyChange },
-  } = useController({
+  } = useController<FV, "currency">({
     control: control,
     name: "currency",
   });
@@ -59,44 +79,25 @@ export default function Form({ recipient, widgetConfig, details }: Props) {
           classes={{ label: "font-semibold" }}
           required
         />
-        <Field<FormValues>
+        <Field<FV>
           name="amount"
           label="Donation amount"
           classes={{ label: "font-semibold" }}
           required
           // validation must be dynamicly set depending on which exact currency is selected
-          registerOptions={{
-            required: "required",
-            min: currency.min
-              ? {
-                  value: currency.min,
-                  message: `must be greater than ${currency.min}`,
-                }
-              : undefined,
-            pattern: {
-              value: /[0-9]+/,
-              message: "must be a number",
-            },
-            shouldUnregister: true,
-          }}
           tooltip={createTooltip(currency)}
         />
         {!authUserEmail && (
-          <Field<FormValues>
+          <Field<FV>
             name="email"
             label="Email"
             required
             classes={{ label: "font-semibold" }}
-            registerOptions={{
-              required: "required",
-              validate: (value) =>
-                requiredString.email().isValidSync(value) || "invalid email",
-            }}
           />
         )}
         {!recipient.isKYCRequired && (
           // if KYC is required, the checkbox is redundant
-          <CheckField<FormValues>
+          <CheckField<FV>
             name="userOptForKYC"
             classes={{
               container: "text-sm",

--- a/src/components/donation/Steps/Submit/StripeCheckout/Checkout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/Checkout.tsx
@@ -8,8 +8,8 @@ import { GENERIC_ERROR_MESSAGE } from "constants/common";
 import { appRoutes, donateWidgetRoutes } from "constants/routes";
 import { useErrorContext } from "contexts/ErrorContext";
 import { FormEventHandler, useState } from "react";
-import Loader from "../Loader";
 import { DonationSource } from "types/lists";
+import Loader from "../Loader";
 
 // Code inspired by React Stripe.js docs, see:
 // https://stripe.com/docs/stripe-js/react#useelements-hook

--- a/src/pages/Admin/Charity/index.tsx
+++ b/src/pages/Admin/Charity/index.tsx
@@ -1,5 +1,7 @@
 import { adminRoutes } from "constants/routes";
 import { Navigate, Route, Routes } from "react-router-dom";
+import Widget from "../../Widget";
+import { useAdminContext } from "../Context";
 import Layout from "../Layout";
 import { LINKS } from "../constants";
 import Banking, { NewPayoutMethod, PayoutMethodDetails } from "./Banking";
@@ -9,8 +11,6 @@ import EditProfile from "./EditProfile";
 import Members from "./Members/Members";
 import ProgramEditor from "./ProgramEditor";
 import Programs from "./Programs";
-import Widget from "../../Widget";
-import { useAdminContext } from "../Context";
 
 export default function Charity() {
   //widget configurer is used in admin

--- a/src/pages/BankingApplications/Filter/index.tsx
+++ b/src/pages/BankingApplications/Filter/index.tsx
@@ -4,9 +4,9 @@ import Icon, { DrawerIcon } from "components/Icon";
 import { cleanObject } from "helpers/cleanObject";
 import { FormEventHandler, useRef } from "react";
 import { FormProvider, useForm } from "react-hook-form";
+import { optionType, schema, stringNumber } from "schemas/shape";
 import { BankingApplicationsQueryParams } from "types/aws";
 import Form from "./Form";
-import { schema } from "./schema";
 import { FormValues as FV } from "./types";
 
 type Props = {
@@ -23,7 +23,15 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
   const methods = useForm<FV>({
     mode: "onChange",
     reValidateMode: "onChange",
-    resolver: yupResolver(schema),
+    resolver: yupResolver(
+      schema<FV>({
+        endowmentID: stringNumber(
+          (s) => s,
+          (n) => n.positive("must be greater than 0").integer("invalid id")
+        ),
+        status: optionType(),
+      })
+    ),
     defaultValues: {
       endowmentID: "",
       status: { label: "Under Review", value: "under-review" },

--- a/src/pages/BankingApplications/Filter/schema.ts
+++ b/src/pages/BankingApplications/Filter/schema.ts
@@ -1,9 +1,0 @@
-import { optionType } from "schemas/shape";
-import { SchemaShape } from "schemas/types";
-import { ObjectSchema, object, string } from "yup";
-import { FormValues } from "./types";
-
-export const schema = object<any, SchemaShape<FormValues>>({
-  endowmentID: string().matches(/^(?:[1-9]\d*|)$/, "invalid id"), // int > 0, or ""
-  status: optionType(),
-}) as ObjectSchema<FormValues>;

--- a/src/pages/Widget/Widget.tsx
+++ b/src/pages/Widget/Widget.tsx
@@ -1,10 +1,10 @@
+import Seo from "components/Seo";
+import { APP_NAME, DAPP_URL } from "constants/env";
+import { useLocation } from "react-router-dom";
 import { useEndowment } from "services/aws/useEndowment";
 import Configurer from "./Configurer";
 import Preview from "./Preview";
 import Snippet from "./Snippet";
-import { useLocation } from "react-router-dom";
-import Seo from "components/Seo";
-import { APP_NAME, DAPP_URL } from "constants/env";
 
 export default function Widget({ endowId }: { endowId?: number }) {
   const location = useLocation();

--- a/src/schemas/number.ts
+++ b/src/schemas/number.ts
@@ -1,7 +1,0 @@
-import * as Yup from "yup";
-import { testTokenDigits } from "./tests";
-
-export const tokenConstraint = Yup.number()
-  .positive("invalid: must be greater than zero ")
-  .typeError("invalid: must be a number")
-  .test("max precision", "must not be greater than 6 digits", testTokenDigits);

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -1,6 +1,14 @@
 import { OptionType } from "types/components";
 import type { TokenWithAmount as TWA } from "types/tx";
-import { NumberSchema, StringSchema, lazy, number, object, string } from "yup";
+import {
+  NumberSchema,
+  ObjectSchema,
+  StringSchema,
+  lazy,
+  number,
+  object,
+  string,
+} from "yup";
 import { requiredString } from "./string";
 import { testTokenDigits } from "./tests";
 import { SchemaShape } from "./types";
@@ -10,8 +18,16 @@ export const stringNumber = (
   num: (schema: NumberSchema) => NumberSchema
 ) =>
   lazy((v) =>
-    !v ? str(string()) : num(number().typeError("must be a number"))
+    !v && typeof v !== "number"
+      ? str(string())
+      : num(number().typeError("must be a number"))
   );
+
+export function schema<T extends object>(shape: SchemaShape<T>) {
+  return object<any, SchemaShape<object /** internal */>>(
+    shape
+  ) as ObjectSchema<T>;
+}
 
 type Key = keyof TWA;
 type Min = TWA["min_donation_amnt"];


### PR DESCRIPTION
regex used to validate donation amount allows input so long as contains number e.g. `abcd12` (valid). Could update the regex but opt to use `yup` constructs instead - this also add more specific errors
`blank` -> `required`
`adfs`. -> `invalid number`
`-1, 0 ..` -> `must be greater than 0`

unlike patter matching
`adfs`. -> `must be a number`
`-1, ..` -> `must be a number`

## Explanation of the solution
* use yup validators instead of pattern matching
* create extensible convenience schema builder `stringSchema` and `schema`
* update other simple schemas to use `stringSchema` and `schema` builders

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
