### PR TITLE
Closes BG-1069: Account Type error should appear closer to the actual component(s)

### DIFF
--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -155,9 +155,17 @@ export default function RecipientDetailsForm({
         if (f.type === "radio") {
           return (
             <div key={f.key} className="grid gap-1">
-              <Label required={labelRequired} className="mb-1">
-                {f.name}
-              </Label>
+              <div className="flex gap-3 items-center">
+                <Label required={labelRequired} className="mb-1">
+                  {f.name}
+                </Label>
+                <ErrorMessage
+                  errors={errors}
+                  name={f.key}
+                  as="p"
+                  className="text-red text-xs"
+                />
+              </div>
               <div className="flex items-center gap-2">
                 {f.valuesAllowed?.map((v) => (
                   <div
@@ -185,12 +193,6 @@ export default function RecipientDetailsForm({
                   </div>
                 ))}
               </div>
-              <ErrorMessage
-                errors={errors}
-                name={f.key}
-                as="p"
-                className="text-red text-xs justify-self-end -mb-5"
-              />
             </div>
           );
         }


### PR DESCRIPTION
## Explanation of the solution
Error is next to the label, as per [Andrey's request](https://linear.app/better-giving/issue/BG-1069/account-type-error-should-appear-closer-to-the-actual-components#comment-45cdc22f).

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- start registration
- go to step 5 http://localhost:4200/register/steps/5
- click Submit
- **verify account type-related error appears next to the label**

## UI changes for review

![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/19427053/e66dd8e7-80a0-4dd8-9148-93994a887dba)