### PR TITLE
Update all input fields to trim start & end space characters

### DIFF
--- a/src/App/Footer/Newsletter/SubscriptionForm.tsx
+++ b/src/App/Footer/Newsletter/SubscriptionForm.tsx
@@ -21,6 +21,7 @@ export default function SubscriptionForm() {
     resolver: yupResolver(
       object({
         email: string()
+          .trim()
           .email("Invalid email format")
           .required("Please enter your email."),
       })

--- a/src/components/KYCForm/schema.ts
+++ b/src/components/KYCForm/schema.ts
@@ -5,18 +5,18 @@ import { FormValues as FV } from "./types";
 
 export const schema = object<any, SchemaShape<FV>>({
   name: object<any, SchemaShape<FV["name"]>>({
-    first: requiredString,
-    last: requiredString,
+    first: requiredString.trim(),
+    last: requiredString.trim(),
   }),
   address: object<any, SchemaShape<FV["address"]>>({
-    street: requiredString,
+    street: requiredString.trim(),
     //complement: optional
   }),
-  city: requiredString,
-  postalCode: requiredString,
+  city: requiredString.trim(),
+  postalCode: requiredString.trim(),
   country: object<any, SchemaShape<FV["country"]>>({
-    name: requiredString,
+    name: requiredString.trim(),
   }),
   //  usState: no need to validate, optional and preselected
-  kycEmail: requiredString.email("invalid"),
+  kycEmail: requiredString.trim().email("invalid"),
 }) as ObjectSchema<FV>;

--- a/src/components/donation/Steps/DonateMethods/ChariotConnect/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/ChariotConnect/Form.tsx
@@ -38,7 +38,7 @@ export default function Form({ recipient, widgetConfig, details }: Props) {
           (s) => s.required("required"),
           (n) => n.positive("must be greater than 0")
         ),
-        email: requiredString.email("invalid email"),
+        email: requiredString.trim().email("invalid email"),
       })
     ),
   });

