### PR TITLE
BG-1107, BG-1126: Fiat checkout summary

### DIFF
--- a/src/components/BankDetails/BankDetails.tsx
+++ b/src/components/BankDetails/BankDetails.tsx
@@ -1,7 +1,7 @@
 import Divider from "components/Divider";
 import useDebouncer from "hooks/useDebouncer";
 import { useState } from "react";
-import { useCurrencisQuery } from "services/aws/wise";
+import { useWiseCurrenciesQuery } from "services/aws/wise";
 import { Currency } from "types/components";
 import CurrencySelector from "../CurrencySelector";
 import ExpectedFunds from "./ExpectedFunds";
@@ -24,6 +24,7 @@ export default function BankDetails({ FormButtons, onSubmit }: Props) {
   const [currency, setCurrency] = useState<Currency>({
     code: "USD",
     name: "United States Dollar",
+    rate: 1,
   });
   const [amount, setAmount] = useState(
     DEFAULT_EXPECTED_MONTHLY_DONATIONS_AMOUNT
@@ -45,7 +46,7 @@ export default function BankDetails({ FormButtons, onSubmit }: Props) {
     }
   };
 
-  const currencies = useCurrencisQuery({});
+  const currencies = useWiseCurrenciesQuery({});
 
   return (
     <div className="grid gap-6">

--- a/src/components/CurrencySelector/CurrencyOptions.tsx
+++ b/src/components/CurrencySelector/CurrencyOptions.tsx
@@ -51,8 +51,8 @@ export default function CurrencyOptions({
         <Combobox.Options
           className={`${classes} w-full bg-white dark:bg-blue-d6 shadow-lg rounded max-h-52 overflow-y-auto scroller text-base ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm`}
         >
-          {currencies.map(({ code, name, min }) => (
-            <Combobox.Option key={code} value={{ code, name, min }}>
+          {currencies.map(({ code, name, min, rate }) => (
+            <Combobox.Option key={code} value={{ code, name, min, rate }}>
               {({ active, selected }) => (
                 <div
                   className={`${active ? "bg-blue-l2 dark:bg-blue-d1" : ""} ${

--- a/src/components/donation/Steps/DonateMethods/ChariotConnect/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/ChariotConnect/Form.tsx
@@ -7,6 +7,7 @@ import { requiredString } from "schemas/string";
 import { setDetails } from "slices/donation";
 import { useGetter, useSetter } from "store/accessors";
 import { userIsSignedIn } from "types/auth";
+import { Currency } from "types/components";
 import { FormValues as FV, Props } from "./types";
 
 // Chariot accepts only USD.
@@ -14,7 +15,7 @@ import { FormValues as FV, Props } from "./types";
 //
 // The minimum amount should not be hardcoded as it differs depending on which provider is selected.
 // See https://givechariot.readme.io/reference/create-grant
-const USD_CURRENCY = { code: "usd" };
+const USD_CURRENCY: Currency = { code: "usd", rate: 1 };
 
 export default function Form({ recipient, widgetConfig, details }: Props) {
   const authUser = useGetter((state) => state.auth.user);

--- a/src/components/donation/Steps/DonateMethods/PayPal/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/PayPal/Form.tsx
@@ -23,7 +23,7 @@ export default function Form({ recipient, details, widgetConfig }: Props) {
   const initial: FV = {
     source: widgetConfig ? "bg-widget" : "bg-marketplace",
     amount: "",
-    currency: { code: USD_CODE, min: 1 },
+    currency: { code: USD_CODE, min: 1, rate: 1 },
     email: authUserEmail,
     userOptForKYC: false,
   };

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -23,7 +23,7 @@ export default function Form({ recipient, widgetConfig, details }: Props) {
   const initial: FV = {
     source: widgetConfig ? "bg-widget" : "bg-marketplace",
     amount: "",
-    currency: { code: USD_CODE, min: 1 },
+    currency: { code: USD_CODE, min: 1, rate: 1 },
     email: authUserEmail,
     userOptForKYC: false,
   };

--- a/src/components/donation/Steps/Splits/Splits.tsx
+++ b/src/components/donation/Steps/Splits/Splits.tsx
@@ -35,8 +35,10 @@ export default function Split({
     }
   })();
 
-  const locked = +amount * (lockedSplitPct / 100);
-  const liq = +amount - locked;
+  const liq = +amount * ((100 - lockedSplitPct) / 100);
+  //derive locked from liquid to be consistent with checkout
+  const locked = +amount - liq;
+  const DECIMALS = details.method === "crypto" ? 4 : 2;
 
   return (
     <div className="grid content-start p-4 @md:p-8">
@@ -86,14 +88,14 @@ export default function Split({
           <dt className="text-gray-d1 text-xs">Compounded Forever</dt>
           <dd>
             <span className="text-xs font-medium mr-1">{symbol}</span>
-            <span>{humanize(locked, 4)}</span>
+            <span>{humanize(locked, DECIMALS)}</span>
           </dd>
         </dl>
         <dl>
           <dt className="text-gray-d1 text-xs">Instantly Available</dt>
           <dd className="text-right">
             <span className="text-xs font-medium mr-1">{symbol}</span>
-            <span>{humanize(liq, 4)}</span>
+            <span>{humanize(liq, DECIMALS)}</span>
           </dd>
         </dl>
       </div>

--- a/src/components/donation/Steps/Submit/ChariotConnectCheckout.tsx
+++ b/src/components/donation/Steps/Submit/ChariotConnectCheckout.tsx
@@ -1,3 +1,4 @@
+import ContentLoader from "components/ContentLoader";
 import { GENERIC_ERROR_MESSAGE } from "constants/common";
 import { CHARIOT_CONNECT_ID } from "constants/env";
 import { appRoutes, donateWidgetRoutes } from "constants/routes";
@@ -9,7 +10,9 @@ import { ChariotCheckoutStep, setStep } from "slices/donation";
 import { useSetter } from "store/accessors";
 import BackBtn from "../BackBtn";
 import Err from "./Err";
-import Loader from "./Loader";
+import Currency from "./common/Currrency";
+import Heading from "./common/Heading";
+import SplitSummary from "./common/SplitSummary";
 
 // Followed Stripe's custom flow docs
 // https://stripe.com/docs/payments/quickstart
@@ -33,8 +36,13 @@ export default function ChariotConnectCheckout(props: ChariotCheckoutStep) {
     };
   };
 
+  const currency = details.currency;
+  const total = +details.amount;
+  const liq = total * (liquidSplitPct / 100);
+  const locked = total - liq;
+
   return (
-    <div className="grid content-start gap-8 p-4 @md:p-8">
+    <div className="flex flex-col content-start p-4 @md:p-8 group">
       <BackBtn
         type="button"
         onClick={() => {
@@ -45,8 +53,20 @@ export default function ChariotConnectCheckout(props: ChariotCheckoutStep) {
         }}
       />
 
+      <Heading classes="my-4" />
+
+      <SplitSummary
+        classes="mb-auto"
+        total={<Currency {...currency} amount={total} classes="text-gray-d2" />}
+        liquid={<Currency {...currency} amount={liq} classes="text-sm" />}
+        locked={<Currency {...currency} amount={locked} classes="text-sm" />}
+      />
+
+      {/** <CharioConnect/> is not yet rendered */}
+      <ContentLoader className="rounded h-14 w-full group-has-[chariot-connect]:hidden" />
+
       {isLoading ? (
-        <Loader msg="Processing donation..." />
+        <ContentLoader className="rounded h-12 w-full" />
       ) : isError ? (
         <Err error={error} />
       ) : (

--- a/src/components/donation/Steps/Submit/ChariotConnectCheckout.tsx
+++ b/src/components/donation/Steps/Submit/ChariotConnectCheckout.tsx
@@ -43,18 +43,8 @@ export default function ChariotConnectCheckout(props: ChariotCheckoutStep) {
 
   return (
     <div className="flex flex-col content-start p-4 @md:p-8 group">
-      <BackBtn
-        type="button"
-        onClick={() => {
-          const action = details.userOptForKYC
-            ? setStep("kyc-form")
-            : setStep("donate-form");
-          dispatch(action);
-        }}
-      />
-
+      <BackBtn type="button" onClick={() => dispatch(setStep("splits"))} />
       <Heading classes="my-4" />
-
       <SplitSummary
         classes="mb-auto"
         total={<Currency {...currency} amount={total} classes="text-gray-d2" />}

--- a/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
@@ -1,5 +1,4 @@
 import { WalletProvider } from "@terra-money/wallet-provider";
-import Icon from "components/Icon";
 import { chainOptions } from "constants/chainOptions";
 import { chains } from "constants/chains";
 import WalletContext from "contexts/WalletContext/WalletContext";
@@ -9,6 +8,8 @@ import { CryptoSubmitStep, setStep } from "slices/donation";
 import { useSetter } from "store/accessors";
 import Image from "../../../../Image";
 import BackBtn from "../../BackBtn";
+import Heading from "../common/Heading";
+import SplitSummary from "../common/SplitSummary";
 import Checkout from "./Checkout";
 
 export default function Crypto(props: CryptoSubmitStep) {
@@ -28,10 +29,7 @@ export default function Crypto(props: CryptoSubmitStep) {
     <div className="grid content-start p-4 @md:p-8">
       <BackBtn type="button" onClick={goBack} className="mb-4" />
 
-      <h4 className="flex items-center text-lg gap-2 mb-2">
-        <Icon type="StickyNote" />
-        <span className="font-semibold">Your donation summary</span>
-      </h4>
+      <Heading classes="mb-2" />
 
       <dl className="text-gray-d1 py-3 flex items-center justify-between border-b border-prim">
         <dt className="mr-auto">Currency</dt>
@@ -47,18 +45,11 @@ export default function Crypto(props: CryptoSubmitStep) {
         <dd className="text-gray-d2">{chains[details.chainId.value].name}</dd>
       </dl>
 
-      <dl className="text-gray-d1 py-3 gap-y-2 grid grid-cols-[1fr_auto] justify-between border-y border-prim">
-        <dt className="mr-auto">Total donation</dt>
-        <Amount classes="text-gray-d2" amount={total} />
-        <div className="flex items-center justify-between col-span-full">
-          <dt className="mr-auto text-sm">Sustainable Fund</dt>
-          <Amount classes="text-sm" amount={locked} />
-        </div>
-        <div className="flex items-center justify-between col-span-full">
-          <dt className="mr-auto text-sm">Instantly Available</dt>
-          <Amount classes="text-sm" amount={liq} />
-        </div>
-      </dl>
+      <SplitSummary
+        total={<Amount classes="text-gray-d2" amount={total} />}
+        liquid={<Amount classes="text-sm" amount={liq} />}
+        locked={<Amount classes="text-sm" amount={locked} />}
+      />
 
       <WalletProvider {...chainOptions}>
         <WalletContext>

--- a/src/components/donation/Steps/Submit/PaypalCheckout/Checkout.tsx
+++ b/src/components/donation/Steps/Submit/PaypalCheckout/Checkout.tsx
@@ -30,7 +30,7 @@ export default function Checkout({ orderId, source }: Props) {
       {isPending && <ContentLoader className="rounded h-14 w-full" />}
       {!isPending && (
         <PayPalButtons
-          className="w-full py-4"
+          className="w-full"
           disabled={isSubmitting}
           onCancel={() => setSubmitting(false)}
           onError={(error) => {

--- a/src/components/donation/Steps/Submit/PaypalCheckout/PaypalCheckout.tsx
+++ b/src/components/donation/Steps/Submit/PaypalCheckout/PaypalCheckout.tsx
@@ -1,11 +1,14 @@
 import { PayPalScriptProvider } from "@paypal/react-paypal-js";
+import ContentLoader from "components/ContentLoader";
 import { PAYPAL_CLIENT_ID } from "constants/env";
 import { usePaypalOrderQuery } from "services/apes";
 import { PaypalCheckoutStep, setStep } from "slices/donation";
 import { useSetter } from "store/accessors";
 import BackBtn from "../../BackBtn";
 import Err from "../Err";
-import Loader from "../Loader";
+import Currency from "../common/Currrency";
+import Heading from "../common/Heading";
+import SplitSummary from "../common/SplitSummary";
 import Checkout from "./Checkout";
 
 // Followed Stripe's custom flow docs
@@ -39,12 +42,26 @@ export default function PaypalCheckout(props: PaypalCheckoutStep) {
 
   const dispatch = useSetter();
 
+  const currency = details.currency;
+  const total = +details.amount;
+  const liq = total * (liquidSplitPct / 100);
+  const locked = total - liq;
+
   return (
-    <div className="grid grid-rows-[auto_1fr] min-h-[16rem] isolate p-4 @md:p-8">
+    <div className="flex flex-col min-h-[16rem] isolate p-4 @md:p-8">
       <BackBtn onClick={() => dispatch(setStep("splits"))} type="button" />
 
+      <Heading classes="my-4" />
+
+      <SplitSummary
+        classes="mb-auto"
+        total={<Currency {...currency} amount={total} classes="text-gray-d2" />}
+        liquid={<Currency {...currency} amount={liq} classes="text-sm" />}
+        locked={<Currency {...currency} amount={locked} classes="text-sm" />}
+      />
+
       {isLoading ? (
-        <Loader msg="Loading payment form..." />
+        <ContentLoader className="rounded h-14 w-full mt-auto" />
       ) : isError || !orderId ? (
         <Err error={error} />
       ) : (

--- a/src/components/donation/Steps/Submit/PaypalCheckout/PaypalCheckout.tsx
+++ b/src/components/donation/Steps/Submit/PaypalCheckout/PaypalCheckout.tsx
@@ -48,7 +48,7 @@ export default function PaypalCheckout(props: PaypalCheckoutStep) {
   const locked = total - liq;
 
   return (
-    <div className="flex flex-col min-h-[16rem] isolate p-4 @md:p-8">
+    <div className="flex flex-col isolate p-4 @md:p-8">
       <BackBtn onClick={() => dispatch(setStep("splits"))} type="button" />
 
       <Heading classes="my-4" />

--- a/src/components/donation/Steps/Submit/PaypalCheckout/PaypalCheckout.tsx
+++ b/src/components/donation/Steps/Submit/PaypalCheckout/PaypalCheckout.tsx
@@ -61,7 +61,7 @@ export default function PaypalCheckout(props: PaypalCheckoutStep) {
       />
 
       {isLoading ? (
-        <ContentLoader className="rounded h-14 w-full mt-auto" />
+        <ContentLoader className="rounded h-14 w-full" />
       ) : isError || !orderId ? (
         <Err error={error} />
       ) : (

--- a/src/components/donation/Steps/Submit/StripeCheckout/Checkout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/Checkout.tsx
@@ -79,7 +79,7 @@ export default function Checkout({ source }: { source: DonationSource }) {
         <Loader />
       ) : (
         <button
-          className="btn-orange btn-donate w-full"
+          className="btn-orange btn-donate w-full mt-6"
           disabled={!stripe || !elements || isSubmitting || isLoading}
           type="submit"
         >

--- a/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
@@ -7,6 +7,9 @@ import { useSetter } from "store/accessors";
 import BackBtn from "../../BackBtn";
 import Err from "../Err";
 import Loader from "../Loader";
+import Currency from "../common/Currrency";
+import Heading from "../common/Heading";
+import SplitSummary from "../common/SplitSummary";
 import Checkout from "./Checkout";
 
 const stripePromise = loadStripe(PUBLIC_STRIPE_KEY);
@@ -41,9 +44,22 @@ export default function StripeCheckout(props: StripeCheckoutStep) {
 
   const dispatch = useSetter();
 
+  const currency = details.currency;
+  const total = +details.amount;
+  const liq = total * (liquidSplitPct / 100);
+  const locked = total - liq;
+
   return (
-    <div className="grid content-start gap-8 p-4 @md:p-8">
+    <div className="grid content-start p-4 @md:p-8">
       <BackBtn type="button" onClick={() => dispatch(setStep("splits"))} />
+      <Heading classes="my-4" />
+
+      <SplitSummary
+        classes="mb-4"
+        total={<Currency {...currency} amount={total} classes="text-gray-d2" />}
+        liquid={<Currency {...currency} amount={liq} classes="text-sm" />}
+        locked={<Currency {...currency} amount={locked} classes="text-sm" />}
+      />
 
       {isLoading ? (
         <Loader msg="Loading payment form.." />

--- a/src/components/donation/Steps/Submit/common/Currrency.tsx
+++ b/src/components/donation/Steps/Submit/common/Currrency.tsx
@@ -1,0 +1,16 @@
+import { humanize } from "helpers";
+import { Currency as TCurrency } from "types/components";
+
+type Props = TCurrency & { classes?: string; amount: string | number };
+export default function Currency({ code, classes = "", amount, rate }: Props) {
+  const CODE = code.toUpperCase();
+  return (
+    <dd className={classes}>
+      {CODE === "USD"
+        ? `$${humanize(amount, 2)}`
+        : rate
+          ? `${CODE} ${humanize(amount, 2)} ($${humanize(+amount * rate, 2)})`
+          : `${CODE} ${humanize(amount, 2)}`}
+    </dd>
+  );
+}

--- a/src/components/donation/Steps/Submit/common/Heading.tsx
+++ b/src/components/donation/Steps/Submit/common/Heading.tsx
@@ -1,0 +1,10 @@
+import Icon from "components/Icon";
+
+export default function Heading({ classes = "" }) {
+  return (
+    <h4 className={`flex items-center text-lg gap-2 ${classes}`}>
+      <Icon type="StickyNote" />
+      <span className="font-semibold">Your donation summary</span>
+    </h4>
+  );
+}

--- a/src/components/donation/Steps/Submit/common/SplitSummary.tsx
+++ b/src/components/donation/Steps/Submit/common/SplitSummary.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+
+type Props = {
+  total: ReactNode;
+  locked: ReactNode;
+  liquid: ReactNode;
+};
+
+export default function SplitSummary(props: Props) {
+  return (
+    <dl className="text-gray-d1 py-3 gap-y-2 grid grid-cols-[1fr_auto] justify-between border-y border-prim">
+      <dt className="mr-auto">Total donation</dt>
+      {props.total}
+      <div className="flex items-center justify-between col-span-full">
+        <dt className="mr-auto text-sm">Sustainable Fund</dt>
+        {props.locked}
+      </div>
+      <div className="flex items-center justify-between col-span-full">
+        <dt className="mr-auto text-sm">Instantly Available</dt>
+        {props.liquid}
+      </div>
+    </dl>
+  );
+}

--- a/src/components/donation/Steps/Submit/common/SplitSummary.tsx
+++ b/src/components/donation/Steps/Submit/common/SplitSummary.tsx
@@ -4,11 +4,16 @@ type Props = {
   total: ReactNode;
   locked: ReactNode;
   liquid: ReactNode;
+  classes?: string;
 };
 
 export default function SplitSummary(props: Props) {
   return (
-    <dl className="text-gray-d1 py-3 gap-y-2 grid grid-cols-[1fr_auto] justify-between border-y border-prim">
+    <dl
+      className={`text-gray-d1 py-3 gap-y-2 grid grid-cols-[1fr_auto] justify-between border-y border-prim ${
+        props.classes ?? ""
+      }`}
+    >
       <dt className="mr-auto">Total donation</dt>
       {props.total}
       <div className="flex items-center justify-between col-span-full">

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -108,6 +108,7 @@ export const apes = createApi({
         res.currencies.map((c) => ({
           code: c.currency_code,
           min: c.minimum_amount,
+          rate: c.rate,
         })),
     }),
     stripeCurrencies: builder.query<Currency[], null>({
@@ -132,6 +133,7 @@ export const apes = createApi({
               data: data.currencies.map((c) => ({
                 code: c.currency_code,
                 min: c.minimum_amount,
+                rate: c.rate,
               })),
             };
           });

--- a/src/services/aws/wise.ts
+++ b/src/services/aws/wise.ts
@@ -6,6 +6,7 @@ import {
   V2RecipientAccount,
   WiseCurrency,
 } from "types/aws";
+import { Currency } from "types/components";
 import { aws } from "../aws/aws";
 import { version as v } from "../helpers";
 
@@ -29,8 +30,10 @@ export const wise = aws.injectEndpoints({
     recipient: builder.query<V2RecipientAccount, string>({
       query: (id: string) => `${baseURL}/v2/accounts/${id}`,
     }),
-    currencis: builder.query<WiseCurrency[], unknown>({
+    wiseCurrencies: builder.query<Currency[], unknown>({
       query: () => `${baseURL}/v1/currencies`,
+      transformResponse: (res: WiseCurrency[]) =>
+        res.map((r) => ({ rate: null, code: r.code, name: r.name })),
     }),
 
     newRequirements: builder.mutation<
@@ -104,7 +107,7 @@ export const wise = aws.injectEndpoints({
 export const {
   useCreateRecipientMutation,
   useRecipientQuery,
-  useCurrencisQuery,
+  useWiseCurrenciesQuery,
   useRequirementsQuery,
   useNewRequirementsMutation,
 } = wise;

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -18,4 +18,9 @@ export type Country = {
 };
 
 //currency selector
-export type Currency = { code: string; name?: string; min?: number };
+export type Currency = {
+  code: string;
+  name?: string;
+  min?: number;
+  rate: number | null;
+};


### PR DESCRIPTION
## Explanation of the solution
* include summary in stripe checkout
<img width="577" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/87334820-77ba-4c47-a78d-6b1c8df40bae">

* include summary in paypal checkout
<img width="593" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/768c0e50-12e1-438b-96ea-470f4cdcb141">

* include summary in DAF checkout 
<img width="584" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/ab63d0ff-2d80-4791-81e9-fd7917b2f9bf">


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
