### PR TITLE
Closes BG-1122: registration marker not filled even when step is complete

### DIFF
--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -127,7 +127,7 @@ function Step({
         {/** circle */}
         <div
           className={`w-4 aspect-square ${
-            isDone ? "bg-orange" : "bg-gray-l3 dark:bg-bluegray"
+            isDone || isCurr ? "bg-orange" : "bg-gray-l3 dark:bg-bluegray"
           } rounded-full transform -translate-x-1/2`}
         />
         <span


### PR DESCRIPTION
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- start registration
- **verify "Contact Details" circle is filled with orange even though the step is incomplete**
- complete step 1
- **verify the circle of every subsequent step gets orange filled when it is the current one**

## UI changes for review

Something like in the image below, note that "Documentation" step is not complete:
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/19427053/176f75ac-4d53-4841-aa61-7c042382a984)

Going back one step - circle next to "Documentation" turns grey:
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/19427053/1c04caaf-2c5f-4dc5-a220-4e3350800c2a)
