### PR TITLE
Change method state reset

### DIFF
--- a/src/slices/donation/donation.ts
+++ b/src/slices/donation/donation.ts
@@ -23,10 +23,15 @@ const donation = createSlice({
       return { step: "donate-form", recipient: payload };
     },
     setDetails: (state, { payload }: PayloadAction<DonationDetails>) => {
+      const curr: DonationState =
+        state.step === "donate-form" && state.details?.method !== payload.method
+          ? { step: "donate-form", recipient: state.recipient }
+          : state;
+
       //skip KYC for stocks, as not being saved in DB
       if (payload.method === "stocks") {
         return {
-          ...(state as SubmitStep),
+          ...(curr as SubmitStep),
           step: "submit",
           details: payload,
         };
@@ -34,13 +39,13 @@ const donation = createSlice({
 
       if (state.recipient?.isKYCRequired || payload.userOptForKYC) {
         return {
-          ...(state as KYCStep),
+          ...(curr as KYCStep),
           step: "kyc-form",
           details: payload,
         };
       }
       return {
-        ...(state as SplitsStep),
+        ...(curr as SplitsStep),
         step: "splits",
         details: payload,
       };


### PR DESCRIPTION
SCENARIO:
user proceeds with `card`, set `split:23`, `tip:17%`,
user changes mind, proceeds with `crypto` - should parameters from old steps be retained ?

## Explanation of the solution


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
