### PR TITLE
Decouple react-hook-form from `<input/>`

### DIFF
--- a/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetails.tsx
@@ -1,5 +1,6 @@
 import { Info, LoadingStatus } from "components/Status";
 import { Label } from "components/form";
+import { NativeRadio } from "components/form/Radio";
 import { isEmpty } from "helpers";
 import { memo, useState } from "react";
 import { useRequirementsQuery } from "services/aws/wise";
@@ -63,18 +64,19 @@ function RecipientDetails({
         <Label className="mb-2" required>
           Transfer type
         </Label>
-        <select
-          value={reqIdx}
-          onChange={(e) => setSelectedIdx(+e.target.value)}
-          disabled={disabled || isFetching}
-          className="field-input"
-        >
+        <div className="flex items-center gap-6">
           {requirements.map((v, i) => (
-            <option key={v.type} value={i}>
+            <NativeRadio
+              classes="flex items-center gap-1.5"
+              onChange={(e) => setSelectedIdx(+e.target.value)}
+              checked={selectedIdx === i}
+              key={v.type}
+              value={i}
+            >
               {v.title}
-            </option>
+            </NativeRadio>
           ))}
-        </select>
+        </div>
       </div>
 
       <RecipientDetailsForm

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -194,7 +194,7 @@ export default function RecipientDetailsForm({
               label={f.name}
               type="text"
               placeholder={f.example}
-              registerReturn={register(f.key, {
+              {...register(f.key, {
                 required: f.required ? "required" : false,
                 maxLength: f.maxLength
                   ? {

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -163,14 +163,14 @@ export default function RecipientDetailsForm({
                 {f.valuesAllowed?.map((v) => (
                   <NativeRadio
                     classes="flex items-center gap-1.5"
-                    key={v.key}
-                    value={v.key}
-                    registerReturn={register(f.key, {
+                    {...register(f.key, {
                       required: f.required ? "required" : false,
                       onChange: f.refreshRequirementsOnChange
                         ? refresh
                         : undefined,
                     })}
+                    key={v.key}
+                    value={v.key}
                   >
                     <span className="capitalize">{v.key.toLowerCase()}</span>
                   </NativeRadio>

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -189,6 +189,7 @@ export default function RecipientDetailsForm({
         if (f.type === "text") {
           return (
             <NativeField
+              key={f.key}
               required={f.required ? true : undefined}
               error={get(errors, f.key)?.message}
               label={f.name}

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -1,10 +1,11 @@
 import { ErrorMessage } from "@hookform/error-message";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import { Label } from "components/form";
+import { Label, NativeField } from "components/form";
+import { NativeRadio } from "components/form/Radio";
 import { GENERIC_ERROR_MESSAGE } from "constants/common";
 import { useErrorContext } from "contexts/ErrorContext";
 import { isEmpty } from "helpers";
-import { useForm } from "react-hook-form";
+import { get, useForm } from "react-hook-form";
 import {
   useCreateRecipientMutation,
   useNewRequirementsMutation,
@@ -158,31 +159,21 @@ export default function RecipientDetailsForm({
               <Label required={labelRequired} className="mb-1">
                 {f.name}
               </Label>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-4">
                 {f.valuesAllowed?.map((v) => (
-                  <div
+                  <NativeRadio
+                    classes="flex items-center gap-1.5"
                     key={v.key}
-                    className="relative border border-prim rounded px-4 py-3.5 text-sm has-[:checked]:border-orange has-[:disabled]:bg-gray-l5 w-32 h-10 focus-within:ring-1 focus-within:ring-gray-d1"
+                    value={v.key}
+                    {...register(f.key, {
+                      required: f.required ? "required" : false,
+                      onChange: f.refreshRequirementsOnChange
+                        ? refresh
+                        : undefined,
+                    })}
                   >
-                    <input
-                      className="appearance none w-0 h-0"
-                      id={`radio__${v.key}`}
-                      type="radio"
-                      value={v.key}
-                      {...register(f.key, {
-                        required: f.required ? "required" : false,
-                        onChange: f.refreshRequirementsOnChange
-                          ? refresh
-                          : undefined,
-                      })}
-                    />
-                    <label
-                      htmlFor={`radio__${v.key}`}
-                      className="absolute inset-0 w-full grid place-items-center"
-                    >
-                      {v.name}
-                    </label>
-                  </div>
+                    <span className="capitalize">{v.key.toLowerCase()}</span>
+                  </NativeRadio>
                 ))}
               </div>
               <ErrorMessage
@@ -197,53 +188,44 @@ export default function RecipientDetailsForm({
 
         if (f.type === "text") {
           return (
-            <div key={f.key} className="grid gap-1">
-              <Label required={labelRequired} htmlFor={f.key}>
-                {f.name}
-              </Label>
-              <input
-                className="field-input"
-                type="text"
-                placeholder={f.example}
-                {...register(f.key, {
-                  required: f.required ? "required" : false,
-                  maxLength: f.maxLength
-                    ? {
-                        value: f.maxLength,
-                        message: `max ${f.maxLength} chars`,
-                      }
-                    : undefined,
-                  minLength: f.minLength
-                    ? {
-                        value: f.minLength,
-                        message: `min ${f.minLength} chars`,
-                      }
-                    : undefined,
-                  pattern: f.validationRegexp
-                    ? {
-                        value: new RegExp(f.validationRegexp),
-                        message: "invalid",
-                      }
-                    : undefined,
+            <NativeField
+              required={f.required ? true : undefined}
+              error={get(errors, f.key)?.message}
+              label={f.name}
+              type="text"
+              placeholder={f.example}
+              registerReturn={register(f.key, {
+                required: f.required ? "required" : false,
+                maxLength: f.maxLength
+                  ? {
+                      value: f.maxLength,
+                      message: `max ${f.maxLength} chars`,
+                    }
+                  : undefined,
+                minLength: f.minLength
+                  ? {
+                      value: f.minLength,
+                      message: `min ${f.minLength} chars`,
+                    }
+                  : undefined,
+                pattern: f.validationRegexp
+                  ? {
+                      value: new RegExp(f.validationRegexp),
+                      message: "invalid",
+                    }
+                  : undefined,
 
-                  validate: f.validationAsync
-                    ? async (v: string) => {
-                        const { params, url } = f.validationAsync!;
-                        const res = await fetch(`${url}?${params[0].key}=${v}`);
-                        return res.ok || "invalid";
-                      }
-                    : undefined,
-                  //onBlur only as text input changes rapidly
-                  onBlur: f.refreshRequirementsOnChange ? refresh : undefined,
-                })}
-              />
-              <ErrorMessage
-                errors={errors}
-                name={f.key}
-                as="p"
-                className="text-red text-xs justify-self-end -mb-5"
-              />
-            </div>
+                validate: f.validationAsync
+                  ? async (v: string) => {
+                      const { params, url } = f.validationAsync!;
+                      const res = await fetch(`${url}?${params[0].key}=${v}`);
+                      return res.ok || "invalid";
+                    }
+                  : undefined,
+                //onBlur only as text input changes rapidly
+                onBlur: f.refreshRequirementsOnChange ? refresh : undefined,
+              })}
+            />
           );
         }
 

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -165,7 +165,7 @@ export default function RecipientDetailsForm({
                     classes="flex items-center gap-1.5"
                     key={v.key}
                     value={v.key}
-                    {...register(f.key, {
+                    registerReturn={register(f.key, {
                       required: f.required ? "required" : false,
                       onChange: f.refreshRequirementsOnChange
                         ? refresh

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -15,8 +15,6 @@ type Common = PropsWithChildren<{
   required?: boolean;
 }>;
 
-type NativeProps = UseFormRegisterReturn & Common & { error?: string };
-
 export function CheckField<T extends FieldValues>({
   name,
   disabled,
@@ -28,12 +26,13 @@ export function CheckField<T extends FieldValues>({
     register,
     formState: { isSubmitting, errors },
   } = useFormContext<T>();
+
   return (
     <NativeCheckField
       {...register(name)}
       {...rest}
       disabled={disabled || isSubmitting}
-      error={get(errors, name)}
+      error={get(errors, name)?.message}
     />
   );
 }
@@ -42,10 +41,10 @@ export function NativeCheckField({
   classes,
   disabled,
   required,
-  error,
   children,
+  error,
   ...registerReturn
-}: NativeProps) {
+}: Common & UseFormRegisterReturn & { error?: string }) {
   const { container, input: int, lbl, error: errClass } = unpack(classes);
   const name = registerReturn.name;
   const id = `__${name}`;

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -1,41 +1,42 @@
 import { ErrorMessage } from "@hookform/error-message";
 import { PropsWithChildren } from "react";
-import { FieldValues, Path, get, useFormContext } from "react-hook-form";
+import { FormState, UseFormRegisterReturn, get } from "react-hook-form";
 import { unpack } from "./helpers";
 import { Classes } from "./types";
 
-export function CheckField<T extends FieldValues>({
-  name,
-  children,
-  classes,
-  disabled,
-  required,
-}: PropsWithChildren<{
-  name: Path<T>;
+type Custom = PropsWithChildren<{
   classes?: Classes;
   disabled?: boolean;
   required?: boolean;
-}>) {
-  const {
-    register,
-    formState: { isSubmitting, errors },
-  } = useFormContext<T>();
+  invalid?: boolean;
+  formState?: FormState<any>;
+}>;
 
-  const id = `__${name}`;
+type Props = UseFormRegisterReturn & Custom;
+
+export function CheckField({
+  classes,
+  disabled,
+  required,
+  children,
+  invalid,
+  formState,
+  ...registerReturn
+}: Props) {
   const { container, input: int, lbl, error } = unpack(classes);
-
-  const invalid = !!get(errors, name);
+  const name = registerReturn.name;
+  const id = `__${name}`;
 
   return (
     <div className={`check-field ${container}`}>
       <input
-        {...register(name)}
+        {...registerReturn}
         className={int + " peer"}
         type="checkbox"
         id={id}
-        disabled={isSubmitting || disabled}
-        aria-disabled={isSubmitting || disabled}
-        aria-invalid={invalid}
+        disabled={formState?.isSubmitting || disabled}
+        aria-disabled={formState?.isSubmitting || disabled}
+        aria-invalid={!!get(formState?.errors, name) || invalid}
       />
       {!!children && (
         <label data-required={required} className={lbl} htmlFor={id}>
@@ -43,13 +44,15 @@ export function CheckField<T extends FieldValues>({
         </label>
       )}
 
-      <ErrorMessage
-        data-error
-        errors={errors}
-        name={name as any}
-        as="p"
-        className={error}
-      />
+      {formState?.errors && (
+        <ErrorMessage
+          data-error
+          errors={formState.errors}
+          name={name as any}
+          as="p"
+          className={error}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -31,9 +31,9 @@ export function CheckField<T extends FieldValues>({
   return (
     <NativeCheckField
       {...register(name)}
+      {...rest}
       disabled={disabled || isSubmitting}
       error={get(errors, name)}
-      {...rest}
     />
   );
 }

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -12,40 +12,38 @@ type Props = Omit<
   error?: string;
 };
 
-function _CheckField(
-  { classes, required, children, error, ...props }: Props,
-  ref: any
-) {
-  const { container, input: int, lbl, error: errClass } = unpack(classes);
-  const id = `__${props.name}`;
+const NativeCheckField = forwardRef<HTMLInputElement, Props>(
+  ({ classes, required, children, error, ...props }, ref) => {
+    const { container, input: int, lbl, error: errClass } = unpack(classes);
+    const id = `__${props.name}`;
 
-  return (
-    <div className={`check-field ${container}`}>
-      <input
-        {...props}
-        ref={ref}
-        className={int + " peer"}
-        type="checkbox"
-        id={id}
-        aria-disabled={props.disabled}
-        aria-invalid={!!error}
-      />
-      {children && (
-        <label data-required={required} className={lbl} htmlFor={id}>
-          {children}
-        </label>
-      )}
+    return (
+      <div className={`check-field ${container}`}>
+        <input
+          {...props}
+          ref={ref}
+          className={int + " peer"}
+          type="checkbox"
+          id={id}
+          aria-disabled={props.disabled}
+          aria-invalid={!!error}
+        />
+        {children && (
+          <label data-required={required} className={lbl} htmlFor={id}>
+            {children}
+          </label>
+        )}
 
-      {error && (
-        <p data-error className={errClass}>
-          {error}
-        </p>
-      )}
-    </div>
-  );
-}
+        {error && (
+          <p data-error className={errClass}>
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
 
-export const NativeCheckField = forwardRef(_CheckField) as typeof _CheckField;
 export function CheckField<T extends FieldValues>({
   name,
   disabled,

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -28,7 +28,6 @@ function _CheckField(
         className={int + " peer"}
         type="checkbox"
         id={id}
-        disabled={props.disabled}
         aria-disabled={props.disabled}
         aria-invalid={!!error}
       />

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -1,45 +1,35 @@
-import { PropsWithChildren, forwardRef } from "react";
-import {
-  FieldValues,
-  Path,
-  UseFormRegisterReturn,
-  get,
-  useFormContext,
-} from "react-hook-form";
+import { InputHTMLAttributes, ReactNode, forwardRef } from "react";
+import { FieldValues, Path, get, useFormContext } from "react-hook-form";
 import { unpack } from "./helpers";
 import { Classes } from "./types";
 
-type Common = PropsWithChildren<{
+type Custom = {
   classes?: Classes;
-  disabled?: boolean;
-  required?: boolean;
-}>;
+  children?: ReactNode;
+  error?: string;
+};
+
+type Props = Omit<InputHTMLAttributes<HTMLInputElement>, "className" | "type"> &
+  Custom;
 
 function _CheckField(
-  {
-    classes,
-    disabled,
-    required,
-    children,
-    error,
-    ...registerReturn
-  }: Common & UseFormRegisterReturn & { error?: string },
+  { classes, required, children, error, ...props }: Props,
   ref: any
 ) {
   const { container, input: int, lbl, error: errClass } = unpack(classes);
-  const name = registerReturn.name;
+  const name = props.name;
   const id = `__${name}`;
 
   return (
     <div className={`check-field ${container}`}>
       <input
-        {...registerReturn}
+        {...props}
         ref={ref}
         className={int + " peer"}
         type="checkbox"
         id={id}
-        disabled={disabled}
-        aria-disabled={disabled}
+        disabled={props.disabled}
+        aria-disabled={props.disabled}
         aria-invalid={!!error}
       />
       {children && (
@@ -60,9 +50,8 @@ function _CheckField(
 export const NativeCheckField = forwardRef(_CheckField) as typeof _CheckField;
 export function CheckField<T extends FieldValues>({
   name,
-  disabled,
   ...rest
-}: Common & {
+}: Omit<Props, "name"> & {
   name: Path<T>;
 }) {
   const {
@@ -74,7 +63,7 @@ export function CheckField<T extends FieldValues>({
     <NativeCheckField
       {...register(name)}
       {...rest}
-      disabled={disabled || isSubmitting}
+      disabled={rest.disabled || isSubmitting}
       error={get(errors, name)?.message}
     />
   );

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, forwardRef } from "react";
 import {
   FieldValues,
   Path,
@@ -15,36 +15,17 @@ type Common = PropsWithChildren<{
   required?: boolean;
 }>;
 
-export function CheckField<T extends FieldValues>({
-  name,
-  disabled,
-  ...rest
-}: Common & {
-  name: Path<T>;
-}) {
-  const {
-    register,
-    formState: { isSubmitting, errors },
-  } = useFormContext<T>();
-
-  return (
-    <NativeCheckField
-      {...register(name)}
-      {...rest}
-      disabled={disabled || isSubmitting}
-      error={get(errors, name)?.message}
-    />
-  );
-}
-
-export function NativeCheckField({
-  classes,
-  disabled,
-  required,
-  children,
-  error,
-  ...registerReturn
-}: Common & UseFormRegisterReturn & { error?: string }) {
+function _CheckField(
+  {
+    classes,
+    disabled,
+    required,
+    children,
+    error,
+    ...registerReturn
+  }: Common & UseFormRegisterReturn & { error?: string },
+  ref: any
+) {
   const { container, input: int, lbl, error: errClass } = unpack(classes);
   const name = registerReturn.name;
   const id = `__${name}`;
@@ -53,6 +34,7 @@ export function NativeCheckField({
     <div className={`check-field ${container}`}>
       <input
         {...registerReturn}
+        ref={ref}
         className={int + " peer"}
         type="checkbox"
         id={id}
@@ -72,5 +54,28 @@ export function NativeCheckField({
         </p>
       )}
     </div>
+  );
+}
+
+export const NativeCheckField = forwardRef(_CheckField) as typeof _CheckField;
+export function CheckField<T extends FieldValues>({
+  name,
+  disabled,
+  ...rest
+}: Common & {
+  name: Path<T>;
+}) {
+  const {
+    register,
+    formState: { isSubmitting, errors },
+  } = useFormContext<T>();
+
+  return (
+    <NativeCheckField
+      {...register(name)}
+      {...rest}
+      disabled={disabled || isSubmitting}
+      error={get(errors, name)?.message}
+    />
   );
 }

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -19,9 +19,8 @@ type NativeProps = UseFormRegisterReturn & Common & { error?: string };
 
 export function CheckField<T extends FieldValues>({
   name,
-  classes,
   disabled,
-  required,
+  ...rest
 }: Common & {
   name: Path<T>;
 }) {
@@ -32,10 +31,9 @@ export function CheckField<T extends FieldValues>({
   return (
     <NativeCheckField
       {...register(name)}
-      classes={classes}
-      required={required}
       disabled={disabled || isSubmitting}
       error={get(errors, name)}
+      {...rest}
     />
   );
 }

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -17,8 +17,7 @@ function _CheckField(
   ref: any
 ) {
   const { container, input: int, lbl, error: errClass } = unpack(classes);
-  const name = props.name;
-  const id = `__${name}`;
+  const id = `__${props.name}`;
 
   return (
     <div className={`check-field ${container}`}>
@@ -50,7 +49,7 @@ export const NativeCheckField = forwardRef(_CheckField) as typeof _CheckField;
 export function CheckField<T extends FieldValues>({
   name,
   disabled,
-  ...rest
+  ...props
 }: Omit<Props, "name"> & {
   name: Path<T>;
 }) {
@@ -62,7 +61,7 @@ export function CheckField<T extends FieldValues>({
   return (
     <NativeCheckField
       {...register(name)}
-      {...rest}
+      {...props}
       disabled={disabled || isSubmitting}
       error={get(errors, name)?.message}
     />

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -3,14 +3,14 @@ import { FieldValues, Path, get, useFormContext } from "react-hook-form";
 import { unpack } from "./helpers";
 import { Classes } from "./types";
 
-type Custom = {
+type Props = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "className" | "type"
+> & {
   classes?: Classes;
   children?: ReactNode;
   error?: string;
 };
-
-type Props = Omit<InputHTMLAttributes<HTMLInputElement>, "className" | "type"> &
-  Custom;
 
 function _CheckField(
   { classes, required, children, error, ...props }: Props,
@@ -50,6 +50,7 @@ function _CheckField(
 export const NativeCheckField = forwardRef(_CheckField) as typeof _CheckField;
 export function CheckField<T extends FieldValues>({
   name,
+  disabled,
   ...rest
 }: Omit<Props, "name"> & {
   name: Path<T>;
@@ -63,7 +64,7 @@ export function CheckField<T extends FieldValues>({
     <NativeCheckField
       {...register(name)}
       {...rest}
-      disabled={rest.disabled || isSubmitting}
+      disabled={disabled || isSubmitting}
       error={get(errors, name)?.message}
     />
   );

--- a/src/components/form/DateInput.tsx
+++ b/src/components/form/DateInput.tsx
@@ -28,13 +28,13 @@ export const NativeDateInput = forwardRef(_Date) as typeof _Date;
 
 export default function DateInput<T extends FieldValues>({
   name,
-  ...rest
+  ...props
 }: Omit<Props, "name"> & { name: Path<T> }) {
   const {
     register,
     formState: { errors },
   } = useFormContext<T>();
   return (
-    <NativeDateInput {...register(name)} {...rest} error={get(errors, name)} />
+    <NativeDateInput {...register(name)} {...props} error={get(errors, name)} />
   );
 }

--- a/src/components/form/DateInput.tsx
+++ b/src/components/form/DateInput.tsx
@@ -1,5 +1,10 @@
-import { ErrorMessage } from "@hookform/error-message";
-import { FieldValues, Path, useFormContext } from "react-hook-form";
+import {
+  FieldValues,
+  Path,
+  UseFormRegisterReturn,
+  get,
+  useFormContext,
+} from "react-hook-form";
 
 export default function DateInput<T extends FieldValues>({
   name,
@@ -10,19 +15,26 @@ export default function DateInput<T extends FieldValues>({
     register,
     formState: { errors },
   } = useFormContext<T>();
+  return <NativeDateInput {...register(name)} error={get(errors, name)} />;
+}
+
+export function NativeDateInput({
+  error,
+  ...props
+}: UseFormRegisterReturn & { error?: string }) {
   return (
     <div>
       <input
-        {...register(name)}
+        {...props}
         type="date"
         className="date-input uppercase text-sm relative w-full px-4 py-3 border border-prim rounded-md border-collapse dark:bg-blue-d6"
       />
-      <ErrorMessage
-        errors={errors}
-        as="span"
-        name={name as any}
-        className="w-full text-xs text-red-l4 dark:text-red-l2"
-      />
+
+      {error && (
+        <span className="w-full text-xs text-red-l4 dark:text-red-l2">
+          {error}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/components/form/DateInput.tsx
+++ b/src/components/form/DateInput.tsx
@@ -1,11 +1,12 @@
 import { InputHTMLAttributes, forwardRef } from "react";
 import { FieldValues, Path, get, useFormContext } from "react-hook-form";
 
+type Ref = HTMLInputElement;
 type Props = Omit<InputHTMLAttributes<HTMLInputElement>, "type"> & {
   error?: string;
 };
 
-function _Date({ error, ...props }: Props, ref: any) {
+const NativeDateInput = forwardRef<Ref, Props>(({ error, ...props }, ref) => {
   return (
     <div>
       <input
@@ -22,9 +23,7 @@ function _Date({ error, ...props }: Props, ref: any) {
       )}
     </div>
   );
-}
-
-export const NativeDateInput = forwardRef(_Date) as typeof _Date;
+});
 
 export default function DateInput<T extends FieldValues>({
   name,

--- a/src/components/form/DateInput.tsx
+++ b/src/components/form/DateInput.tsx
@@ -1,16 +1,11 @@
-import { forwardRef } from "react";
-import {
-  FieldValues,
-  Path,
-  UseFormRegisterReturn,
-  get,
-  useFormContext,
-} from "react-hook-form";
+import { InputHTMLAttributes, forwardRef } from "react";
+import { FieldValues, Path, get, useFormContext } from "react-hook-form";
 
-function _Date(
-  { error, ...props }: UseFormRegisterReturn & { error?: string },
-  ref: any
-) {
+type Props = Omit<InputHTMLAttributes<HTMLInputElement>, "type"> & {
+  error?: string;
+};
+
+function _Date({ error, ...props }: Props, ref: any) {
   return (
     <div>
       <input
@@ -33,9 +28,7 @@ export const NativeDateInput = forwardRef(_Date) as typeof _Date;
 
 export default function DateInput<T extends FieldValues>({
   name,
-}: {
-  name: Path<T>;
-}) {
+}: Omit<Props, "name"> & { name: Path<T> }) {
   const {
     register,
     formState: { errors },

--- a/src/components/form/DateInput.tsx
+++ b/src/components/form/DateInput.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react";
 import {
   FieldValues,
   Path,
@@ -6,26 +7,15 @@ import {
   useFormContext,
 } from "react-hook-form";
 
-export default function DateInput<T extends FieldValues>({
-  name,
-}: {
-  name: Path<T>;
-}) {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext<T>();
-  return <NativeDateInput {...register(name)} error={get(errors, name)} />;
-}
-
-export function NativeDateInput({
-  error,
-  ...props
-}: UseFormRegisterReturn & { error?: string }) {
+function _Date(
+  { error, ...props }: UseFormRegisterReturn & { error?: string },
+  ref: any
+) {
   return (
     <div>
       <input
         {...props}
+        ref={ref}
         type="date"
         className="date-input uppercase text-sm relative w-full px-4 py-3 border border-prim rounded-md border-collapse dark:bg-blue-d6"
       />
@@ -37,4 +27,18 @@ export function NativeDateInput({
       )}
     </div>
   );
+}
+
+export const NativeDateInput = forwardRef(_Date) as typeof _Date;
+
+export default function DateInput<T extends FieldValues>({
+  name,
+}: {
+  name: Path<T>;
+}) {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<T>();
+  return <NativeDateInput {...register(name)} error={get(errors, name)} />;
 }

--- a/src/components/form/DateInput.tsx
+++ b/src/components/form/DateInput.tsx
@@ -28,10 +28,13 @@ export const NativeDateInput = forwardRef(_Date) as typeof _Date;
 
 export default function DateInput<T extends FieldValues>({
   name,
+  ...rest
 }: Omit<Props, "name"> & { name: Path<T> }) {
   const {
     register,
     formState: { errors },
   } = useFormContext<T>();
-  return <NativeDateInput {...register(name)} error={get(errors, name)} />;
+  return (
+    <NativeDateInput {...register(name)} {...rest} error={get(errors, name)} />
+  );
 }

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -8,7 +8,7 @@ const textarea = "textarea" as const;
 type TextArea = typeof textarea;
 type InputType = HTMLInputTypeAttribute | TextArea;
 
-type Common<T extends InputType> = Omit<
+type Props<T extends InputType> = Omit<
   T extends TextArea
     ? React.TextareaHTMLAttributes<HTMLTextAreaElement>
     : React.InputHTMLAttributes<HTMLInputElement>,
@@ -24,7 +24,7 @@ function _Field<T extends InputType = InputType>(
     error,
     required, //extract from props to disable native validation
     ...props
-  }: Common<T> & { error?: string },
+  }: Props<T> & { error?: string },
   ref: any
 ) {
   const { container, input, lbl, error: errClass } = unpack(classes);
@@ -33,7 +33,7 @@ function _Field<T extends InputType = InputType>(
 
   return (
     <div className={container + " field"} aria-required={required}>
-      <Label className={lbl} required={props.disabled} htmlFor={id}>
+      <Label className={lbl} required={required} htmlFor={id}>
         {label}
       </Label>
 
@@ -74,7 +74,7 @@ export function Field<T extends FieldValues, K extends InputType = InputType>({
   name,
   disabled,
   ...rest
-}: Omit<Common<K>, "name"> & { name: Path<T> }) {
+}: Omit<Props<K>, "name"> & { name: Path<T> }) {
   const {
     register,
     formState: { errors, isSubmitting },

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -22,7 +22,7 @@ function _Field<T extends InputType = InputType>(
     classes,
     tooltip,
     error,
-    required,
+    required, //extract from props to disable native validation
     ...props
   }: Common<T> & { error?: string },
   ref: any

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -33,10 +33,10 @@ export function Field<T extends FieldValues, K extends InputType = InputType>({
 
   return (
     <NativeField
-      registerReturn={register(name)}
+      {...rest}
+      {...register(name)}
       error={get(errors, name)}
       disabled={disabled || isSubmitting}
-      {...rest}
     />
   );
 }
@@ -49,12 +49,11 @@ export function NativeField<T extends InputType = InputType>({
   required,
   disabled,
   error,
-  registerReturn,
   ...props
-}: Common<T> & { error?: string; registerReturn: UseFormRegisterReturn }) {
+}: Common<T> & UseFormRegisterReturn & { error?: string }) {
   const { container, input, lbl, error: errClass } = unpack(classes);
 
-  const id = "__" + String(name);
+  const id = "__" + String(props.name);
 
   return (
     <div className={container + " field"} aria-required={required}>
@@ -64,7 +63,6 @@ export function NativeField<T extends InputType = InputType>({
 
       {createElement(type === textarea ? textarea : "input", {
         ...props,
-        ...registerReturn,
         ...(type === textarea ? {} : { type }),
         id,
         "aria-invalid": !error,

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -73,6 +73,7 @@ export const NativeField = forwardRef(_Field) as typeof _Field;
 export function Field<T extends FieldValues, K extends InputType = InputType>({
   name,
   disabled,
+  type,
   ...rest
 }: Omit<Props<K>, "name"> & { name: Path<T> }) {
   const {
@@ -82,7 +83,7 @@ export function Field<T extends FieldValues, K extends InputType = InputType>({
 
   return (
     <NativeField
-      {...register(name)}
+      {...register(name, { valueAsNumber: type === "number" })}
       {...rest} //native properties override that from register
       disabled={disabled || isSubmitting}
       error={get(errors, name)?.message}

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -1,11 +1,5 @@
 import { HTMLInputTypeAttribute, createElement } from "react";
-import {
-  FieldValues,
-  Path,
-  UseFormRegisterReturn,
-  get,
-  useFormContext,
-} from "react-hook-form";
+import { FieldValues, Path, get, useFormContext } from "react-hook-form";
 import { Label } from ".";
 import { unpack } from "./helpers";
 import { Classes } from "./types";
@@ -18,14 +12,14 @@ type Common<T extends InputType> = Omit<
   T extends TextArea
     ? React.TextareaHTMLAttributes<HTMLTextAreaElement>
     : React.InputHTMLAttributes<HTMLInputElement>,
-  "autoComplete" | "className" | "name" | "id" | "spellCheck" | "type"
+  "autoComplete" | "className" | "spellCheck" | "type"
 > & { type?: T; classes?: Classes | string; tooltip?: string; label: string };
 
 export function Field<T extends FieldValues, K extends InputType = InputType>({
   name,
   disabled,
   ...rest
-}: Common<K> & { name: Path<T> }) {
+}: Omit<Common<K>, "name"> & { name: Path<T> }) {
   const {
     register,
     formState: { errors, isSubmitting },
@@ -33,8 +27,8 @@ export function Field<T extends FieldValues, K extends InputType = InputType>({
 
   return (
     <NativeField
-      {...rest}
-      registerReturn={register(name)}
+      {...register(name)}
+      {...rest} //native properties override that from register
       disabled={disabled || isSubmitting}
       error={get(errors, name)?.message}
     />
@@ -46,30 +40,25 @@ export function NativeField<T extends InputType = InputType>({
   label,
   classes,
   tooltip,
-  required,
-  disabled,
   error,
-  registerReturn,
   ...props
-}: Common<T> & { error?: string; registerReturn: UseFormRegisterReturn }) {
+}: Common<T> & { error?: string }) {
   const { container, input, lbl, error: errClass } = unpack(classes);
 
-  const id = "__" + String(registerReturn.name);
+  const id = "__" + props.name;
 
   return (
-    <div className={container + " field"} aria-required={required}>
-      <Label className={lbl} required={required} htmlFor={id}>
+    <div className={container + " field"} aria-required={props.required}>
+      <Label className={lbl} required={props.disabled} htmlFor={id}>
         {label}
       </Label>
 
       {createElement(type === textarea ? textarea : "input", {
-        ...registerReturn,
         ...props,
         ...(type === textarea ? {} : { type }),
         id,
         "aria-invalid": !!error,
-        disabled,
-        "aria-disabled": disabled,
+        "aria-disabled": props.disabled,
         className: `${input}`,
         autoComplete: "off",
         spellCheck: false,

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -1,4 +1,9 @@
-import { HTMLInputTypeAttribute, createElement, forwardRef } from "react";
+import {
+  HTMLInputTypeAttribute,
+  LegacyRef,
+  createElement,
+  forwardRef,
+} from "react";
 import { FieldValues, Path, get, useFormContext } from "react-hook-form";
 import { Label } from ".";
 import { unpack } from "./helpers";
@@ -25,7 +30,7 @@ function _Field<T extends InputType = InputType>(
     required, //extract from props to disable native validation
     ...props
   }: Props<T> & { error?: string },
-  ref: any
+  ref: LegacyRef<HTMLInputElement | HTMLTextAreaElement>
 ) {
   const { container, input, lbl, error: errClass } = unpack(classes);
 

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -34,9 +34,9 @@ export function Field<T extends FieldValues, K extends InputType = InputType>({
   return (
     <NativeField
       {...rest}
-      {...register(name)}
-      error={get(errors, name)}
+      registerReturn={register(name)}
       disabled={disabled || isSubmitting}
+      error={get(errors, name)?.message}
     />
   );
 }
@@ -49,11 +49,12 @@ export function NativeField<T extends InputType = InputType>({
   required,
   disabled,
   error,
+  registerReturn,
   ...props
-}: Common<T> & UseFormRegisterReturn & { error?: string }) {
+}: Common<T> & { error?: string; registerReturn: UseFormRegisterReturn }) {
   const { container, input, lbl, error: errClass } = unpack(classes);
 
-  const id = "__" + String(props.name);
+  const id = "__" + String(registerReturn.name);
 
   return (
     <div className={container + " field"} aria-required={required}>
@@ -62,6 +63,7 @@ export function NativeField<T extends InputType = InputType>({
       </Label>
 
       {createElement(type === textarea ? textarea : "input", {
+        ...registerReturn,
         ...props,
         ...(type === textarea ? {} : { type }),
         id,
@@ -74,7 +76,7 @@ export function NativeField<T extends InputType = InputType>({
       })}
 
       {(tooltip && ( //tooltip in normal flow
-        <p className={error + " text-left mt-2 left-0 text-xs"}>
+        <p className={errClass + " text-left mt-2 left-0 text-xs"}>
           <span className="text-gray-d1 dark:text-gray">{tooltip}</span>{" "}
           {error && (
             <span className="text-red dark:text-red-l2 text-xs before:content-['('] before:mr-0.5 after:content-[')'] after:ml-0.5 empty:before:hidden empty:after:hidden">

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -65,7 +65,7 @@ export function NativeField<T extends InputType = InputType>({
         ...props,
         ...(type === textarea ? {} : { type }),
         id,
-        "aria-invalid": !error,
+        "aria-invalid": !!error,
         disabled,
         "aria-disabled": disabled,
         className: `${input}`,

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -19,7 +19,7 @@ export function Radio<T extends FieldValues, K extends Path<T>>({
   name,
   disabled,
   ...rest
-}: Common<T, K> & UseFormRegisterReturn & { error?: string }) {
+}: Common<T, K> & { name?: Path<T> }) {
   const {
     register,
     formState: { isSubmitting },

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -12,7 +12,7 @@ type Props<T extends FieldValues, K extends Path<T>> = Omit<
   value: PathValue<T, K> extends string ? PathValue<T, K> : never;
 };
 
-export function _Radio<T extends FieldValues, K extends Path<T>>(
+function _Radio<T extends FieldValues, K extends Path<T>>(
   { children, classes, ...props }: Props<T, K>,
   ref: any
 ) {

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -27,9 +27,9 @@ export function Radio<T extends FieldValues, K extends Path<T>>({
 
   return (
     <NativeRadio
-      {...register(name as any)}
-      {...rest}
+      registerReturn={register(name as any)}
       disabled={isSubmitting || disabled}
+      {...rest}
     />
   );
 }
@@ -39,15 +39,15 @@ export function NativeRadio<T extends FieldValues, K extends Path<T>>({
   classes,
   value,
   disabled,
-  ...props
-}: Common<T, K> & UseFormRegisterReturn) {
-  const id = `__${props.name}-${value}`;
+  registerReturn,
+}: Common<T, K> & { registerReturn: UseFormRegisterReturn }) {
+  const id = `__${registerReturn.name}-${value}`;
   const { container, input } = unpack(classes);
 
   return (
     <label className={`radio ${container}`} htmlFor={id}>
       <input
-        {...props}
+        {...registerReturn}
         id={id}
         type="radio"
         className={`peer ${input}`}

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -3,7 +3,7 @@ import { FieldValues, Path, PathValue, useFormContext } from "react-hook-form";
 import { unpack } from "./helpers";
 import { Classes } from "./types";
 
-type Common<T extends FieldValues, K extends Path<T>> = Omit<
+type Props<T extends FieldValues, K extends Path<T>> = Omit<
   InputHTMLAttributes<HTMLInputElement>,
   "type" | "className" | "value"
 > & {
@@ -13,7 +13,7 @@ type Common<T extends FieldValues, K extends Path<T>> = Omit<
 };
 
 export function _Radio<T extends FieldValues, K extends Path<T>>(
-  { children, classes, ...rest }: Common<T, K>,
+  { children, classes, ...rest }: Props<T, K>,
   ref: any
 ) {
   const id = `__${rest.name}-${rest.value}`;
@@ -40,7 +40,7 @@ export function Radio<T extends FieldValues, K extends Path<T>>({
   name,
   disabled,
   ...rest
-}: Common<T, K> & { name?: Path<T> }) {
+}: Omit<Props<T, K>, "name"> & { name?: Path<T> }) {
   const {
     register,
     formState: { isSubmitting },

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, ReactNode } from "react";
+import { InputHTMLAttributes, ReactNode, forwardRef } from "react";
 import { FieldValues, Path, PathValue, useFormContext } from "react-hook-form";
 import { unpack } from "./helpers";
 import { Classes } from "./types";
@@ -11,6 +11,30 @@ type Common<T extends FieldValues, K extends Path<T>> = Omit<
   classes?: Classes;
   value: PathValue<T, K> extends string ? PathValue<T, K> : never;
 };
+
+export function _Radio<T extends FieldValues, K extends Path<T>>(
+  { children, classes, ...rest }: Common<T, K>,
+  ref: any
+) {
+  const id = `__${rest.name}-${rest.value}`;
+  const { container, input } = unpack(classes);
+
+  return (
+    <label className={`radio ${container}`} htmlFor={id}>
+      <input
+        {...rest}
+        ref={ref}
+        id={id}
+        type="radio"
+        className={`peer ${input}`}
+        disabled={rest.disabled}
+      />
+      {children || rest.value}
+    </label>
+  );
+}
+
+export const NativeRadio = forwardRef(_Radio) as typeof _Radio;
 
 export function Radio<T extends FieldValues, K extends Path<T>>({
   name,
@@ -28,27 +52,5 @@ export function Radio<T extends FieldValues, K extends Path<T>>({
       {...register(name as any)}
       {...rest}
     />
-  );
-}
-
-export function NativeRadio<T extends FieldValues, K extends Path<T>>({
-  children,
-  classes,
-  ...rest
-}: Common<T, K>) {
-  const id = `__${rest.name}-${rest.value}`;
-  const { container, input } = unpack(classes);
-
-  return (
-    <label className={`radio ${container}`} htmlFor={id}>
-      <input
-        {...rest}
-        id={id}
-        type="radio"
-        className={`peer ${input}`}
-        disabled={rest.disabled}
-      />
-      {children || rest.value}
-    </label>
   );
 }

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -1,19 +1,16 @@
-import { PropsWithChildren } from "react";
-import {
-  FieldValues,
-  Path,
-  PathValue,
-  UseFormRegisterReturn,
-  useFormContext,
-} from "react-hook-form";
+import { InputHTMLAttributes, ReactNode } from "react";
+import { FieldValues, Path, PathValue, useFormContext } from "react-hook-form";
 import { unpack } from "./helpers";
 import { Classes } from "./types";
 
-type Common<T extends FieldValues, K extends Path<T>> = PropsWithChildren<{
-  disabled?: boolean;
+type Common<T extends FieldValues, K extends Path<T>> = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "type" | "className" | "value"
+> & {
+  children?: ReactNode;
   classes?: Classes;
   value: PathValue<T, K> extends string ? PathValue<T, K> : never;
-}>;
+};
 
 export function Radio<T extends FieldValues, K extends Path<T>>({
   name,
@@ -27,8 +24,8 @@ export function Radio<T extends FieldValues, K extends Path<T>>({
 
   return (
     <NativeRadio
-      registerReturn={register(name as any)}
       disabled={isSubmitting || disabled}
+      {...register(name as any)}
       {...rest}
     />
   );
@@ -37,24 +34,21 @@ export function Radio<T extends FieldValues, K extends Path<T>>({
 export function NativeRadio<T extends FieldValues, K extends Path<T>>({
   children,
   classes,
-  value,
-  disabled,
-  registerReturn,
-}: Common<T, K> & { registerReturn: UseFormRegisterReturn }) {
-  const id = `__${registerReturn.name}-${value}`;
+  ...rest
+}: Common<T, K>) {
+  const id = `__${rest.name}-${rest.value}`;
   const { container, input } = unpack(classes);
 
   return (
     <label className={`radio ${container}`} htmlFor={id}>
       <input
-        {...registerReturn}
+        {...rest}
         id={id}
         type="radio"
         className={`peer ${input}`}
-        disabled={disabled}
-        value={value}
+        disabled={rest.disabled}
       />
-      {children || value}
+      {children || rest.value}
     </label>
   );
 }

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -1,37 +1,57 @@
 import { PropsWithChildren } from "react";
-import { FieldValues, Path, PathValue, useFormContext } from "react-hook-form";
+import {
+  FieldValues,
+  Path,
+  PathValue,
+  UseFormRegisterReturn,
+  useFormContext,
+} from "react-hook-form";
 import { unpack } from "./helpers";
 import { Classes } from "./types";
 
-type Props<T extends FieldValues, K extends Path<T>> = PropsWithChildren<{
-  name: K;
-  value: PathValue<T, K> extends string ? PathValue<T, K> : never;
-  classes?: Classes;
+type Common<T extends FieldValues, K extends Path<T>> = PropsWithChildren<{
   disabled?: boolean;
+  classes?: Classes;
+  value: PathValue<T, K> extends string ? PathValue<T, K> : never;
 }>;
 
 export function Radio<T extends FieldValues, K extends Path<T>>({
-  children,
-  classes,
   name,
-  value,
   disabled,
-}: Props<T, K>) {
-  const id = `__${name}-${value}`;
-  const { container, input } = unpack(classes);
+  ...rest
+}: Common<T, K> & UseFormRegisterReturn & { error?: string }) {
   const {
     register,
     formState: { isSubmitting },
   } = useFormContext<T>();
 
   return (
+    <NativeRadio
+      {...register(name as any)}
+      {...rest}
+      disabled={isSubmitting || disabled}
+    />
+  );
+}
+
+export function NativeRadio<T extends FieldValues, K extends Path<T>>({
+  children,
+  classes,
+  value,
+  disabled,
+  ...props
+}: Common<T, K> & UseFormRegisterReturn) {
+  const id = `__${name}-${value}`;
+  const { container, input } = unpack(classes);
+
+  return (
     <label className={`radio ${container}`} htmlFor={id}>
       <input
-        {...register(name)}
+        {...props}
         id={id}
         type="radio"
         className={`peer ${input}`}
-        disabled={isSubmitting || disabled}
+        disabled={disabled}
         value={value}
       />
       {children || value}

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -13,23 +13,23 @@ type Props<T extends FieldValues, K extends Path<T>> = Omit<
 };
 
 export function _Radio<T extends FieldValues, K extends Path<T>>(
-  { children, classes, ...rest }: Props<T, K>,
+  { children, classes, ...props }: Props<T, K>,
   ref: any
 ) {
-  const id = `__${rest.name}-${rest.value}`;
+  const id = `__${props.name}-${props.value}`;
   const { container, input } = unpack(classes);
 
   return (
     <label className={`radio ${container}`} htmlFor={id}>
       <input
-        {...rest}
+        {...props}
         ref={ref}
         id={id}
         type="radio"
         className={`peer ${input}`}
-        disabled={rest.disabled}
+        disabled={props.disabled}
       />
-      {children || rest.value}
+      {children || props.value}
     </label>
   );
 }

--- a/src/components/form/Radio.tsx
+++ b/src/components/form/Radio.tsx
@@ -41,7 +41,7 @@ export function NativeRadio<T extends FieldValues, K extends Path<T>>({
   disabled,
   ...props
 }: Common<T, K> & UseFormRegisterReturn) {
-  const id = `__${name}-${value}`;
+  const id = `__${props.name}-${value}`;
   const { container, input } = unpack(classes);
 
   return (


### PR DESCRIPTION
When creating new forms which fields are not even deep in the component tree still requires [additional context wrapping](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/2d06dedad8a404746bd3f774db8aaf25d9758cc1/src/components/donation/Steps/DonateMethods/PayPal/Form.tsx#L61) to make reusable components in (`/components/form/* `) work. 

As an example, `components/form/Field` wasn't reused in [RecipientDetailsForm](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/2d06dedad8a404746bd3f774db8aaf25d9758cc1/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx#L204) as form context is not provided there.




## Explanation of the solution
* extract `<NativeField/>` from `<Field/>` - but retain `<Field/>` context implementation to not affect our forms - do the same for `<CheckField/>` , `<Radio/>`, `<DateInput/>`
* reuse `<NativeField/>` in [`RecipientDetailsForm`](https://github.com/AngelProtocolFinance/angelprotocol-web-app/blob/2d06dedad8a404746bd3f774db8aaf25d9758cc1/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx#L204) and verify it's as functional as native `<input />`

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