--- a/src/components/donation/Steps/DonateMethods/PayPal/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/PayPal/Form.tsx
@@ -33,7 +33,7 @@ export default function Form({ recipient, details, widgetConfig }: Props) {
     defaultValues: details || initial,
     resolver: yupResolver(
       schema<FV>({
-        email: requiredString.email("invalid email"),
+        email: requiredString.trim().email("invalid email"),
         amount: stringNumber(
           (s) => s.required("required"),
           (n) =>

--- a/src/components/donation/Steps/DonateMethods/Stocks/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stocks/Form.tsx
@@ -20,9 +20,10 @@ export default function Form(props: StockFormStep) {
         },
     resolver: yupResolver(
       object({
-        symbol: string().required("required"),
+        symbol: string().required("required").trim(),
         numShares: string()
           .required("required")
+          .trim()
           .matches(/^[1-9]\d*$/, "invalid"),
       })
     ),

--- a/src/components/donation/Steps/DonateMethods/Stocks/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stocks/Form.tsx
@@ -2,8 +2,9 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { Field } from "components/form";
 import { FormProvider, UseFormReturn, useForm } from "react-hook-form";
 import { useDispatch } from "react-redux";
+import { requiredString } from "schemas/string";
 import { StockFormStep, setDetails } from "slices/donation";
-import { object, string } from "yup";
+import { object } from "yup";
 
 export default function Form(props: StockFormStep) {
   const dispatch = useDispatch();
@@ -20,11 +21,8 @@ export default function Form(props: StockFormStep) {
         },
     resolver: yupResolver(
       object({
-        symbol: string().required("required").trim(),
-        numShares: string()
-          .required("required")
-          .trim()
-          .matches(/^[1-9]\d*$/, "invalid"),
+        symbol: requiredString.trim(),
+        numShares: requiredString.trim().matches(/^[1-9]\d*$/, "invalid"),
       })
     ),
   });

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -33,7 +33,7 @@ export default function Form({ recipient, widgetConfig, details }: Props) {
     defaultValues: details || initial,
     resolver: yupResolver(
       schema<FV>({
-        email: requiredString.email("invalid email"),
+        email: requiredString.trim().email("invalid email"),
         amount: stringNumber(
           (s) => s.required("required"),
           (n) =>

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
@@ -29,7 +29,9 @@ export default function Prompt({ verdict, uuid }: Props) {
     resolver: yupResolver(
       object({
         reason:
-          verdict === "approve" ? string() : string().required("required"),
+          verdict === "approve"
+            ? string().trim()
+            : string().required("required").trim(),
       })
     ),
     defaultValues: { reason: "" },

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
@@ -12,6 +12,7 @@ import {
   UseFormReturn,
   useForm,
 } from "react-hook-form";
+import { requiredString } from "schemas/string";
 import { useUpdateBankingApplicationMutation } from "services/aws/banking-applications";
 import { object, string } from "yup";
 
@@ -28,10 +29,7 @@ export default function Prompt({ verdict, uuid }: Props) {
   const methods = useForm({
     resolver: yupResolver(
       object({
-        reason:
-          verdict === "approve"
-            ? string().trim()
-            : string().required("required").trim(),
+        reason: verdict === "approve" ? string().trim() : requiredString.trim(),
       })
     ),
     defaultValues: { reason: "" },

--- a/src/pages/Admin/Charity/EditProfile/schema.ts
+++ b/src/pages/Admin/Charity/EditProfile/schema.ts
@@ -28,14 +28,14 @@ export const schema = object<any, SchemaShape<FV>>({
   sdgs: array()
     .min(1, "required")
     .max(MAX_SDGS, `maximum ${MAX_SDGS} selections allowed`),
-  tagline: requiredString.max(140, "max length is 140 chars"),
+  tagline: requiredString.trim().max(140, "max length is 140 chars"),
   image: fileObj,
   card_img: fileObj,
   logo: fileObj,
   url: url,
   // registration_number: no need to validate,
   endow_designation: optionType({ required: true }),
-  name: requiredString,
+  name: requiredString.trim(),
   active_in_countries: array(),
   social_media_urls: object().shape<SchemaShape<FV["social_media_urls"]>>({
     facebook: url,

--- a/src/pages/Admin/Charity/Members/AddForm.tsx
+++ b/src/pages/Admin/Charity/Members/AddForm.tsx
@@ -26,9 +26,10 @@ export default function AddForm({ added, endowID }: Props) {
   const methods = useForm({
     resolver: yupResolver(
       object({
-        firstName: requiredString,
-        lastName: requiredString,
+        firstName: requiredString.trim(),
+        lastName: requiredString.trim(),
         email: requiredString
+          .trim()
           .email("invalid email")
           .notOneOf(added, "already a member"),
       })

--- a/src/pages/Admin/Charity/ProgramEditor/schema.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/schema.ts
@@ -24,10 +24,9 @@ const fileObj = object().shape<SchemaShape<ImgLink>>({
 
 const milesStoneSchema = object<any, SchemaShape<FormMilestone>>({
   milestone_date: date().typeError("invalid date"),
-  milestone_description: string().max(
-    MAX_CHARS,
-    `max length is ${MAX_CHARS} chars`
-  ),
+  milestone_description: string()
+    .trim()
+    .max(MAX_CHARS, `max length is ${MAX_CHARS} chars`),
   milestone_title: requiredString,
   milestone_media: fileObj,
 });

--- a/src/pages/Admin/Charity/ProgramEditor/schema.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/schema.ts
@@ -27,18 +27,17 @@ const milesStoneSchema = object<any, SchemaShape<FormMilestone>>({
   milestone_description: string()
     .trim()
     .max(MAX_CHARS, `max length is ${MAX_CHARS} chars`),
-  milestone_title: requiredString,
+  milestone_title: requiredString.trim(),
   milestone_media: fileObj,
 });
 
 //construct strict shape to avoid hardcoding shape keys
 
 export const schema = object<any, SchemaShape<FV>>({
-  title: requiredString,
-  description: requiredString.max(
-    MAX_CHARS,
-    `max length is ${MAX_CHARS} chars`
-  ),
+  title: requiredString.trim(),
+  description: requiredString
+    .trim()
+    .max(MAX_CHARS, `max length is ${MAX_CHARS} chars`),
   image: fileObj,
   milestones: array(milesStoneSchema),
 }) as ObjectSchema<FV>;

--- a/src/pages/Application/Prompt.tsx
+++ b/src/pages/Application/Prompt.tsx
@@ -12,6 +12,7 @@ import {
   UseFormReturn,
   useForm,
 } from "react-hook-form";
+import { requiredString } from "schemas/string";
 import { useReviewApplicationMutation } from "services/aws/aws";
 import { object, string } from "yup";
 
@@ -29,10 +30,7 @@ export default function Prompt({ verdict, orgName, uuid }: Props) {
   const methods = useForm({
     resolver: yupResolver(
       object({
-        reason:
-          verdict === "approve"
-            ? string().trim()
-            : string().required("required").trim(),
+        reason: verdict === "approve" ? string().trim() : requiredString.trim(),
       })
     ),
     defaultValues: { reason: "" },

--- a/src/pages/Application/Prompt.tsx
+++ b/src/pages/Application/Prompt.tsx
@@ -30,7 +30,9 @@ export default function Prompt({ verdict, orgName, uuid }: Props) {
     resolver: yupResolver(
       object({
         reason:
-          verdict === "approve" ? string() : string().required("required"),
+          verdict === "approve"
+            ? string().trim()
+            : string().required("required").trim(),
       })
     ),
     defaultValues: { reason: "" },

--- a/src/pages/Applications/Filter/schema.ts
+++ b/src/pages/Applications/Filter/schema.ts
@@ -23,6 +23,6 @@ export const schema = object<any, SchemaShape<FormValues>>({
             ? schema.min(ref(startKey), "can't be earlier than start date")
             : schema
         )
-      : string().required("invalid")
+      : string().required("invalid").trim()
   ),
 }) as ObjectSchema<FormValues>;

--- a/src/pages/BankingApplication/Prompt.tsx
+++ b/src/pages/BankingApplication/Prompt.tsx
@@ -29,7 +29,9 @@ export default function Prompt({ verdict, uuid }: Props) {
     resolver: yupResolver(
       object({
         reason:
-          verdict === "approve" ? string() : string().required("required"),
+          verdict === "approve"
+            ? string().trim()
+            : string().required("required").trim(),
       })
     ),
     defaultValues: { reason: "" },

--- a/src/pages/BankingApplication/Prompt.tsx
+++ b/src/pages/BankingApplication/Prompt.tsx
@@ -12,6 +12,7 @@ import {
   UseFormReturn,
   useForm,
 } from "react-hook-form";
+import { requiredString } from "schemas/string";
 import { useUpdateBankingApplicationMutation } from "services/aws/banking-applications";
 import { object, string } from "yup";
 
@@ -28,10 +29,7 @@ export default function Prompt({ verdict, uuid }: Props) {
   const methods = useForm({
     resolver: yupResolver(
       object({
-        reason:
-          verdict === "approve"
-            ? string().trim()
-            : string().required("required").trim(),
+        reason: verdict === "approve" ? string().trim() : requiredString.trim(),
       })
     ),
     defaultValues: { reason: "" },

--- a/src/pages/BankingApplications/Prompt.tsx
+++ b/src/pages/BankingApplications/Prompt.tsx
@@ -29,7 +29,9 @@ export default function Prompt({ verdict, uuid }: Props) {
     resolver: yupResolver(
       object({
         reason:
-          verdict === "approve" ? string() : string().required("required"),
+          verdict === "approve"
+            ? string().trim()
+            : string().required("required").trim(),
       })
     ),
     defaultValues: { reason: "" },

--- a/src/pages/BankingApplications/Prompt.tsx
+++ b/src/pages/BankingApplications/Prompt.tsx
@@ -12,6 +12,7 @@ import {
   UseFormReturn,
   useForm,
 } from "react-hook-form";
+import { requiredString } from "schemas/string";
 import { useUpdateBankingApplicationMutation } from "services/aws/banking-applications";
 import { object, string } from "yup";
 
@@ -28,10 +29,7 @@ export default function Prompt({ verdict, uuid }: Props) {
   const methods = useForm({
     resolver: yupResolver(
       object({
-        reason:
-          verdict === "approve"
-            ? string().trim()
-            : string().required("required").trim(),
+        reason: verdict === "approve" ? string().trim() : requiredString.trim(),
       })
     ),
     defaultValues: { reason: "" },

--- a/src/pages/Donations/Filter/schema.ts
+++ b/src/pages/Donations/Filter/schema.ts
@@ -23,6 +23,6 @@ export const schema = object<any, SchemaShape<FormValues>>({
             ? schema.min(ref(startKey), "can't be earlier than start date")
             : schema
         )
-      : string().required("invalid")
+      : string().required("invalid").trim()
   ),
 }) as ObjectSchema<FormValues>;

--- a/src/pages/Gift/Claim/index.tsx
+++ b/src/pages/Gift/Claim/index.tsx
@@ -12,7 +12,7 @@ export default function Claim({ classes = "" }) {
     },
     resolver: yupResolver(
       object({
-        secret: requiredString,
+        secret: requiredString.trim(),
       })
     ),
   });

--- a/src/pages/Gift/Mailer/schema.ts
+++ b/src/pages/Gift/Mailer/schema.ts
@@ -4,10 +4,10 @@ import { ObjectSchema, object, string } from "yup";
 import { FormValues as FV } from "./types";
 
 export const schema = object<any, SchemaShape<FV>>({
-  purchaser: requiredString,
+  purchaser: requiredString.trim(),
   recipient: object<any, SchemaShape<FV["recipient"]>>({
-    name: requiredString,
-    email: requiredString.email("invalid email"),
+    name: requiredString.trim(),
+    email: requiredString.trim().email("invalid email"),
   }),
-  message: string(),
+  message: string().trim(),
 }) as ObjectSchema<FV>;

--- a/src/pages/Registration/Resume/index.tsx
+++ b/src/pages/Registration/Resume/index.tsx
@@ -12,7 +12,7 @@ export default function Resume({ classes = "" }: { classes?: string }) {
     },
     resolver: yupResolver(
       object({
-        reference: string().required("required"),
+        reference: string().required("required").trim(),
       })
     ),
   });

--- a/src/pages/Registration/Resume/index.tsx
+++ b/src/pages/Registration/Resume/index.tsx
@@ -1,7 +1,8 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import { getSavedRegistrationReference } from "helpers";
 import { FormProvider, useForm } from "react-hook-form";
-import { object, string } from "yup";
+import { requiredString } from "schemas/string";
+import { object } from "yup";
 import Form from "./Form";
 import { FormValues } from "./types";
 
@@ -12,7 +13,7 @@ export default function Resume({ classes = "" }: { classes?: string }) {
     },
     resolver: yupResolver(
       object({
-        reference: string().required("required").trim(),
+        reference: requiredString.trim(),
       })
     ),
   });

--- a/src/pages/Registration/Steps/ContactDetails/schema.ts
+++ b/src/pages/Registration/Steps/ContactDetails/schema.ts
@@ -10,25 +10,29 @@ type Key = keyof FormValues;
 const roleKey: Key = "Role";
 const referralMethodKey: Key = "ReferralMethod";
 
-const otherRole = string().when(roleKey, ([option], schema) =>
-  (option as OptionType<ContactRoles>).value === "other"
-    ? schema.required("required")
-    : schema
-);
-
-const otherReferralMethod = (referralMethod: ReferralMethods) =>
-  string().when(referralMethodKey, ([option], schema) =>
-    (option as OptionType<ReferralMethods>).value === referralMethod
+const otherRole = string()
+  .trim()
+  .when(roleKey, ([option], schema) =>
+    (option as OptionType<ContactRoles>).value === "other"
       ? schema.required("required")
       : schema
   );
 
+const otherReferralMethod = (referralMethod: ReferralMethods) =>
+  string()
+    .trim()
+    .when(referralMethodKey, ([option], schema) =>
+      (option as OptionType<ReferralMethods>).value === referralMethod
+        ? schema.required("required")
+        : schema
+    );
+
 export const schema = object<any, SchemaShape<FormValues>>({
-  OrganizationName: requiredString,
-  FirstName: requiredString,
-  LastName: requiredString,
+  OrganizationName: requiredString.trim(),
+  FirstName: requiredString.trim(),
+  LastName: requiredString.trim(),
   //email: disabled: already validated at signup
-  Goals: requiredString,
+  Goals: requiredString.trim(),
   Role: optionType({ required: true }),
   ReferralMethod: optionType({ required: true }),
   OtherReferralMethod: otherReferralMethod("other"),

--- a/src/pages/Registration/Steps/Documentation/FSA/schema.ts
+++ b/src/pages/Registration/Steps/Documentation/FSA/schema.ts
@@ -22,12 +22,11 @@ const assetShape = fileDropzoneAssetShape(
 );
 
 export const schema = object<any, SchemaShape<FormValues>>({
-  RegistrationNumber: requiredString,
+  RegistrationNumber: requiredString.trim(),
   ProofOfIdentity: assetShape,
   ProofOfRegistration: assetShape,
-  LegalEntityType: requiredString,
-  ProjectDescription: requiredString.max(
-    4000,
-    "maximum 4000 characters allowed"
-  ),
+  LegalEntityType: requiredString.trim(),
+  ProjectDescription: requiredString
+    .trim()
+    .max(4000, "maximum 4000 characters allowed"),
 }) as ObjectSchema<FormValues>;

--- a/src/pages/Registration/Steps/Documentation/NonFSA/NonFSA.tsx
+++ b/src/pages/Registration/Steps/Documentation/NonFSA/NonFSA.tsx
@@ -13,7 +13,9 @@ export default function NonFSA(props: Props) {
   const { data } = useRegState<4>();
   const { doc } = props;
   const methods = useForm<FV>({
-    resolver: yupResolver(object({ EIN: string().required("required") })),
+    resolver: yupResolver(
+      object({ EIN: string().required("required").trim() })
+    ),
     defaultValues: doc
       ? doc
       : {

--- a/src/pages/Registration/Steps/Documentation/NonFSA/NonFSA.tsx
+++ b/src/pages/Registration/Steps/Documentation/NonFSA/NonFSA.tsx
@@ -3,7 +3,8 @@ import LoadText from "components/LoadText";
 import { Field } from "components/form";
 import { FormProvider, useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
-import { object, string } from "yup";
+import { requiredString } from "schemas/string";
+import { object } from "yup";
 import { steps } from "../../../routes";
 import { useRegState } from "../../StepGuard";
 import { FormValues as FV, Props } from "./types";
@@ -13,9 +14,7 @@ export default function NonFSA(props: Props) {
   const { data } = useRegState<4>();
   const { doc } = props;
   const methods = useForm<FV>({
-    resolver: yupResolver(
-      object({ EIN: string().required("required").trim() })
-    ),
+    resolver: yupResolver(object({ EIN: requiredString.trim() })),
     defaultValues: doc
       ? doc
       : {

--- a/src/pages/Registration/Steps/OrgDetails/schema.ts
+++ b/src/pages/Registration/Steps/OrgDetails/schema.ts
@@ -12,7 +12,7 @@ export const schema = object<any, SchemaShape<FormValues>>({
     .min(1, "required")
     .max(MAX_SDGS, `maximum ${MAX_SDGS} selections allowed`),
   HqCountry: object<any, SchemaShape<Country>>({
-    name: requiredString,
+    name: requiredString.trim(),
   }),
   EndowDesignation: optionType({ required: true }),
 }) as ObjectSchema<FormValues>;

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -15,7 +15,7 @@ import { SchemaShape } from "./types";
 
 /**
  * No need to trim the value, as Yup's cast when calling `number()`
- * parses the value ignoring leading/trailing whitespaces,
+ * parses the value ignoring leading/trailing whitespaces.
  *
  * See https://github.com/jquense/yup?tab=readme-ov-file#number
  */

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -19,7 +19,7 @@ export const stringNumber = (
 ) =>
   lazy((v) =>
     !v && typeof v !== "number"
-      ? str(string().trim())
+      ? str(string())
       : num(number().typeError("must be a number"))
   );
 

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -13,6 +13,12 @@ import { requiredString } from "./string";
 import { testTokenDigits } from "./tests";
 import { SchemaShape } from "./types";
 
+/**
+ * No need to trim the value, as Yup's cast when calling `number()`
+ * parses the value ignoring leading/trailing whitespaces,
+ *
+ * See https://github.com/jquense/yup?tab=readme-ov-file#number
+ */
 export const stringNumber = (
   str: (schema: StringSchema) => StringSchema,
   num: (schema: NumberSchema) => NumberSchema

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -19,7 +19,7 @@ export const stringNumber = (
 ) =>
   lazy((v) =>
     !v && typeof v !== "number"
-      ? str(string())
+      ? str(string().trim())
       : num(number().typeError("must be a number"))
   );
 

--- a/src/schemas/string.ts
+++ b/src/schemas/string.ts
@@ -9,7 +9,7 @@ export const requiredString = Yup.string().required("required");
 
 export const walletAddr = (chainId: ChainID) =>
   Yup.lazy((val) =>
-    val === ""
+    !val || (typeof val === "string" && val.trim() === "")
       ? Yup.string()
       : Yup.string()
           .trim()

--- a/src/schemas/string.ts
+++ b/src/schemas/string.ts
@@ -9,7 +9,7 @@ export const requiredString = Yup.string().required("required");
 
 export const walletAddr = (chainId: ChainID) =>
   Yup.lazy((val) =>
-    !val || (typeof val === "string" && val.trim() === "")
+    val === ""
       ? Yup.string()
       : Yup.string()
           .trim()

--- a/src/schemas/string.ts
+++ b/src/schemas/string.ts
@@ -11,13 +11,13 @@ export const walletAddr = (chainId: ChainID) =>
   Yup.lazy((val) =>
     val === ""
       ? Yup.string()
-      : Yup.string().matches(
-          walletAddrPatten(chainId),
-          "wallet address not valid"
-        )
+      : Yup.string()
+          .trim()
+          .matches(walletAddrPatten(chainId), "wallet address not valid")
   );
 
 export const url = Yup.string()
+  .trim()
   /** though our validation library also supports http and ftp,
    * Our use case is fairly limited to user giving us links to their social media or website
    * which is widespread to be on https.


### PR DESCRIPTION
## Explanation of the solution
Towards BG-1143

- added [Yup.string().trim()](https://github.com/jquense/yup?tab=readme-ov-file#stringtrimmessage-string--function-schema) wherever appropriate
- use the opportunity to swap all `Yup.string().required("required")` instances with `requiredString`.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

