### PR TITLE
Closes BG-1134: set Splits currency code as uppercase by default

### DIFF
--- a/src/components/donation/Steps/Splits/Splits.tsx
+++ b/src/components/donation/Steps/Splits/Splits.tsx
@@ -31,7 +31,7 @@ export default function Split({
       }
       default:
         const { amount, currency } = details;
-        return [amount, currency.code.toUpperCase()];
+        return [amount, currency.code];
     }
   })();
 
@@ -87,14 +87,18 @@ export default function Split({
         <dl>
           <dt className="text-gray-d1 text-xs">Compounded Forever</dt>
           <dd>
-            <span className="text-xs font-medium mr-1">{symbol}</span>
+            <span className="text-xs font-medium mr-1">
+              {symbol.toUpperCase()}
+            </span>
             <span>{humanize(locked, DECIMALS)}</span>
           </dd>
         </dl>
         <dl>
           <dt className="text-gray-d1 text-xs">Instantly Available</dt>
           <dd className="text-right">
-            <span className="text-xs font-medium mr-1">{symbol}</span>
+            <span className="text-xs font-medium mr-1">
+              {symbol.toUpperCase()}
+            </span>
             <span>{humanize(liq, DECIMALS)}</span>
           </dd>
         </dl>


### PR DESCRIPTION
## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
