### PR TITLE
Update RichTextEditor content parameter to always keep track of number of characters

### DIFF
--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -48,10 +48,6 @@ export default function RichText(props: Props) {
         const numChars = quill.getLength() - 1;
         setNumChars(numChars);
 
-        if (props.charLimit && numChars > props.charLimit) {
-          return props.onError(`character limit reached`);
-        }
-
         props.onChange({
           //quill clean state has residual `\n`
           value: numChars <= 0 ? "" : JSON.stringify(quill.getContents()),

--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -5,86 +5,86 @@ import { Props } from "./types";
 import "./richtext.css";
 
 export default function RichText(props: Props) {
-	const [numChars, setNumChars] = useState(props.content.length ?? 0);
+  const [numChars, setNumChars] = useState(props.content.length ?? 0);
 
-	const containerRef = useCallback((container: HTMLDivElement | null) => {
-		if (!container) return;
+  const containerRef = useCallback((container: HTMLDivElement | null) => {
+    if (!container) return;
 
-		const quill = new Quill(container, {
-			placeholder: props.placeHolder,
-			readOnly: props.readOnly,
-			theme: "snow",
-			formats: ["bold", "italic", "indent", "list"],
-			modules: {
-				toolbar: [
-					["bold", "italic"],
-					[{ list: "ordered" }, { list: "bullet" }],
-				],
-			},
-		});
+    const quill = new Quill(container, {
+      placeholder: props.placeHolder,
+      readOnly: props.readOnly,
+      theme: "snow",
+      formats: ["bold", "italic", "indent", "list"],
+      modules: {
+        toolbar: [
+          ["bold", "italic"],
+          [{ list: "ordered" }, { list: "bullet" }],
+        ],
+      },
+    });
 
-		try {
-			quill.setContents(JSON.parse(props.content.value));
-		} catch (err) {
-			//previous rich text format based on draft-js will throw parse error
-			//in this case just set it to blank
-			quill.setContents(quill.getContents());
-		} finally {
-			// set initial number of chars
-			setNumChars(quill.getLength() - 1);
-		}
+    try {
+      quill.setContents(JSON.parse(props.content.value));
+    } catch (err) {
+      //previous rich text format based on draft-js will throw parse error
+      //in this case just set it to blank
+      quill.setContents(quill.getContents());
+    } finally {
+      // set initial number of chars
+      setNumChars(quill.getLength() - 1);
+    }
 
-		if (!props.readOnly) {
-			/** even if quill is empty, it's string value for form purposes is not.
+    if (!props.readOnly) {
+      /** even if quill is empty, it's string value for form purposes is not.
       after mounting, set form value to "", so that form state with initially empty quill value
       will be blocked by validation on re-submit
       */
-			if (quill.getLength() <= 1) {
-				props.onChange({ value: "", length: 0 });
-			}
+      if (quill.getLength() <= 1) {
+        props.onChange({ value: "", length: 0 });
+      }
 
-			quill.on("editor-change", function handleChange() {
-				//quill content min length is 1
-				const numChars = quill.getLength() - 1;
-				setNumChars(numChars);
+      quill.on("editor-change", function handleChange() {
+        //quill content min length is 1
+        const numChars = quill.getLength() - 1;
+        setNumChars(numChars);
 
-				if (props.charLimit && numChars > props.charLimit) {
-					return props.onError(`character limit reached`);
-				}
+        if (props.charLimit && numChars > props.charLimit) {
+          return props.onError(`character limit reached`);
+        }
 
-				props.onChange({
-					//quill clean state has residual `\n`
-					value: numChars <= 0 ? "" : JSON.stringify(quill.getContents()),
-					length: numChars,
-				});
-			});
-		}
-		//eslint-disable-next-line
-	}, []);
+        props.onChange({
+          //quill clean state has residual `\n`
+          value: numChars <= 0 ? "" : JSON.stringify(quill.getContents()),
+          length: numChars,
+        });
+      });
+    }
+    //eslint-disable-next-line
+  }, []);
 
-	return (
-		<div
-			aria-invalid={props.invalid}
-			aria-disabled={props.disabled}
-			className={`relative ${props.classes?.container || ""} ${
-				props.readOnly ? "toolbar-hidden" : ""
-			}`}
-		>
-			<div
-				style={{ fontFamily: "inherit", fontSize: "inherit" }}
-				className="w-full h-full text-base"
-				ref={containerRef}
-			/>
-			{!props.readOnly && (
-				<span
-					className={`absolute top-4 right-4 text-xs uppercase ${
-						props.classes?.charCounter ?? ""
-					}`}
-				>
-					chars : {numChars}
-					{props.charLimit && ` /${props.charLimit}`}
-				</span>
-			)}
-		</div>
-	);
+  return (
+    <div
+      aria-invalid={props.invalid}
+      aria-disabled={props.disabled}
+      className={`relative ${props.classes?.container || ""} ${
+        props.readOnly ? "toolbar-hidden" : ""
+      }`}
+    >
+      <div
+        style={{ fontFamily: "inherit", fontSize: "inherit" }}
+        className="w-full h-full text-base"
+        ref={containerRef}
+      />
+      {!props.readOnly && (
+        <span
+          className={`absolute top-4 right-4 text-xs uppercase ${
+            props.classes?.charCounter ?? ""
+          }`}
+        >
+          chars : {numChars}
+          {props.charLimit && ` /${props.charLimit}`}
+        </span>
+      )}
+    </div>
+  );
 }

--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -5,85 +5,86 @@ import { Props } from "./types";
 import "./richtext.css";
 
 export default function RichText(props: Props) {
-  const [numChars, setNumChars] = useState(0);
+	const [numChars, setNumChars] = useState(props.content.length);
 
-  const containerRef = useCallback((container: HTMLDivElement | null) => {
-    if (!container) return;
+	const containerRef = useCallback((container: HTMLDivElement | null) => {
+		if (!container) return;
 
-    const quill = new Quill(container, {
-      placeholder: props.placeHolder,
-      readOnly: props.readOnly,
-      theme: "snow",
-      formats: ["bold", "italic", "indent", "list"],
-      modules: {
-        toolbar: [
-          ["bold", "italic"],
-          [{ list: "ordered" }, { list: "bullet" }],
-        ],
-      },
-    });
+		const quill = new Quill(container, {
+			placeholder: props.placeHolder,
+			readOnly: props.readOnly,
+			theme: "snow",
+			formats: ["bold", "italic", "indent", "list"],
+			modules: {
+				toolbar: [
+					["bold", "italic"],
+					[{ list: "ordered" }, { list: "bullet" }],
+				],
+			},
+		});
 
-    try {
-      quill.setContents(JSON.parse(props.content));
-    } catch (err) {
-      //previous rich text format based on draft-js will throw parse error
-      //in this case just set it to blank
-      quill.setContents(quill.getContents());
-    } finally {
-      // set initial number of chars
-      setNumChars(quill.getLength() - 1);
-    }
+		try {
+			quill.setContents(JSON.parse(props.content.value));
+		} catch (err) {
+			//previous rich text format based on draft-js will throw parse error
+			//in this case just set it to blank
+			quill.setContents(quill.getContents());
+		} finally {
+			// set initial number of chars
+			setNumChars(quill.getLength() - 1);
+		}
 
-    if (!props.readOnly) {
-      /** even if quill is empty, it's string value for form purposes is not.
+		if (!props.readOnly) {
+			/** even if quill is empty, it's string value for form purposes is not.
       after mounting, set form value to "", so that form state with initially empty quill value
       will be blocked by validation on re-submit
       */
-      if (quill.getLength() <= 1) {
-        props.onChange("");
-      }
+			if (quill.getLength() <= 1) {
+				props.onChange({ value: "", length: 0 });
+			}
 
-      quill.on("editor-change", function handleChange() {
-        //quill content min length is 1
-        const numChars = quill.getLength() - 1;
-        setNumChars(numChars);
+			quill.on("editor-change", function handleChange() {
+				//quill content min length is 1
+				const numChars = quill.getLength() - 1;
+				setNumChars(numChars);
 
-        if (props.charLimit && numChars > props.charLimit) {
-          return props.onError(`character limit reached`);
-        }
+				if (props.charLimit && numChars > props.charLimit) {
+					return props.onError(`character limit reached`);
+				}
 
-        props.onChange(
-          //quill clean state has residual `\n`
-          numChars <= 0 ? "" : JSON.stringify(quill.getContents())
-        );
-      });
-    }
-    //eslint-disable-next-line
-  }, []);
+				props.onChange({
+					//quill clean state has residual `\n`
+					value: numChars <= 0 ? "" : JSON.stringify(quill.getContents()),
+					length: numChars,
+				});
+			});
+		}
+		//eslint-disable-next-line
+	}, []);
 
-  return (
-    <div
-      aria-invalid={props.invalid}
-      aria-disabled={props.disabled}
-      className={`relative ${props.classes?.container || ""} ${
-        props.readOnly ? "toolbar-hidden" : ""
-      }`}
-    >
-      <div
-        style={{ fontFamily: "inherit", fontSize: "inherit" }}
-        className="w-full h-full text-base"
-        ref={containerRef}
-      />
-      {!props.readOnly && (
-        <span
-          className={`absolute top-4 right-4 text-xs uppercase ${
-            props.classes?.charCounter ?? ""
-          }`}
-        >
-          chars : {numChars}
-          {props.charLimit && ` /${props.charLimit}`}
-        </span>
-      )}
-    </div>
-  );
+	return (
+		<div
+			aria-invalid={props.invalid}
+			aria-disabled={props.disabled}
+			className={`relative ${props.classes?.container || ""} ${
+				props.readOnly ? "toolbar-hidden" : ""
+			}`}
+		>
+			<div
+				style={{ fontFamily: "inherit", fontSize: "inherit" }}
+				className="w-full h-full text-base"
+				ref={containerRef}
+			/>
+			{!props.readOnly && (
+				<span
+					className={`absolute top-4 right-4 text-xs uppercase ${
+						props.classes?.charCounter ?? ""
+					}`}
+				>
+					chars : {numChars}
+					{props.charLimit && ` /${props.charLimit}`}
+				</span>
+			)}
+		</div>
+	);
 }

--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -5,7 +5,7 @@ import { Props } from "./types";
 import "./richtext.css";
 
 export default function RichText(props: Props) {
-  const [numChars, setNumChars] = useState(props.content.length ?? 0);
+  const [numChars, setNumChars] = useState(0);
 
   const containerRef = useCallback((container: HTMLDivElement | null) => {
     if (!container) return;

--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -5,7 +5,7 @@ import { Props } from "./types";
 import "./richtext.css";
 
 export default function RichText(props: Props) {
-	const [numChars, setNumChars] = useState(props.content.length);
+	const [numChars, setNumChars] = useState(props.content.length ?? 0);
 
 	const containerRef = useCallback((container: HTMLDivElement | null) => {
 		if (!container) return;

--- a/src/components/RichText/RichTextEditor.tsx
+++ b/src/components/RichText/RichTextEditor.tsx
@@ -14,7 +14,7 @@ export function RichTextEditor<T extends FieldValues>(
   props: {
     fieldName: Path<T>;
     classes?: EditorClasses & { error?: string };
-  } & Pick<Editable, "charLimit" | "placeHolder">,
+  } & Pick<Editable, "charLimit" | "placeHolder">
 ) {
   const {
     setError,

--- a/src/components/RichText/RichTextEditor.tsx
+++ b/src/components/RichText/RichTextEditor.tsx
@@ -1,52 +1,52 @@
 import { ErrorMessage } from "@hookform/error-message";
 import "quill/dist/quill.bubble.css";
 import {
-  FieldValues,
-  Path,
-  get,
-  useController,
-  useFormContext,
+	FieldValues,
+	Path,
+	get,
+	useController,
+	useFormContext,
 } from "react-hook-form";
-import { Editable, EditorClasses } from "./types";
 import RichText from "./RichText";
+import { Editable, EditorClasses } from "./types";
 
 export function RichTextEditor<T extends FieldValues>(
-  props: {
-    fieldName: Path<T>;
-    classes?: EditorClasses & { error?: string };
-  } & Pick<Editable, "charLimit" | "placeHolder">
+	props: {
+		fieldName: Path<T>;
+		classes?: EditorClasses & { error?: string };
+	} & Pick<Editable, "charLimit" | "placeHolder">,
 ) {
-  const {
-    setError,
-    formState: { isSubmitting },
-  } = useFormContext<T>();
-  const {
-    formState: { errors },
-    field: { value, onChange },
-  } = useController<T>({ name: props.fieldName });
+	const {
+		setError,
+		formState: { isSubmitting },
+	} = useFormContext<T>();
+	const {
+		formState: { errors },
+		field: { value, onChange },
+	} = useController<T>({ name: props.fieldName });
 
-  const invalid = !!get(errors, props.fieldName);
+	const invalid = !!get(errors, props.fieldName);
 
-  return (
-    <>
-      <RichText
-        content={value}
-        onChange={onChange}
-        onError={(error) => {
-          setError(props.fieldName, { message: error });
-        }}
-        placeHolder={props.placeHolder}
-        charLimit={props.charLimit}
-        classes={props.classes}
-        disabled={isSubmitting}
-        invalid={invalid}
-      />
-      <ErrorMessage
-        errors={errors}
-        name={props.fieldName as any}
-        as="p"
-        className={props.classes?.error}
-      />
-    </>
-  );
+	return (
+		<>
+			<RichText
+				content={value}
+				onChange={onChange}
+				onError={(error) => {
+					setError(props.fieldName, { message: error });
+				}}
+				placeHolder={props.placeHolder}
+				charLimit={props.charLimit}
+				classes={props.classes}
+				disabled={isSubmitting}
+				invalid={invalid}
+			/>
+			<ErrorMessage
+				errors={errors}
+				name={props.fieldName as any}
+				as="p"
+				className={props.classes?.error}
+			/>
+		</>
+	);
 }

--- a/src/components/RichText/RichTextEditor.tsx
+++ b/src/components/RichText/RichTextEditor.tsx
@@ -1,52 +1,52 @@
 import { ErrorMessage } from "@hookform/error-message";
 import "quill/dist/quill.bubble.css";
 import {
-	FieldValues,
-	Path,
-	get,
-	useController,
-	useFormContext,
+  FieldValues,
+  Path,
+  get,
+  useController,
+  useFormContext,
 } from "react-hook-form";
 import RichText from "./RichText";
 import { Editable, EditorClasses } from "./types";
 
 export function RichTextEditor<T extends FieldValues>(
-	props: {
-		fieldName: Path<T>;
-		classes?: EditorClasses & { error?: string };
-	} & Pick<Editable, "charLimit" | "placeHolder">,
+  props: {
+    fieldName: Path<T>;
+    classes?: EditorClasses & { error?: string };
+  } & Pick<Editable, "charLimit" | "placeHolder">,
 ) {
-	const {
-		setError,
-		formState: { isSubmitting },
-	} = useFormContext<T>();
-	const {
-		formState: { errors },
-		field: { value, onChange },
-	} = useController<T>({ name: props.fieldName });
+  const {
+    setError,
+    formState: { isSubmitting },
+  } = useFormContext<T>();
+  const {
+    formState: { errors },
+    field: { value, onChange },
+  } = useController<T>({ name: props.fieldName });
 
-	const invalid = !!get(errors, props.fieldName);
+  const invalid = !!get(errors, props.fieldName);
 
-	return (
-		<>
-			<RichText
-				content={value}
-				onChange={onChange}
-				onError={(error) => {
-					setError(props.fieldName, { message: error });
-				}}
-				placeHolder={props.placeHolder}
-				charLimit={props.charLimit}
-				classes={props.classes}
-				disabled={isSubmitting}
-				invalid={invalid}
-			/>
-			<ErrorMessage
-				errors={errors}
-				name={props.fieldName as any}
-				as="p"
-				className={props.classes?.error}
-			/>
-		</>
-	);
+  return (
+    <>
+      <RichText
+        content={value}
+        onChange={onChange}
+        onError={(error) => {
+          setError(props.fieldName, { message: error });
+        }}
+        placeHolder={props.placeHolder}
+        charLimit={props.charLimit}
+        classes={props.classes}
+        disabled={isSubmitting}
+        invalid={invalid}
+      />
+      <ErrorMessage
+        errors={errors}
+        name={props.fieldName as any}
+        as="p"
+        className={props.classes?.error}
+      />
+    </>
+  );
 }

--- a/src/components/RichText/RichTextEditor.tsx
+++ b/src/components/RichText/RichTextEditor.tsx
@@ -17,7 +17,6 @@ export function RichTextEditor<T extends FieldValues>(
   } & Pick<Editable, "charLimit" | "placeHolder">
 ) {
   const {
-    setError,
     formState: { isSubmitting },
   } = useFormContext<T>();
   const {
@@ -32,9 +31,6 @@ export function RichTextEditor<T extends FieldValues>(
       <RichText
         content={value}
         onChange={onChange}
-        onError={(error) => {
-          setError(props.fieldName, { message: error });
-        }}
         placeHolder={props.placeHolder}
         charLimit={props.charLimit}
         classes={props.classes}

--- a/src/components/RichText/RichTextEditor.tsx
+++ b/src/components/RichText/RichTextEditor.tsx
@@ -7,8 +7,8 @@ import {
   useController,
   useFormContext,
 } from "react-hook-form";
-import RichText from "./RichText";
 import { Editable, EditorClasses } from "./types";
+import RichText from "./RichText";
 
 export function RichTextEditor<T extends FieldValues>(
   props: {

--- a/src/components/RichText/types.ts
+++ b/src/components/RichText/types.ts
@@ -5,7 +5,7 @@ type ReadOnly = {
 
 export type Editable = {
   readOnly?: never;
-  onChange(...event: any[]): void;
+  onChange(content: RichTextContent): void;
   onError(error: string): void;
   placeHolder?: string;
   charLimit?: number;
@@ -16,6 +16,11 @@ export type Editable = {
 export type EditorClasses = { container?: string; charCounter?: string };
 
 export type Props = (ReadOnly | Editable) & {
-  content: string;
+  content: RichTextContent;
   classes?: EditorClasses;
+};
+
+export type RichTextContent = {
+  value: string;
+  length: number;
 };

--- a/src/components/RichText/types.ts
+++ b/src/components/RichText/types.ts
@@ -1,23 +1,23 @@
 import { RichTextContent } from "types/components";
 
 type ReadOnly = {
-	readOnly: true;
-	//map editable attr to never
+  readOnly: true;
+  //map editable attr to never
 } & Partial<{ [key in keyof Omit<Editable, "readOnly">]?: never }>;
 
 export type Editable = {
-	readOnly?: never;
-	onChange(content: Required<RichTextContent>): void;
-	onError(error: string): void;
-	placeHolder?: string;
-	charLimit?: number;
-	disabled?: boolean;
-	invalid?: boolean;
+  readOnly?: never;
+  onChange(content: Required<RichTextContent>): void;
+  onError(error: string): void;
+  placeHolder?: string;
+  charLimit?: number;
+  disabled?: boolean;
+  invalid?: boolean;
 };
 
 export type EditorClasses = { container?: string; charCounter?: string };
 
 export type Props = (ReadOnly | Editable) & {
-	content: RichTextContent;
-	classes?: EditorClasses;
+  content: RichTextContent;
+  classes?: EditorClasses;
 };

--- a/src/components/RichText/types.ts
+++ b/src/components/RichText/types.ts
@@ -1,26 +1,23 @@
+import { RichTextContent } from "types/components";
+
 type ReadOnly = {
-  readOnly: true;
-  //map editable attr to never
+	readOnly: true;
+	//map editable attr to never
 } & Partial<{ [key in keyof Omit<Editable, "readOnly">]?: never }>;
 
 export type Editable = {
-  readOnly?: never;
-  onChange(content: RichTextContent): void;
-  onError(error: string): void;
-  placeHolder?: string;
-  charLimit?: number;
-  disabled?: boolean;
-  invalid?: boolean;
+	readOnly?: never;
+	onChange(content: RichTextContent): void;
+	onError(error: string): void;
+	placeHolder?: string;
+	charLimit?: number;
+	disabled?: boolean;
+	invalid?: boolean;
 };
 
 export type EditorClasses = { container?: string; charCounter?: string };
 
 export type Props = (ReadOnly | Editable) & {
-  content: RichTextContent;
-  classes?: EditorClasses;
-};
-
-export type RichTextContent = {
-  value: string;
-  length: number;
+	content: RichTextContent;
+	classes?: EditorClasses;
 };

--- a/src/components/RichText/types.ts
+++ b/src/components/RichText/types.ts
@@ -8,7 +8,6 @@ type ReadOnly = {
 export type Editable = {
   readOnly?: never;
   onChange(content: Required<RichTextContent>): void;
-  onError(error: string): void;
   placeHolder?: string;
   charLimit?: number;
   disabled?: boolean;

--- a/src/components/RichText/types.ts
+++ b/src/components/RichText/types.ts
@@ -18,6 +18,6 @@ export type Editable = {
 export type EditorClasses = { container?: string; charCounter?: string };
 
 export type Props = (ReadOnly | Editable) & {
-  content: RichTextContent;
+  content: Pick<RichTextContent, "value">;
   classes?: EditorClasses;
 };

--- a/src/components/RichText/types.ts
+++ b/src/components/RichText/types.ts
@@ -7,7 +7,7 @@ type ReadOnly = {
 
 export type Editable = {
 	readOnly?: never;
-	onChange(content: RichTextContent): void;
+	onChange(content: Required<RichTextContent>): void;
 	onError(error: string): void;
 	placeHolder?: string;
 	charLimit?: number;

--- a/src/components/RichText/types.ts
+++ b/src/components/RichText/types.ts
@@ -18,6 +18,11 @@ export type Editable = {
 export type EditorClasses = { container?: string; charCounter?: string };
 
 export type Props = (ReadOnly | Editable) & {
+  /**
+   * Setting this type to be compatible with RichTextContent makes it
+   * unnecessary for RichTextEditor to define complicated type to make
+   * its value content value compatible with type of RichText.content.
+   */
   content: Pick<RichTextContent, "value">;
   classes?: EditorClasses;
 };

--- a/src/pages/Admin/Charity/EditProfile/Form.tsx
+++ b/src/pages/Admin/Charity/EditProfile/Form.tsx
@@ -15,7 +15,7 @@ import { Field, Label } from "components/form";
 import { appRoutes } from "constants/routes";
 import { unsdgs } from "constants/unsdgs";
 import { getSDGLabelValuePair } from "./getSDGLabelValuePair";
-import { MAX_SIZE_IN_BYTES, VALID_MIME_TYPES } from "./schema";
+import { MAX_CHARS, MAX_SIZE_IN_BYTES, VALID_MIME_TYPES } from "./schema";
 import useEditProfile from "./useEditProfile";
 
 const sdgOptions = Object.entries(unsdgs).map(([key, { title }]) =>
@@ -95,7 +95,7 @@ export default function Form() {
         <RichTextEditor<FV>
           fieldName="overview"
           placeHolder="A short overview of your organization"
-          charLimit={4000}
+          charLimit={MAX_CHARS}
           classes={{
             container:
               "rich-text-toolbar border border-prim text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",

--- a/src/pages/Admin/Charity/EditProfile/index.tsx
+++ b/src/pages/Admin/Charity/EditProfile/index.tsx
@@ -2,8 +2,8 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { FormProvider, useForm } from "react-hook-form";
 import { FV } from "./types";
 import {
-	EndowmentProfileUpdate,
-	EndowmentProfile as TProfile,
+  EndowmentProfileUpdate,
+  EndowmentProfile as TProfile,
 } from "types/aws";
 import { useEndowment } from "services/aws/useEndowment";
 import { country } from "components/CountrySelector";
@@ -18,64 +18,64 @@ import { schema } from "./schema";
 import { toProfileUpdate } from "./update";
 
 export default function EditProfile() {
-	const { id } = useAdminContext();
-	const { data: profile, isLoading, isError, isFetching } = useEndowment(id);
+  const { id } = useAdminContext();
+  const { data: profile, isLoading, isError, isFetching } = useEndowment(id);
 
-	const content =
-		isLoading || isFetching ? (
-			<FormSkeleton classes="max-w-4xl justify-self-center mt-6" />
-		) : isError || !profile ? (
-			<FormError errorMessage="Failed to load profile" />
-		) : (
-			<FormWithContext {...profile} />
-		);
+  const content =
+    isLoading || isFetching ? (
+      <FormSkeleton classes="max-w-4xl justify-self-center mt-6" />
+    ) : isError || !profile ? (
+      <FormError errorMessage="Failed to load profile" />
+    ) : (
+      <FormWithContext {...profile} />
+    );
 
-	return (
-		<>
-			<Seo title="Edit Profile" url={`${adminRoutes.edit_profile}/${id}`} />
-			{content}
-		</>
-	);
+  return (
+    <>
+      <Seo title="Edit Profile" url={`${adminRoutes.edit_profile}/${id}`} />
+      {content}
+    </>
+  );
 }
 
 function FormWithContext(props: TProfile & { id: number }) {
-	//
-	const init: EndowmentProfileUpdate = toProfileUpdate({
-		type: "initial",
-		data: { ...props, id: props.id },
-	});
+  //
+  const init: EndowmentProfileUpdate = toProfileUpdate({
+    type: "initial",
+    data: { ...props, id: props.id },
+  });
 
-	const defaults: FV = {
-		...init,
-		image: {
-			name: "",
-			publicUrl: props.image ?? "",
-			preview: props.image ?? "",
-		},
-		logo: { name: "", publicUrl: props.logo, preview: props.logo },
-		endow_designation: init.endow_designation
-			? { label: init.endow_designation, value: init.endow_designation }
-			: { label: "", value: "" },
-		hq_country: country(props.hq_country),
-		sdgs: init.sdgs.map((x) => getSDGLabelValuePair(x, unsdgs[x].title)),
-		active_in_countries: init.active_in_countries.map((x) => ({
-			label: x,
-			value: x,
-		})),
-		overview: { value: props.overview },
+  const defaults: FV = {
+    ...init,
+    image: {
+      name: "",
+      publicUrl: props.image ?? "",
+      preview: props.image ?? "",
+    },
+    logo: { name: "", publicUrl: props.logo, preview: props.logo },
+    endow_designation: init.endow_designation
+      ? { label: init.endow_designation, value: init.endow_designation }
+      : { label: "", value: "" },
+    hq_country: country(props.hq_country),
+    sdgs: init.sdgs.map((x) => getSDGLabelValuePair(x, unsdgs[x].title)),
+    active_in_countries: init.active_in_countries.map((x) => ({
+      label: x,
+      value: x,
+    })),
+    overview: { value: props.overview },
 
-		//meta
-		initial: init,
-	};
+    //meta
+    initial: init,
+  };
 
-	const methods = useForm<FV>({
-		defaultValues: defaults,
-		resolver: yupResolver(schema),
-	});
+  const methods = useForm<FV>({
+    defaultValues: defaults,
+    resolver: yupResolver(schema),
+  });
 
-	return (
-		<FormProvider {...methods}>
-			<Form />
-		</FormProvider>
-	);
+  return (
+    <FormProvider {...methods}>
+      <Form />
+    </FormProvider>
+  );
 }

--- a/src/pages/Admin/Charity/EditProfile/index.tsx
+++ b/src/pages/Admin/Charity/EditProfile/index.tsx
@@ -2,8 +2,8 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { FormProvider, useForm } from "react-hook-form";
 import { FV } from "./types";
 import {
-  EndowmentProfileUpdate,
-  EndowmentProfile as TProfile,
+	EndowmentProfileUpdate,
+	EndowmentProfile as TProfile,
 } from "types/aws";
 import { useEndowment } from "services/aws/useEndowment";
 import { country } from "components/CountrySelector";
@@ -18,63 +18,64 @@ import { schema } from "./schema";
 import { toProfileUpdate } from "./update";
 
 export default function EditProfile() {
-  const { id } = useAdminContext();
-  const { data: profile, isLoading, isError, isFetching } = useEndowment(id);
+	const { id } = useAdminContext();
+	const { data: profile, isLoading, isError, isFetching } = useEndowment(id);
 
-  const content =
-    isLoading || isFetching ? (
-      <FormSkeleton classes="max-w-4xl justify-self-center mt-6" />
-    ) : isError || !profile ? (
-      <FormError errorMessage="Failed to load profile" />
-    ) : (
-      <FormWithContext {...profile} />
-    );
+	const content =
+		isLoading || isFetching ? (
+			<FormSkeleton classes="max-w-4xl justify-self-center mt-6" />
+		) : isError || !profile ? (
+			<FormError errorMessage="Failed to load profile" />
+		) : (
+			<FormWithContext {...profile} />
+		);
 
-  return (
-    <>
-      <Seo title="Edit Profile" url={`${adminRoutes.edit_profile}/${id}`} />
-      {content}
-    </>
-  );
+	return (
+		<>
+			<Seo title="Edit Profile" url={`${adminRoutes.edit_profile}/${id}`} />
+			{content}
+		</>
+	);
 }
 
 function FormWithContext(props: TProfile & { id: number }) {
-  //
-  const init: EndowmentProfileUpdate = toProfileUpdate({
-    type: "initial",
-    data: { ...props, id: props.id },
-  });
+	//
+	const init: EndowmentProfileUpdate = toProfileUpdate({
+		type: "initial",
+		data: { ...props, id: props.id },
+	});
 
-  const defaults: FV = {
-    ...init,
-    image: {
-      name: "",
-      publicUrl: props.image ?? "",
-      preview: props.image ?? "",
-    },
-    logo: { name: "", publicUrl: props.logo, preview: props.logo },
-    endow_designation: init.endow_designation
-      ? { label: init.endow_designation, value: init.endow_designation }
-      : { label: "", value: "" },
-    hq_country: country(props.hq_country),
-    sdgs: init.sdgs.map((x) => getSDGLabelValuePair(x, unsdgs[x].title)),
-    active_in_countries: init.active_in_countries.map((x) => ({
-      label: x,
-      value: x,
-    })),
+	const defaults: FV = {
+		...init,
+		image: {
+			name: "",
+			publicUrl: props.image ?? "",
+			preview: props.image ?? "",
+		},
+		logo: { name: "", publicUrl: props.logo, preview: props.logo },
+		endow_designation: init.endow_designation
+			? { label: init.endow_designation, value: init.endow_designation }
+			: { label: "", value: "" },
+		hq_country: country(props.hq_country),
+		sdgs: init.sdgs.map((x) => getSDGLabelValuePair(x, unsdgs[x].title)),
+		active_in_countries: init.active_in_countries.map((x) => ({
+			label: x,
+			value: x,
+		})),
+		overview: { value: props.overview },
 
-    //meta
-    initial: init,
-  };
+		//meta
+		initial: init,
+	};
 
-  const methods = useForm<FV>({
-    defaultValues: defaults,
-    resolver: yupResolver(schema),
-  });
+	const methods = useForm<FV>({
+		defaultValues: defaults,
+		resolver: yupResolver(schema),
+	});
 
-  return (
-    <FormProvider {...methods}>
-      <Form />
-    </FormProvider>
-  );
+	return (
+		<FormProvider {...methods}>
+			<Form />
+		</FormProvider>
+	);
 }

--- a/src/pages/Admin/Charity/EditProfile/schema.ts
+++ b/src/pages/Admin/Charity/EditProfile/schema.ts
@@ -16,7 +16,7 @@ export const VALID_MIME_TYPES: ImageMIMEType[] = [
 ];
 
 export const MAX_SIZE_IN_BYTES = 1e6;
-export const MAX_CHARS = 4000
+export const MAX_CHARS = 4000;
 
 // we only need to validate the pre-crop image and if we confirm it is valid
 // we can be sure that the cropped image is valid too
@@ -46,5 +46,5 @@ export const schema = object<any, SchemaShape<FV>>({
     youtube: url,
     tiktok: url,
   }),
-  overview: richTextContent({ maxChars: MAX_CHARS })
+  overview: richTextContent({ maxChars: MAX_CHARS }),
 }) as ObjectSchema<FV>;

--- a/src/pages/Admin/Charity/EditProfile/schema.ts
+++ b/src/pages/Admin/Charity/EditProfile/schema.ts
@@ -1,12 +1,12 @@
+import { ObjectSchema, array, object } from "yup";
+import { FV } from "./types";
+import { SchemaShape } from "schemas/types";
+import { ImageMIMEType } from "types/lists";
 import { ImgLink } from "components/ImgEditor";
-import { MAX_SDGS } from "constants/unsdgs";
 import { genFileSchema } from "schemas/file";
 import { optionType, richTextContent } from "schemas/shape";
 import { requiredString, url } from "schemas/string";
-import { SchemaShape } from "schemas/types";
-import { ImageMIMEType } from "types/lists";
-import { ObjectSchema, array, object } from "yup";
-import { FV } from "./types";
+import { MAX_SDGS } from "constants/unsdgs";
 
 export const VALID_MIME_TYPES: ImageMIMEType[] = [
   "image/jpeg",

--- a/src/pages/Admin/Charity/EditProfile/schema.ts
+++ b/src/pages/Admin/Charity/EditProfile/schema.ts
@@ -1,12 +1,12 @@
-import { ObjectSchema, array, object } from "yup";
-import { FV } from "./types";
+import { ImgLink } from "components/ImgEditor";
+import { MAX_SDGS } from "constants/unsdgs";
+import { genFileSchema } from "schemas/file";
+import { optionType, richTextContent } from "schemas/shape";
+import { requiredString, url } from "schemas/string";
 import { SchemaShape } from "schemas/types";
 import { ImageMIMEType } from "types/lists";
-import { ImgLink } from "components/ImgEditor";
-import { genFileSchema } from "schemas/file";
-import { optionType } from "schemas/shape";
-import { requiredString, url } from "schemas/string";
-import { MAX_SDGS } from "constants/unsdgs";
+import { ObjectSchema, array, object } from "yup";
+import { FV } from "./types";
 
 export const VALID_MIME_TYPES: ImageMIMEType[] = [
   "image/jpeg",
@@ -16,6 +16,7 @@ export const VALID_MIME_TYPES: ImageMIMEType[] = [
 ];
 
 export const MAX_SIZE_IN_BYTES = 1e6;
+export const MAX_CHARS = 4000
 
 // we only need to validate the pre-crop image and if we confirm it is valid
 // we can be sure that the cropped image is valid too
@@ -45,4 +46,5 @@ export const schema = object<any, SchemaShape<FV>>({
     youtube: url,
     tiktok: url,
   }),
+  overview: richTextContent({ maxChars: MAX_CHARS })
 }) as ObjectSchema<FV>;

--- a/src/pages/Admin/Charity/EditProfile/types.ts
+++ b/src/pages/Admin/Charity/EditProfile/types.ts
@@ -6,14 +6,14 @@ import { UNSDG_NUMS } from "types/lists";
 import { ImgLink } from "components/ImgEditor";
 
 export type FV = OverrideProperties<
-	EndowmentProfileUpdate,
-	{
-		endow_designation: OptionType<EndowDesignation | "">;
-		logo: ImgLink;
-		image: ImgLink;
-		hq_country: Country;
-		sdgs: OptionType<UNSDG_NUMS>[];
-		active_in_countries: OptionType<string>[];
-		overview: RichTextContent;
-	}
+  EndowmentProfileUpdate,
+  {
+    endow_designation: OptionType<EndowDesignation | "">;
+    logo: ImgLink;
+    image: ImgLink;
+    hq_country: Country;
+    sdgs: OptionType<UNSDG_NUMS>[];
+    active_in_countries: OptionType<string>[];
+    overview: RichTextContent;
+  }
 > & { initial: EndowmentProfileUpdate };

--- a/src/pages/Admin/Charity/EditProfile/types.ts
+++ b/src/pages/Admin/Charity/EditProfile/types.ts
@@ -1,18 +1,19 @@
 import { OverrideProperties } from "type-fest";
 import { EndowDesignation, EndowmentProfileUpdate } from "types/aws";
-import { OptionType } from "types/components";
+import { OptionType, RichTextContent } from "types/components";
 import { Country } from "types/components";
 import { UNSDG_NUMS } from "types/lists";
 import { ImgLink } from "components/ImgEditor";
 
 export type FV = OverrideProperties<
-  EndowmentProfileUpdate,
-  {
-    endow_designation: OptionType<EndowDesignation | "">;
-    logo: ImgLink;
-    image: ImgLink;
-    hq_country: Country;
-    sdgs: OptionType<UNSDG_NUMS>[];
-    active_in_countries: OptionType<string>[];
-  }
+	EndowmentProfileUpdate,
+	{
+		endow_designation: OptionType<EndowDesignation | "">;
+		logo: ImgLink;
+		image: ImgLink;
+		hq_country: Country;
+		sdgs: OptionType<UNSDG_NUMS>[];
+		active_in_countries: OptionType<string>[];
+		overview: RichTextContent;
+	}
 > & { initial: EndowmentProfileUpdate };

--- a/src/pages/Admin/Charity/EditProfile/update.ts
+++ b/src/pages/Admin/Charity/EditProfile/update.ts
@@ -4,59 +4,60 @@ import { EndowmentProfile, EndowmentProfileUpdate } from "types/aws";
 
 type RequiredFields = Pick<EndowmentProfileUpdate, "id">;
 type Arg =
-  | {
-      type: "initial";
-      data: EndowmentProfile & RequiredFields;
-    }
-  | {
-      type: "final";
-      data: Except<FV, "id" | "initial"> & RequiredFields;
-      urls: { image: string; logo: string };
-    };
+	| {
+			type: "initial";
+			data: EndowmentProfile & RequiredFields;
+	  }
+	| {
+			type: "final";
+			data: Except<FV, "id" | "initial"> & RequiredFields;
+			urls: { image: string; logo: string };
+	  };
 
 export function toProfileUpdate(arg: Arg): EndowmentProfileUpdate {
-  if (arg.type === "initial") {
-    const { data: d } = arg;
-    return {
-      id: d.id,
-      active_in_countries: d.active_in_countries,
-      contact_email: d.contact_email,
-      endow_designation: d.endow_designation,
-      hq_country: d.hq_country,
-      image: d.image,
-      kyc_donors_only: d.kyc_donors_only,
-      logo: d.logo,
-      name: d.name,
-      overview: d.overview,
-      program: [], //program is updated in /create-program
-      program_id: "",
-      published: d.published,
-      registration_number: d.registration_number,
-      sdgs: d.sdgs,
-      social_media_urls: {
-        facebook: d.social_media_urls.facebook,
-        instagram: d.social_media_urls.instagram,
-        linkedin: d.social_media_urls.linkedin,
-        twitter: d.social_media_urls.twitter,
-        discord: d.social_media_urls.discord,
-        youtube: d.social_media_urls.youtube,
-        tiktok: d.social_media_urls.tiktok,
-      },
-      street_address: d.street_address,
-      tagline: d.tagline ?? "",
-      url: d.url ?? "",
-    };
-  }
+	if (arg.type === "initial") {
+		const { data: d } = arg;
+		return {
+			id: d.id,
+			active_in_countries: d.active_in_countries,
+			contact_email: d.contact_email,
+			endow_designation: d.endow_designation,
+			hq_country: d.hq_country,
+			image: d.image,
+			kyc_donors_only: d.kyc_donors_only,
+			logo: d.logo,
+			name: d.name,
+			overview: d.overview,
+			program: [], //program is updated in /create-program
+			program_id: "",
+			published: d.published,
+			registration_number: d.registration_number,
+			sdgs: d.sdgs,
+			social_media_urls: {
+				facebook: d.social_media_urls.facebook,
+				instagram: d.social_media_urls.instagram,
+				linkedin: d.social_media_urls.linkedin,
+				twitter: d.social_media_urls.twitter,
+				discord: d.social_media_urls.discord,
+				youtube: d.social_media_urls.youtube,
+				tiktok: d.social_media_urls.tiktok,
+			},
+			street_address: d.street_address,
+			tagline: d.tagline ?? "",
+			url: d.url ?? "",
+		};
+	}
 
-  const { data: fv, urls } = arg;
-  return {
-    ...fv,
-    program: [], //program is updated in /create-program
-    image: urls.image,
-    logo: urls.logo,
-    hq_country: fv.hq_country.name,
-    endow_designation: fv.endow_designation.value,
-    sdgs: fv.sdgs.map((opt) => opt.value),
-    active_in_countries: fv.active_in_countries.map((opt) => opt.value),
-  };
+	const { data: fv, urls } = arg;
+	return {
+		...fv,
+		program: [], //program is updated in /create-program
+		image: urls.image,
+		logo: urls.logo,
+		hq_country: fv.hq_country.name,
+		endow_designation: fv.endow_designation.value,
+		sdgs: fv.sdgs.map((opt) => opt.value),
+		active_in_countries: fv.active_in_countries.map((opt) => opt.value),
+		overview: fv.overview.value,
+	};
 }

--- a/src/pages/Admin/Charity/EditProfile/update.ts
+++ b/src/pages/Admin/Charity/EditProfile/update.ts
@@ -4,60 +4,60 @@ import { EndowmentProfile, EndowmentProfileUpdate } from "types/aws";
 
 type RequiredFields = Pick<EndowmentProfileUpdate, "id">;
 type Arg =
-	| {
-			type: "initial";
-			data: EndowmentProfile & RequiredFields;
-	  }
-	| {
-			type: "final";
-			data: Except<FV, "id" | "initial"> & RequiredFields;
-			urls: { image: string; logo: string };
-	  };
+  | {
+      type: "initial";
+      data: EndowmentProfile & RequiredFields;
+    }
+  | {
+      type: "final";
+      data: Except<FV, "id" | "initial"> & RequiredFields;
+      urls: { image: string; logo: string };
+    };
 
 export function toProfileUpdate(arg: Arg): EndowmentProfileUpdate {
-	if (arg.type === "initial") {
-		const { data: d } = arg;
-		return {
-			id: d.id,
-			active_in_countries: d.active_in_countries,
-			contact_email: d.contact_email,
-			endow_designation: d.endow_designation,
-			hq_country: d.hq_country,
-			image: d.image,
-			kyc_donors_only: d.kyc_donors_only,
-			logo: d.logo,
-			name: d.name,
-			overview: d.overview,
-			program: [], //program is updated in /create-program
-			program_id: "",
-			published: d.published,
-			registration_number: d.registration_number,
-			sdgs: d.sdgs,
-			social_media_urls: {
-				facebook: d.social_media_urls.facebook,
-				instagram: d.social_media_urls.instagram,
-				linkedin: d.social_media_urls.linkedin,
-				twitter: d.social_media_urls.twitter,
-				discord: d.social_media_urls.discord,
-				youtube: d.social_media_urls.youtube,
-				tiktok: d.social_media_urls.tiktok,
-			},
-			street_address: d.street_address,
-			tagline: d.tagline ?? "",
-			url: d.url ?? "",
-		};
-	}
+  if (arg.type === "initial") {
+    const { data: d } = arg;
+    return {
+      id: d.id,
+      active_in_countries: d.active_in_countries,
+      contact_email: d.contact_email,
+      endow_designation: d.endow_designation,
+      hq_country: d.hq_country,
+      image: d.image,
+      kyc_donors_only: d.kyc_donors_only,
+      logo: d.logo,
+      name: d.name,
+      overview: d.overview,
+      program: [], //program is updated in /create-program
+      program_id: "",
+      published: d.published,
+      registration_number: d.registration_number,
+      sdgs: d.sdgs,
+      social_media_urls: {
+        facebook: d.social_media_urls.facebook,
+        instagram: d.social_media_urls.instagram,
+        linkedin: d.social_media_urls.linkedin,
+        twitter: d.social_media_urls.twitter,
+        discord: d.social_media_urls.discord,
+        youtube: d.social_media_urls.youtube,
+        tiktok: d.social_media_urls.tiktok,
+      },
+      street_address: d.street_address,
+      tagline: d.tagline ?? "",
+      url: d.url ?? "",
+    };
+  }
 
-	const { data: fv, urls } = arg;
-	return {
-		...fv,
-		program: [], //program is updated in /create-program
-		image: urls.image,
-		logo: urls.logo,
-		hq_country: fv.hq_country.name,
-		endow_designation: fv.endow_designation.value,
-		sdgs: fv.sdgs.map((opt) => opt.value),
-		active_in_countries: fv.active_in_countries.map((opt) => opt.value),
-		overview: fv.overview.value,
-	};
+  const { data: fv, urls } = arg;
+  return {
+    ...fv,
+    program: [], //program is updated in /create-program
+    image: urls.image,
+    logo: urls.logo,
+    hq_country: fv.hq_country.name,
+    endow_designation: fv.endow_designation.value,
+    sdgs: fv.sdgs.map((opt) => opt.value),
+    active_in_countries: fv.active_in_countries.map((opt) => opt.value),
+    overview: fv.overview.value,
+  };
 }

--- a/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestones.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestones.tsx
@@ -21,7 +21,7 @@ export default function Milestones() {
           onClick={() =>
             append({
               milestone_date: dateToFormFormat(new Date()),
-              milestone_description: "",
+              milestone_description: { value: "" },
               milestone_title: `Milestone ${fields.length + 1}`,
               milestone_media: {
                 name: "",

--- a/src/pages/Admin/Charity/ProgramEditor/ProgramEditor.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramEditor.tsx
@@ -11,72 +11,72 @@ import { schema } from "./schema";
 
 const NEW = "new";
 export default function ProgramEditor() {
-	const { id: programId = "" } = useParams();
-	const { id: endowId } = useAdminContext();
-	const programQuery = useProgramQuery(
-		{ endowId, programId },
-		{ skip: !programId || programId === NEW },
-	);
+  const { id: programId = "" } = useParams();
+  const { id: endowId } = useAdminContext();
+  const programQuery = useProgramQuery(
+    { endowId, programId },
+    { skip: !programId || programId === NEW },
+  );
 
-	if (programId === NEW)
-		return (
-			<Context
-				{...{
-					title: "",
-					description: { value: "" },
-					image: {
-						name: "",
-						publicUrl: "",
-						preview: "",
-					},
-					milestones: [],
-				}}
-			/>
-		);
+  if (programId === NEW)
+    return (
+      <Context
+        {...{
+          title: "",
+          description: { value: "" },
+          image: {
+            name: "",
+            publicUrl: "",
+            preview: "",
+          },
+          milestones: [],
+        }}
+      />
+    );
 
-	return (
-		<QueryLoader
-			queryState={programQuery}
-			messages={{ loading: "Loading program", error: "Failed to load program" }}
-		>
-			{(p) => (
-				<Context
-					{...{
-						title: p.program_title,
-						description: { value: p.program_description },
-						image: {
-							name: "",
-							publicUrl: p.program_banner,
-							preview: p.program_banner,
-						},
-						initial: p,
-						milestones: p.program_milestones.map((m, idx) => ({
-							...m,
-							milestone_date: dateToFormFormat(new Date(m.milestone_date)),
-							milestone_media: {
-								name: "",
-								preview: m.milestone_media,
-								publicUrl: m.milestone_media,
-							},
-							milestone_description: { value: m.milestone_description },
-							idx,
-						})),
-					}}
-				/>
-			)}
-		</QueryLoader>
-	);
+  return (
+    <QueryLoader
+      queryState={programQuery}
+      messages={{ loading: "Loading program", error: "Failed to load program" }}
+    >
+      {(p) => (
+        <Context
+          {...{
+            title: p.program_title,
+            description: { value: p.program_description },
+            image: {
+              name: "",
+              publicUrl: p.program_banner,
+              preview: p.program_banner,
+            },
+            initial: p,
+            milestones: p.program_milestones.map((m, idx) => ({
+              ...m,
+              milestone_date: dateToFormFormat(new Date(m.milestone_date)),
+              milestone_media: {
+                name: "",
+                preview: m.milestone_media,
+                publicUrl: m.milestone_media,
+              },
+              milestone_description: { value: m.milestone_description },
+              idx,
+            })),
+          }}
+        />
+      )}
+    </QueryLoader>
+  );
 }
 
 function Context(props: FV) {
-	const methods = useForm<FV>({
-		defaultValues: props,
-		resolver: yupResolver(schema),
-	});
+  const methods = useForm<FV>({
+    defaultValues: props,
+    resolver: yupResolver(schema),
+  });
 
-	return (
-		<FormProvider {...methods}>
-			<Form />
-		</FormProvider>
-	);
+  return (
+    <FormProvider {...methods}>
+      <Form />
+    </FormProvider>
+  );
 }

--- a/src/pages/Admin/Charity/ProgramEditor/ProgramEditor.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramEditor.tsx
@@ -23,7 +23,7 @@ export default function ProgramEditor() {
       <Context
         {...{
           title: "",
-          description: "",
+          description: { length: 0, value: "" },
           image: {
             name: "",
             publicUrl: "",
@@ -43,7 +43,7 @@ export default function ProgramEditor() {
         <Context
           {...{
             title: p.program_title,
-            description: p.program_description,
+            description: { value: p.program_description, length: 0 },
             image: {
               name: "",
               publicUrl: p.program_banner,

--- a/src/pages/Admin/Charity/ProgramEditor/ProgramEditor.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramEditor.tsx
@@ -15,7 +15,7 @@ export default function ProgramEditor() {
   const { id: endowId } = useAdminContext();
   const programQuery = useProgramQuery(
     { endowId, programId },
-    { skip: !programId || programId === NEW },
+    { skip: !programId || programId === NEW }
   );
 
   if (programId === NEW)

--- a/src/pages/Admin/Charity/ProgramEditor/ProgramEditor.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramEditor.tsx
@@ -11,71 +11,72 @@ import { schema } from "./schema";
 
 const NEW = "new";
 export default function ProgramEditor() {
-  const { id: programId = "" } = useParams();
-  const { id: endowId } = useAdminContext();
-  const programQuery = useProgramQuery(
-    { endowId, programId },
-    { skip: !programId || programId === NEW }
-  );
+	const { id: programId = "" } = useParams();
+	const { id: endowId } = useAdminContext();
+	const programQuery = useProgramQuery(
+		{ endowId, programId },
+		{ skip: !programId || programId === NEW },
+	);
 
-  if (programId === NEW)
-    return (
-      <Context
-        {...{
-          title: "",
-          description: { length: 0, value: "" },
-          image: {
-            name: "",
-            publicUrl: "",
-            preview: "",
-          },
-          milestones: [],
-        }}
-      />
-    );
+	if (programId === NEW)
+		return (
+			<Context
+				{...{
+					title: "",
+					description: { value: "" },
+					image: {
+						name: "",
+						publicUrl: "",
+						preview: "",
+					},
+					milestones: [],
+				}}
+			/>
+		);
 
-  return (
-    <QueryLoader
-      queryState={programQuery}
-      messages={{ loading: "Loading program", error: "Failed to load program" }}
-    >
-      {(p) => (
-        <Context
-          {...{
-            title: p.program_title,
-            description: { value: p.program_description, length: 0 },
-            image: {
-              name: "",
-              publicUrl: p.program_banner,
-              preview: p.program_banner,
-            },
-            initial: p,
-            milestones: p.program_milestones.map((m, idx) => ({
-              ...m,
-              milestone_date: dateToFormFormat(new Date(m.milestone_date)),
-              milestone_media: {
-                name: "",
-                preview: m.milestone_media,
-                publicUrl: m.milestone_media,
-              },
-              idx,
-            })),
-          }}
-        />
-      )}
-    </QueryLoader>
-  );
+	return (
+		<QueryLoader
+			queryState={programQuery}
+			messages={{ loading: "Loading program", error: "Failed to load program" }}
+		>
+			{(p) => (
+				<Context
+					{...{
+						title: p.program_title,
+						description: { value: p.program_description },
+						image: {
+							name: "",
+							publicUrl: p.program_banner,
+							preview: p.program_banner,
+						},
+						initial: p,
+						milestones: p.program_milestones.map((m, idx) => ({
+							...m,
+							milestone_date: dateToFormFormat(new Date(m.milestone_date)),
+							milestone_media: {
+								name: "",
+								preview: m.milestone_media,
+								publicUrl: m.milestone_media,
+							},
+							milestone_description: { value: m.milestone_description },
+							idx,
+						})),
+					}}
+				/>
+			)}
+		</QueryLoader>
+	);
 }
 
 function Context(props: FV) {
-  const methods = useForm<FV>({
-    defaultValues: props,
-    resolver: yupResolver(schema),
-  });
+	const methods = useForm<FV>({
+		defaultValues: props,
+		resolver: yupResolver(schema),
+	});
 
-  return (
-    <FormProvider {...methods}>
-      <Form />
-    </FormProvider>
-  );
+	return (
+		<FormProvider {...methods}>
+			<Form />
+		</FormProvider>
+	);
 }

--- a/src/pages/Admin/Charity/ProgramEditor/schema.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/schema.ts
@@ -8,10 +8,10 @@ import { ObjectSchema, array, date, object } from "yup";
 import { FV, FormMilestone } from "./types";
 
 export const VALID_MIME_TYPES: ImageMIMEType[] = [
-	"image/jpeg",
-	"image/png",
-	"image/webp",
-	"image/svg+xml",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/svg+xml",
 ];
 
 const MAX_SIZE_IN_BYTES = 1e6;
@@ -20,21 +20,21 @@ export const MAX_CHARS = 500;
 // we only need to validate the pre-crop image and if we confirm it is valid
 // we can be sure that the cropped image is valid too
 const fileObj = object().shape<SchemaShape<ImgLink>>({
-	precropFile: genFileSchema(MAX_SIZE_IN_BYTES, VALID_MIME_TYPES),
+  precropFile: genFileSchema(MAX_SIZE_IN_BYTES, VALID_MIME_TYPES),
 });
 
 const milesStoneSchema = object<any, SchemaShape<FormMilestone>>({
-	milestone_date: date().typeError("invalid date"),
-	milestone_description: richTextContent({ maxChars: MAX_CHARS }),
-	milestone_title: requiredString,
-	milestone_media: fileObj,
+  milestone_date: date().typeError("invalid date"),
+  milestone_description: richTextContent({ maxChars: MAX_CHARS }),
+  milestone_title: requiredString,
+  milestone_media: fileObj,
 });
 
 //construct strict shape to avoid hardcoding shape keys
 
 export const schema = object<any, SchemaShape<FV>>({
-	title: requiredString.trim(),
-	description: richTextContent({ maxChars: MAX_CHARS, required: true }),
-	image: fileObj,
-	milestones: array(milesStoneSchema),
+  title: requiredString.trim(),
+  description: richTextContent({ maxChars: MAX_CHARS, required: true }),
+  image: fileObj,
+  milestones: array(milesStoneSchema),
 }) as ObjectSchema<FV>;

--- a/src/pages/Admin/Charity/ProgramEditor/schema.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/schema.ts
@@ -1,11 +1,11 @@
-import { ObjectSchema, array, date, mixed, object, string } from "yup";
-import { FV, FormMilestone } from "./types";
+import { ImgLink } from "components/ImgEditor";
+import { genFileSchema } from "schemas/file";
+import { richTextContent } from "schemas/shape";
+import { requiredString } from "schemas/string";
 import { SchemaShape } from "schemas/types";
 import { ImageMIMEType } from "types/lists";
-import { ImgLink } from "components/ImgEditor";
-import { RichTextContent } from "components/RichText/types";
-import { genFileSchema } from "schemas/file";
-import { requiredString } from "schemas/string";
+import { ObjectSchema, array, date, object } from "yup";
+import { FV, FormMilestone } from "./types";
 
 export const VALID_MIME_TYPES: ImageMIMEType[] = [
 	"image/jpeg",
@@ -25,10 +25,7 @@ const fileObj = object().shape<SchemaShape<ImgLink>>({
 
 const milesStoneSchema = object<any, SchemaShape<FormMilestone>>({
 	milestone_date: date().typeError("invalid date"),
-	milestone_description: string().max(
-		MAX_CHARS,
-		`max length is ${MAX_CHARS} chars`,
-	),
+	milestone_description: richTextContent({ maxChars: MAX_CHARS }),
 	milestone_title: requiredString,
 	milestone_media: fileObj,
 });
@@ -37,17 +34,7 @@ const milesStoneSchema = object<any, SchemaShape<FormMilestone>>({
 
 export const schema = object<any, SchemaShape<FV>>({
 	title: requiredString.trim(),
-	description: mixed<RichTextContent>()
-		.test({
-			name: "required",
-			message: "required",
-			test: (descr) => !!descr?.value,
-		})
-		.test({
-			name: "must be below character limit",
-			message: `max length is ${MAX_CHARS} chars`,
-			test: (descr) => (descr?.length || 0) <= MAX_CHARS,
-		}),
+	description: richTextContent({ maxChars: MAX_CHARS, required: true }),
 	image: fileObj,
 	milestones: array(milesStoneSchema),
 }) as ObjectSchema<FV>;

--- a/src/pages/Admin/Charity/ProgramEditor/schema.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/schema.ts
@@ -1,11 +1,11 @@
+import { ObjectSchema, array, date, object } from "yup";
+import { FV, FormMilestone } from "./types";
+import { SchemaShape } from "schemas/types";
+import { ImageMIMEType } from "types/lists";
 import { ImgLink } from "components/ImgEditor";
 import { genFileSchema } from "schemas/file";
 import { richTextContent } from "schemas/shape";
 import { requiredString } from "schemas/string";
-import { SchemaShape } from "schemas/types";
-import { ImageMIMEType } from "types/lists";
-import { ObjectSchema, array, date, object } from "yup";
-import { FV, FormMilestone } from "./types";
 
 export const VALID_MIME_TYPES: ImageMIMEType[] = [
   "image/jpeg",

--- a/src/pages/Admin/Charity/ProgramEditor/schema.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/schema.ts
@@ -1,16 +1,17 @@
-import { ObjectSchema, array, date, object, string } from "yup";
+import { ObjectSchema, array, date, mixed, object, string } from "yup";
 import { FV, FormMilestone } from "./types";
 import { SchemaShape } from "schemas/types";
 import { ImageMIMEType } from "types/lists";
 import { ImgLink } from "components/ImgEditor";
+import { RichTextContent } from "components/RichText/types";
 import { genFileSchema } from "schemas/file";
 import { requiredString } from "schemas/string";
 
 export const VALID_MIME_TYPES: ImageMIMEType[] = [
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-  "image/svg+xml",
+	"image/jpeg",
+	"image/png",
+	"image/webp",
+	"image/svg+xml",
 ];
 
 const MAX_SIZE_IN_BYTES = 1e6;
@@ -19,27 +20,34 @@ export const MAX_CHARS = 500;
 // we only need to validate the pre-crop image and if we confirm it is valid
 // we can be sure that the cropped image is valid too
 const fileObj = object().shape<SchemaShape<ImgLink>>({
-  precropFile: genFileSchema(MAX_SIZE_IN_BYTES, VALID_MIME_TYPES),
+	precropFile: genFileSchema(MAX_SIZE_IN_BYTES, VALID_MIME_TYPES),
 });
 
 const milesStoneSchema = object<any, SchemaShape<FormMilestone>>({
-  milestone_date: date().typeError("invalid date"),
-  milestone_description: string().max(
-    MAX_CHARS,
-    `max length is ${MAX_CHARS} chars`
-  ),
-  milestone_title: requiredString,
-  milestone_media: fileObj,
+	milestone_date: date().typeError("invalid date"),
+	milestone_description: string().max(
+		MAX_CHARS,
+		`max length is ${MAX_CHARS} chars`,
+	),
+	milestone_title: requiredString,
+	milestone_media: fileObj,
 });
 
 //construct strict shape to avoid hardcoding shape keys
 
 export const schema = object<any, SchemaShape<FV>>({
-  title: requiredString,
-  description: requiredString.max(
-    MAX_CHARS,
-    `max length is ${MAX_CHARS} chars`
-  ),
-  image: fileObj,
-  milestones: array(milesStoneSchema),
+	title: requiredString.trim(),
+	description: mixed<RichTextContent>()
+		.test({
+			name: "required",
+			message: "required",
+			test: (descr) => !!descr?.value,
+		})
+		.test({
+			name: "must be below character limit",
+			message: `max length is ${MAX_CHARS} chars`,
+			test: (descr) => (descr?.length || 0) <= MAX_CHARS,
+		}),
+	image: fileObj,
+	milestones: array(milesStoneSchema),
 }) as ObjectSchema<FV>;

--- a/src/pages/Admin/Charity/ProgramEditor/types.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/types.ts
@@ -1,7 +1,7 @@
 import { ImgLink } from "components/ImgEditor";
-import { RichTextContent } from "components/RichText/types";
 import { OverrideProperties } from "type-fest";
 import { MileStone, Program } from "types/aws";
+import { RichTextContent } from "types/components";
 
 export type FormMilestone = OverrideProperties<
 	MileStone,

--- a/src/pages/Admin/Charity/ProgramEditor/types.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/types.ts
@@ -4,17 +4,17 @@ import { MileStone, Program } from "types/aws";
 import { RichTextContent } from "types/components";
 
 export type FormMilestone = OverrideProperties<
-	MileStone,
-	{ milestone_media: ImgLink; milestone_description: RichTextContent }
+  MileStone,
+  { milestone_media: ImgLink; milestone_description: RichTextContent }
 > & {
-	//meta
-	idx: number;
+  //meta
+  idx: number;
 };
 
 export type FV = {
-	title: string;
-	image: ImgLink;
-	description: RichTextContent;
-	milestones: FormMilestone[];
-	initial?: Program;
+  title: string;
+  image: ImgLink;
+  description: RichTextContent;
+  milestones: FormMilestone[];
+  initial?: Program;
 };

--- a/src/pages/Admin/Charity/ProgramEditor/types.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/types.ts
@@ -1,7 +1,7 @@
-import { ImgLink } from "components/ImgEditor";
 import { OverrideProperties } from "type-fest";
 import { MileStone, Program } from "types/aws";
 import { RichTextContent } from "types/components";
+import { ImgLink } from "components/ImgEditor";
 
 export type FormMilestone = OverrideProperties<
   MileStone,

--- a/src/pages/Admin/Charity/ProgramEditor/types.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/types.ts
@@ -5,7 +5,7 @@ import { RichTextContent } from "types/components";
 
 export type FormMilestone = OverrideProperties<
 	MileStone,
-	{ milestone_media: ImgLink }
+	{ milestone_media: ImgLink; milestone_description: RichTextContent }
 > & {
 	//meta
 	idx: number;

--- a/src/pages/Admin/Charity/ProgramEditor/types.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/types.ts
@@ -1,19 +1,20 @@
+import { ImgLink } from "components/ImgEditor";
+import { RichTextContent } from "components/RichText/types";
 import { OverrideProperties } from "type-fest";
 import { MileStone, Program } from "types/aws";
-import { ImgLink } from "components/ImgEditor";
 
 export type FormMilestone = OverrideProperties<
-  MileStone,
-  { milestone_media: ImgLink }
+	MileStone,
+	{ milestone_media: ImgLink }
 > & {
-  //meta
-  idx: number;
+	//meta
+	idx: number;
 };
 
 export type FV = {
-  title: string;
-  image: ImgLink;
-  description: string;
-  milestones: FormMilestone[];
-  initial?: Program;
+	title: string;
+	image: ImgLink;
+	description: RichTextContent;
+	milestones: FormMilestone[];
+	initial?: Program;
 };

--- a/src/pages/Admin/Charity/ProgramEditor/useSubmit.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/useSubmit.ts
@@ -12,83 +12,83 @@ import { useAdminContext } from "../../Context";
 import { useUpdateEndowmentProfile } from "../common";
 
 export default function useSubmit() {
-	const { id } = useAdminContext();
-	const {
-		reset,
-		handleSubmit,
-		formState: { isSubmitting },
-		getValues,
-	} = useFormContext<FV>();
+  const { id } = useAdminContext();
+  const {
+    reset,
+    handleSubmit,
+    formState: { isSubmitting },
+    getValues,
+  } = useFormContext<FV>();
 
-	const { showModal } = useModalContext();
-	const updateProfile = useUpdateEndowmentProfile();
+  const { showModal } = useModalContext();
+  const updateProfile = useUpdateEndowmentProfile();
 
-	const submit: SubmitHandler<FV> = async ({ initial, ...fv }) => {
-		try {
-			const [imageURL, ...milestoneMediaURLs] = await uploadImgs(
-				[fv.image, ...fv.milestones.map((m) => m.milestone_media)],
-				() => {
-					showModal(
-						TxPrompt,
-						{ loading: "Uploading images.." },
-						{ isDismissible: false },
-					);
-				},
-			);
+  const submit: SubmitHandler<FV> = async ({ initial, ...fv }) => {
+    try {
+      const [imageURL, ...milestoneMediaURLs] = await uploadImgs(
+        [fv.image, ...fv.milestones.map((m) => m.milestone_media)],
+        () => {
+          showModal(
+            TxPrompt,
+            { loading: "Uploading images.." },
+            { isDismissible: false },
+          );
+        },
+      );
 
-			//having initial value means form is for editing
+      //having initial value means form is for editing
 
-			const program: Program = {
-				program_title: fv.title,
-				program_id: initial ? initial.program_id : window.crypto.randomUUID(),
-				program_description: fv.description.value,
-				program_banner: imageURL,
-				program_milestones: fv.milestones.map(({ idx, ...m }, i) => ({
-					...m,
-					milestone_date: new Date(m.milestone_date).toISOString(),
-					milestone_media: milestoneMediaURLs[i],
-					milestone_description: m.milestone_description.value,
-				})),
-			};
+      const program: Program = {
+        program_title: fv.title,
+        program_id: initial ? initial.program_id : window.crypto.randomUUID(),
+        program_description: fv.description.value,
+        program_banner: imageURL,
+        program_milestones: fv.milestones.map(({ idx, ...m }, i) => ({
+          ...m,
+          milestone_date: new Date(m.milestone_date).toISOString(),
+          milestone_media: milestoneMediaURLs[i],
+          milestone_description: m.milestone_description.value,
+        })),
+      };
 
-			if (initial) {
-				const diff = getPayloadDiff(initial, program);
-				if (isEmpty(diff)) {
-					return showModal(TxPrompt, { error: "No changes detected" });
-				}
-			}
+      if (initial) {
+        const diff = getPayloadDiff(initial, program);
+        if (isEmpty(diff)) {
+          return showModal(TxPrompt, { error: "No changes detected" });
+        }
+      }
 
-			const updates: ProfileUpdateMsg = {
-				id,
-				program: [program],
-			};
-			await updateProfile(updates);
-			if (!initial) reset(); //for new program, reset form after submit
-		} catch (err) {
-			logger.error(err);
-			showModal(TxPrompt, {
-				error: err instanceof Error ? err.message : "Unknown error occured",
-			});
-		}
-	};
+      const updates: ProfileUpdateMsg = {
+        id,
+        program: [program],
+      };
+      await updateProfile(updates);
+      if (!initial) reset(); //for new program, reset form after submit
+    } catch (err) {
+      logger.error(err);
+      showModal(TxPrompt, {
+        error: err instanceof Error ? err.message : "Unknown error occured",
+      });
+    }
+  };
 
-	return {
-		reset,
-		submit: handleSubmit(submit),
-		isSubmitting,
-		id,
-		initial: getValues("initial"),
-	};
+  return {
+    reset,
+    submit: handleSubmit(submit),
+    isSubmitting,
+    id,
+    initial: getValues("initial"),
+  };
 }
 
 async function uploadImgs(
-	imgs: ImgLink[],
-	onUpload: () => void,
+  imgs: ImgLink[],
+  onUpload: () => void,
 ): Promise<string[]> {
-	const files = imgs.flatMap((img) => (img.file ? [img.file] : []));
-	if (!isEmpty(files)) onUpload();
-	const baseURL = await uploadFiles(files, "endow-profiles");
-	return imgs.map((img) =>
-		img.file && baseURL ? getFullURL(baseURL, img.file.name) : img.publicUrl,
-	);
+  const files = imgs.flatMap((img) => (img.file ? [img.file] : []));
+  if (!isEmpty(files)) onUpload();
+  const baseURL = await uploadFiles(files, "endow-profiles");
+  return imgs.map((img) =>
+    img.file && baseURL ? getFullURL(baseURL, img.file.name) : img.publicUrl,
+  );
 }

--- a/src/pages/Admin/Charity/ProgramEditor/useSubmit.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/useSubmit.ts
@@ -12,82 +12,82 @@ import { useAdminContext } from "../../Context";
 import { useUpdateEndowmentProfile } from "../common";
 
 export default function useSubmit() {
-  const { id } = useAdminContext();
-  const {
-    reset,
-    handleSubmit,
-    formState: { isSubmitting },
-    getValues,
-  } = useFormContext<FV>();
+	const { id } = useAdminContext();
+	const {
+		reset,
+		handleSubmit,
+		formState: { isSubmitting },
+		getValues,
+	} = useFormContext<FV>();
 
-  const { showModal } = useModalContext();
-  const updateProfile = useUpdateEndowmentProfile();
+	const { showModal } = useModalContext();
+	const updateProfile = useUpdateEndowmentProfile();
 
-  const submit: SubmitHandler<FV> = async ({ initial, ...fv }) => {
-    try {
-      const [imageURL, ...milestoneMediaURLs] = await uploadImgs(
-        [fv.image, ...fv.milestones.map((m) => m.milestone_media)],
-        () => {
-          showModal(
-            TxPrompt,
-            { loading: "Uploading images.." },
-            { isDismissible: false }
-          );
-        }
-      );
+	const submit: SubmitHandler<FV> = async ({ initial, ...fv }) => {
+		try {
+			const [imageURL, ...milestoneMediaURLs] = await uploadImgs(
+				[fv.image, ...fv.milestones.map((m) => m.milestone_media)],
+				() => {
+					showModal(
+						TxPrompt,
+						{ loading: "Uploading images.." },
+						{ isDismissible: false },
+					);
+				},
+			);
 
-      //having initial value means form is for editing
+			//having initial value means form is for editing
 
-      const program: Program = {
-        program_title: fv.title,
-        program_id: initial ? initial.program_id : window.crypto.randomUUID(),
-        program_description: fv.description,
-        program_banner: imageURL,
-        program_milestones: fv.milestones.map(({ idx, ...m }, i) => ({
-          ...m,
-          milestone_date: new Date(m.milestone_date).toISOString(),
-          milestone_media: milestoneMediaURLs[i],
-        })),
-      };
+			const program: Program = {
+				program_title: fv.title,
+				program_id: initial ? initial.program_id : window.crypto.randomUUID(),
+				program_description: fv.description.value,
+				program_banner: imageURL,
+				program_milestones: fv.milestones.map(({ idx, ...m }, i) => ({
+					...m,
+					milestone_date: new Date(m.milestone_date).toISOString(),
+					milestone_media: milestoneMediaURLs[i],
+				})),
+			};
 
-      if (initial) {
-        const diff = getPayloadDiff(initial, program);
-        if (isEmpty(diff)) {
-          return showModal(TxPrompt, { error: "No changes detected" });
-        }
-      }
+			if (initial) {
+				const diff = getPayloadDiff(initial, program);
+				if (isEmpty(diff)) {
+					return showModal(TxPrompt, { error: "No changes detected" });
+				}
+			}
 
-      const updates: ProfileUpdateMsg = {
-        id,
-        program: [program],
-      };
-      await updateProfile(updates);
-      if (!initial) reset(); //for new program, reset form after submit
-    } catch (err) {
-      logger.error(err);
-      showModal(TxPrompt, {
-        error: err instanceof Error ? err.message : "Unknown error occured",
-      });
-    }
-  };
+			const updates: ProfileUpdateMsg = {
+				id,
+				program: [program],
+			};
+			await updateProfile(updates);
+			if (!initial) reset(); //for new program, reset form after submit
+		} catch (err) {
+			logger.error(err);
+			showModal(TxPrompt, {
+				error: err instanceof Error ? err.message : "Unknown error occured",
+			});
+		}
+	};
 
-  return {
-    reset,
-    submit: handleSubmit(submit),
-    isSubmitting,
-    id,
-    initial: getValues("initial"),
-  };
+	return {
+		reset,
+		submit: handleSubmit(submit),
+		isSubmitting,
+		id,
+		initial: getValues("initial"),
+	};
 }
 
 async function uploadImgs(
-  imgs: ImgLink[],
-  onUpload: () => void
+	imgs: ImgLink[],
+	onUpload: () => void,
 ): Promise<string[]> {
-  const files = imgs.flatMap((img) => (img.file ? [img.file] : []));
-  if (!isEmpty(files)) onUpload();
-  const baseURL = await uploadFiles(files, "endow-profiles");
-  return imgs.map((img) =>
-    img.file && baseURL ? getFullURL(baseURL, img.file.name) : img.publicUrl
-  );
+	const files = imgs.flatMap((img) => (img.file ? [img.file] : []));
+	if (!isEmpty(files)) onUpload();
+	const baseURL = await uploadFiles(files, "endow-profiles");
+	return imgs.map((img) =>
+		img.file && baseURL ? getFullURL(baseURL, img.file.name) : img.publicUrl,
+	);
 }

--- a/src/pages/Admin/Charity/ProgramEditor/useSubmit.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/useSubmit.ts
@@ -47,6 +47,7 @@ export default function useSubmit() {
 					...m,
 					milestone_date: new Date(m.milestone_date).toISOString(),
 					milestone_media: milestoneMediaURLs[i],
+					milestone_description: m.milestone_description.value,
 				})),
 			};
 

--- a/src/pages/Admin/Charity/ProgramEditor/useSubmit.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/useSubmit.ts
@@ -31,9 +31,9 @@ export default function useSubmit() {
           showModal(
             TxPrompt,
             { loading: "Uploading images.." },
-            { isDismissible: false },
+            { isDismissible: false }
           );
-        },
+        }
       );
 
       //having initial value means form is for editing
@@ -83,12 +83,12 @@ export default function useSubmit() {
 
 async function uploadImgs(
   imgs: ImgLink[],
-  onUpload: () => void,
+  onUpload: () => void
 ): Promise<string[]> {
   const files = imgs.flatMap((img) => (img.file ? [img.file] : []));
   if (!isEmpty(files)) onUpload();
   const baseURL = await uploadFiles(files, "endow-profiles");
   return imgs.map((img) =>
-    img.file && baseURL ? getFullURL(baseURL, img.file.name) : img.publicUrl,
+    img.file && baseURL ? getFullURL(baseURL, img.file.name) : img.publicUrl
   );
 }

--- a/src/pages/Gift/Mailer/Form.tsx
+++ b/src/pages/Gift/Mailer/Form.tsx
@@ -31,7 +31,7 @@ export default function Form({ classes = "" }) {
         body: JSON.stringify({
           email: recipient.email,
           secret,
-          note: richTextToHTML(message),
+          note: richTextToHTML(message.value),
         }),
       });
 

--- a/src/pages/Gift/Mailer/index.tsx
+++ b/src/pages/Gift/Mailer/index.tsx
@@ -6,24 +6,24 @@ import Form from "./Form";
 import { schema } from "./schema";
 
 export default function Mailer({ classes = "" }) {
-	const { state } = useLocation();
-	const _state = state as { secret: string } | null;
+  const { state } = useLocation();
+  const _state = state as { secret: string } | null;
 
-	const methods = useForm<FormValues>({
-		defaultValues: {
-			recipient: { name: "", email: "" },
-			message: { value: "" },
-			secret: _state?.secret,
-		},
-		resolver: yupResolver(schema),
-	});
+  const methods = useForm<FormValues>({
+    defaultValues: {
+      recipient: { name: "", email: "" },
+      message: { value: "" },
+      secret: _state?.secret,
+    },
+    resolver: yupResolver(schema),
+  });
 
-	// if (!_state) {
-	//   return <Navigate to={`../${routes.index}`} />;
-	// }
-	return (
-		<FormProvider {...methods}>
-			<Form classes={classes} />
-		</FormProvider>
-	);
+  // if (!_state) {
+  //   return <Navigate to={`../${routes.index}`} />;
+  // }
+  return (
+    <FormProvider {...methods}>
+      <Form classes={classes} />
+    </FormProvider>
+  );
 }

--- a/src/pages/Gift/Mailer/index.tsx
+++ b/src/pages/Gift/Mailer/index.tsx
@@ -7,7 +7,7 @@ import { schema } from "./schema";
 
 export default function Mailer({ classes = "" }) {
   const { state } = useLocation();
-  const _state = state as { secret: string } | null;
+  let _state = state as { secret: string } | null;
 
   const methods = useForm<FormValues>({
     defaultValues: {

--- a/src/pages/Gift/Mailer/index.tsx
+++ b/src/pages/Gift/Mailer/index.tsx
@@ -6,24 +6,24 @@ import Form from "./Form";
 import { schema } from "./schema";
 
 export default function Mailer({ classes = "" }) {
-  const { state } = useLocation();
-  let _state = state as { secret: string } | null;
+	const { state } = useLocation();
+	const _state = state as { secret: string } | null;
 
-  const methods = useForm<FormValues>({
-    defaultValues: {
-      recipient: { name: "", email: "" },
-      message: "",
-      secret: _state?.secret,
-    },
-    resolver: yupResolver(schema),
-  });
+	const methods = useForm<FormValues>({
+		defaultValues: {
+			recipient: { name: "", email: "" },
+			message: { value: "" },
+			secret: _state?.secret,
+		},
+		resolver: yupResolver(schema),
+	});
 
-  // if (!_state) {
-  //   return <Navigate to={`../${routes.index}`} />;
-  // }
-  return (
-    <FormProvider {...methods}>
-      <Form classes={classes} />
-    </FormProvider>
-  );
+	// if (!_state) {
+	//   return <Navigate to={`../${routes.index}`} />;
+	// }
+	return (
+		<FormProvider {...methods}>
+			<Form classes={classes} />
+		</FormProvider>
+	);
 }

--- a/src/pages/Gift/Mailer/schema.ts
+++ b/src/pages/Gift/Mailer/schema.ts
@@ -5,10 +5,10 @@ import { requiredString } from "schemas/string";
 import { richTextContent } from "schemas/shape";
 
 export const schema = object<any, SchemaShape<FV>>({
-	purchaser: requiredString,
-	recipient: object<any, SchemaShape<FV["recipient"]>>({
-		name: requiredString,
-		email: requiredString.email("invalid email"),
-	}),
-	message: richTextContent(),
+  purchaser: requiredString,
+  recipient: object<any, SchemaShape<FV["recipient"]>>({
+    name: requiredString,
+    email: requiredString.email("invalid email"),
+  }),
+  message: richTextContent(),
 }) as ObjectSchema<FV>;

--- a/src/pages/Gift/Mailer/schema.ts
+++ b/src/pages/Gift/Mailer/schema.ts
@@ -1,8 +1,8 @@
-import { ObjectSchema, object, string } from "yup";
+import { ObjectSchema, object } from "yup";
 import { FormValues as FV } from "./types";
 import { SchemaShape } from "schemas/types";
-import { requiredString } from "schemas/string";
 import { richTextContent } from "schemas/shape";
+import { requiredString } from "schemas/string";
 
 export const schema = object<any, SchemaShape<FV>>({
   purchaser: requiredString,

--- a/src/pages/Gift/Mailer/schema.ts
+++ b/src/pages/Gift/Mailer/schema.ts
@@ -2,12 +2,13 @@ import { ObjectSchema, object, string } from "yup";
 import { FormValues as FV } from "./types";
 import { SchemaShape } from "schemas/types";
 import { requiredString } from "schemas/string";
+import { richTextContent } from "schemas/shape";
 
 export const schema = object<any, SchemaShape<FV>>({
-  purchaser: requiredString,
-  recipient: object<any, SchemaShape<FV["recipient"]>>({
-    name: requiredString,
-    email: requiredString.email("invalid email"),
-  }),
-  message: string(),
+	purchaser: requiredString,
+	recipient: object<any, SchemaShape<FV["recipient"]>>({
+		name: requiredString,
+		email: requiredString.email("invalid email"),
+	}),
+	message: richTextContent(),
 }) as ObjectSchema<FV>;

--- a/src/pages/Gift/Mailer/types.ts
+++ b/src/pages/Gift/Mailer/types.ts
@@ -1,8 +1,10 @@
-export type FormValues = {
-  purchaser: string;
-  recipient: { name: string; email: string };
-  message: string;
+import { RichTextContent } from "types/components";
 
-  //meta
-  secret: string;
+export type FormValues = {
+	purchaser: string;
+	recipient: { name: string; email: string };
+	message: RichTextContent;
+
+	//meta
+	secret: string;
 };

--- a/src/pages/Gift/Mailer/types.ts
+++ b/src/pages/Gift/Mailer/types.ts
@@ -1,10 +1,10 @@
 import { RichTextContent } from "types/components";
 
 export type FormValues = {
-	purchaser: string;
-	recipient: { name: string; email: string };
-	message: RichTextContent;
+  purchaser: string;
+  recipient: { name: string; email: string };
+  message: RichTextContent;
 
-	//meta
-	secret: string;
+  //meta
+  secret: string;
 };

--- a/src/pages/Profile/Body/GeneralInfo/GeneralInfo.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/GeneralInfo.tsx
@@ -6,26 +6,26 @@ import DetailsColumn from "./DetailsColumn";
 import Programs from "./Programs";
 
 export default function GeneralInfo({ className = "" }) {
-  const profile = useProfileContext();
-  return (
-    <div
-      className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
-    >
-      <div className="flex flex-col gap-8 w-full h-full">
-        <Container title="Overview">
-          <RichText
-            content={profile.overview}
-            classes={{ container: "w-full h-full px-8 py-10" }}
-            readOnly
-          />
-        </Container>
-        {!isEmpty(profile.program) && (
-          <Container title="Programs">
-            <Programs />
-          </Container>
-        )}
-      </div>
-      <DetailsColumn className="self-start lg:sticky lg:top-28" />
-    </div>
-  );
+	const profile = useProfileContext();
+	return (
+		<div
+			className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
+		>
+			<div className="flex flex-col gap-8 w-full h-full">
+				<Container title="Overview">
+					<RichText
+						content={{ value: profile.overview, length: 0 }}
+						classes={{ container: "w-full h-full px-8 py-10" }}
+						readOnly
+					/>
+				</Container>
+				{!isEmpty(profile.program) && (
+					<Container title="Programs">
+						<Programs />
+					</Container>
+				)}
+			</div>
+			<DetailsColumn className="self-start lg:sticky lg:top-28" />
+		</div>
+	);
 }

--- a/src/pages/Profile/Body/GeneralInfo/GeneralInfo.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/GeneralInfo.tsx
@@ -14,7 +14,7 @@ export default function GeneralInfo({ className = "" }) {
 			<div className="flex flex-col gap-8 w-full h-full">
 				<Container title="Overview">
 					<RichText
-						content={{ value: profile.overview, length: 0 }}
+						content={{ value: profile.overview }}
 						classes={{ container: "w-full h-full px-8 py-10" }}
 						readOnly
 					/>

--- a/src/pages/Profile/Body/GeneralInfo/GeneralInfo.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/GeneralInfo.tsx
@@ -6,26 +6,26 @@ import DetailsColumn from "./DetailsColumn";
 import Programs from "./Programs";
 
 export default function GeneralInfo({ className = "" }) {
-	const profile = useProfileContext();
-	return (
-		<div
-			className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
-		>
-			<div className="flex flex-col gap-8 w-full h-full">
-				<Container title="Overview">
-					<RichText
-						content={{ value: profile.overview }}
-						classes={{ container: "w-full h-full px-8 py-10" }}
-						readOnly
-					/>
-				</Container>
-				{!isEmpty(profile.program) && (
-					<Container title="Programs">
-						<Programs />
-					</Container>
-				)}
-			</div>
-			<DetailsColumn className="self-start lg:sticky lg:top-28" />
-		</div>
-	);
+  const profile = useProfileContext();
+  return (
+    <div
+      className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
+    >
+      <div className="flex flex-col gap-8 w-full h-full">
+        <Container title="Overview">
+          <RichText
+            content={{ value: profile.overview }}
+            classes={{ container: "w-full h-full px-8 py-10" }}
+            readOnly
+          />
+        </Container>
+        {!isEmpty(profile.program) && (
+          <Container title="Programs">
+            <Programs />
+          </Container>
+        )}
+      </div>
+      <DetailsColumn className="self-start lg:sticky lg:top-28" />
+    </div>
+  );
 }

--- a/src/pages/Profile/Body/GeneralInfo/Programs.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/Programs.tsx
@@ -26,7 +26,7 @@ function Program(props: TProgram) {
 			<div className="p-5">
 				<p className="text-lg font-bold mb-3 block">{props.program_title}</p>
 				<RichText
-					content={{ value: props.program_description, length: 0 }}
+					content={{ value: props.program_description }}
 					readOnly
 					classes={{ container: "overflow-hidden h-32" }}
 				/>

--- a/src/pages/Profile/Body/GeneralInfo/Programs.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/Programs.tsx
@@ -5,32 +5,32 @@ import RichText from "components/RichText";
 import { useProfileContext } from "../../ProfileContext";
 
 export default function Programs() {
-	const { program } = useProfileContext();
-	return (
-		<div className="w-full h-full px-8 py-10 grid sm:grid-cols-[repeat(auto-fill,minmax(373px,1fr))] gap-8">
-			{program.map((p) => (
-				<Program {...p} key={p.program_id} />
-			))}
-		</div>
-	);
+  const { program } = useProfileContext();
+  return (
+    <div className="w-full h-full px-8 py-10 grid sm:grid-cols-[repeat(auto-fill,minmax(373px,1fr))] gap-8">
+      {program.map((p) => (
+        <Program {...p} key={p.program_id} />
+      ))}
+    </div>
+  );
 }
 
 function Program(props: TProgram) {
-	return (
-		<div className="border border-prim rounded relative group overflow-hidden">
-			<Link
-				to={`program/${props.program_id}`}
-				className="absolute inset-0 group-hover:border group-hover:border-orange dark:group-hover:border-blue"
-			/>
-			<Image src={props.program_banner} className="h-64 w-full object-cover " />
-			<div className="p-5">
-				<p className="text-lg font-bold mb-3 block">{props.program_title}</p>
-				<RichText
-					content={{ value: props.program_description }}
-					readOnly
-					classes={{ container: "overflow-hidden h-32" }}
-				/>
-			</div>
-		</div>
-	);
+  return (
+    <div className="border border-prim rounded relative group overflow-hidden">
+      <Link
+        to={`program/${props.program_id}`}
+        className="absolute inset-0 group-hover:border group-hover:border-orange dark:group-hover:border-blue"
+      />
+      <Image src={props.program_banner} className="h-64 w-full object-cover " />
+      <div className="p-5">
+        <p className="text-lg font-bold mb-3 block">{props.program_title}</p>
+        <RichText
+          content={{ value: props.program_description }}
+          readOnly
+          classes={{ container: "overflow-hidden h-32" }}
+        />
+      </div>
+    </div>
+  );
 }

--- a/src/pages/Profile/Body/GeneralInfo/Programs.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/Programs.tsx
@@ -5,32 +5,32 @@ import RichText from "components/RichText";
 import { useProfileContext } from "../../ProfileContext";
 
 export default function Programs() {
-  const { program } = useProfileContext();
-  return (
-    <div className="w-full h-full px-8 py-10 grid sm:grid-cols-[repeat(auto-fill,minmax(373px,1fr))] gap-8">
-      {program.map((p) => (
-        <Program {...p} key={p.program_id} />
-      ))}
-    </div>
-  );
+	const { program } = useProfileContext();
+	return (
+		<div className="w-full h-full px-8 py-10 grid sm:grid-cols-[repeat(auto-fill,minmax(373px,1fr))] gap-8">
+			{program.map((p) => (
+				<Program {...p} key={p.program_id} />
+			))}
+		</div>
+	);
 }
 
 function Program(props: TProgram) {
-  return (
-    <div className="border border-prim rounded relative group overflow-hidden">
-      <Link
-        to={`program/${props.program_id}`}
-        className="absolute inset-0 group-hover:border group-hover:border-orange dark:group-hover:border-blue"
-      />
-      <Image src={props.program_banner} className="h-64 w-full object-cover " />
-      <div className="p-5">
-        <p className="text-lg font-bold mb-3 block">{props.program_title}</p>
-        <RichText
-          content={props.program_description}
-          readOnly
-          classes={{ container: "overflow-hidden h-32" }}
-        />
-      </div>
-    </div>
-  );
+	return (
+		<div className="border border-prim rounded relative group overflow-hidden">
+			<Link
+				to={`program/${props.program_id}`}
+				className="absolute inset-0 group-hover:border group-hover:border-orange dark:group-hover:border-blue"
+			/>
+			<Image src={props.program_banner} className="h-64 w-full object-cover " />
+			<div className="p-5">
+				<p className="text-lg font-bold mb-3 block">{props.program_title}</p>
+				<RichText
+					content={{ value: props.program_description, length: 0 }}
+					readOnly
+					classes={{ container: "overflow-hidden h-32" }}
+				/>
+			</div>
+		</div>
+	);
 }

--- a/src/pages/Profile/Body/Program/Milestones.tsx
+++ b/src/pages/Profile/Body/Program/Milestones.tsx
@@ -6,71 +6,71 @@ import { isEmpty } from "helpers";
 import Container from "../common/Container";
 
 type Props = {
-  classes?: string;
-  milestones: TMilestone[];
+	classes?: string;
+	milestones: TMilestone[];
 };
 
 export default function Milestones({ classes = "", milestones }: Props) {
-  return (
-    <Container
-      title="Milestones"
-      classes={classes + " w-full lg:w-[29.75rem]"}
-      expanded
-    >
-      {!isEmpty(milestones) ? (
-        <div className="m-6 sm:m-8">
-          {milestones.map((m, idx) => (
-            <Milestone {...m} key={idx} />
-          ))}
-        </div>
-      ) : (
-        <Info classes="m-6">No milestones found</Info>
-      )}
-    </Container>
-  );
+	return (
+		<Container
+			title="Milestones"
+			classes={classes + " w-full lg:w-[29.75rem]"}
+			expanded
+		>
+			{!isEmpty(milestones) ? (
+				<div className="m-6 sm:m-8">
+					{milestones.map((m, idx) => (
+						<Milestone {...m} key={idx} />
+					))}
+				</div>
+			) : (
+				<Info classes="m-6">No milestones found</Info>
+			)}
+		</Container>
+	);
 }
 
 function Milestone({
-  milestone_media,
-  milestone_date,
-  milestone_title,
-  milestone_description,
+	milestone_media,
+	milestone_date,
+	milestone_title,
+	milestone_description,
 }: TMilestone) {
-  const isComplete = new Date() >= new Date(milestone_date);
+	const isComplete = new Date() >= new Date(milestone_date);
 
-  return (
-    <div
-      className={`pb-4 pt-4 first:pt-0 last:pb-0 border-l ${
-        isComplete ? "border-orange" : "border-prim"
-      }`}
-    >
-      {milestone_media && (
-        <div className="pl-6 sm:pl-8">
-          <Image src={milestone_media} className="h-60 w-full rounded" />
-        </div>
-      )}
+	return (
+		<div
+			className={`pb-4 pt-4 first:pt-0 last:pb-0 border-l ${
+				isComplete ? "border-orange" : "border-prim"
+			}`}
+		>
+			{milestone_media && (
+				<div className="pl-6 sm:pl-8">
+					<Image src={milestone_media} className="h-60 w-full rounded" />
+				</div>
+			)}
 
-      <p className="mt-4 pl-6 sm:pl-8 mb-3 text-gray-d1 dark:text-gray text-xs">
-        {new Date(milestone_date).toLocaleDateString()}
-      </p>
-      <h6 className="pl-6 sm:pl-8 font-bold font-work mb-3 relative">
-        {milestone_title}
-        <span className="bg-white dark:bg-blue-d6 w-4 h-6 absolute left-[-0.5px] top-1/2 -translate-y-1/2 -translate-x-1/2" />
-        <span
-          className={`${
-            isComplete ? "bg-orange" : "bg-gray-l3 dark:bg-bluegray"
-          } w-4 h-4 rounded-full absolute left-[-0.5px] top-1/2 -translate-y-1/2 -translate-x-1/2`}
-        />
-      </h6>
-      <div className="pl-6 sm:pl-8">
-        <RichText
-          content={milestone_description}
-          readOnly
-          classes={{
-            container: "text-gray-d1 dark:text-gray text-sm w-full",
-          }}
-        />
-      </div>
-    </div>
-  );
+			<p className="mt-4 pl-6 sm:pl-8 mb-3 text-gray-d1 dark:text-gray text-xs">
+				{new Date(milestone_date).toLocaleDateString()}
+			</p>
+			<h6 className="pl-6 sm:pl-8 font-bold font-work mb-3 relative">
+				{milestone_title}
+				<span className="bg-white dark:bg-blue-d6 w-4 h-6 absolute left-[-0.5px] top-1/2 -translate-y-1/2 -translate-x-1/2" />
+				<span
+					className={`${
+						isComplete ? "bg-orange" : "bg-gray-l3 dark:bg-bluegray"
+					} w-4 h-4 rounded-full absolute left-[-0.5px] top-1/2 -translate-y-1/2 -translate-x-1/2`}
+				/>
+			</h6>
+			<div className="pl-6 sm:pl-8">
+				<RichText
+					content={{ value: milestone_description, length: 0 }}
+					readOnly
+					classes={{
+						container: "text-gray-d1 dark:text-gray text-sm w-full",
+					}}
+				/>
+			</div>
+		</div>
+	);
 }

--- a/src/pages/Profile/Body/Program/Milestones.tsx
+++ b/src/pages/Profile/Body/Program/Milestones.tsx
@@ -64,7 +64,7 @@ function Milestone({
 			</h6>
 			<div className="pl-6 sm:pl-8">
 				<RichText
-					content={{ value: milestone_description, length: 0 }}
+					content={{ value: milestone_description }}
 					readOnly
 					classes={{
 						container: "text-gray-d1 dark:text-gray text-sm w-full",

--- a/src/pages/Profile/Body/Program/Milestones.tsx
+++ b/src/pages/Profile/Body/Program/Milestones.tsx
@@ -6,71 +6,71 @@ import { isEmpty } from "helpers";
 import Container from "../common/Container";
 
 type Props = {
-	classes?: string;
-	milestones: TMilestone[];
+  classes?: string;
+  milestones: TMilestone[];
 };
 
 export default function Milestones({ classes = "", milestones }: Props) {
-	return (
-		<Container
-			title="Milestones"
-			classes={classes + " w-full lg:w-[29.75rem]"}
-			expanded
-		>
-			{!isEmpty(milestones) ? (
-				<div className="m-6 sm:m-8">
-					{milestones.map((m, idx) => (
-						<Milestone {...m} key={idx} />
-					))}
-				</div>
-			) : (
-				<Info classes="m-6">No milestones found</Info>
-			)}
-		</Container>
-	);
+  return (
+    <Container
+      title="Milestones"
+      classes={classes + " w-full lg:w-[29.75rem]"}
+      expanded
+    >
+      {!isEmpty(milestones) ? (
+        <div className="m-6 sm:m-8">
+          {milestones.map((m, idx) => (
+            <Milestone {...m} key={idx} />
+          ))}
+        </div>
+      ) : (
+        <Info classes="m-6">No milestones found</Info>
+      )}
+    </Container>
+  );
 }
 
 function Milestone({
-	milestone_media,
-	milestone_date,
-	milestone_title,
-	milestone_description,
+  milestone_media,
+  milestone_date,
+  milestone_title,
+  milestone_description,
 }: TMilestone) {
-	const isComplete = new Date() >= new Date(milestone_date);
+  const isComplete = new Date() >= new Date(milestone_date);
 
-	return (
-		<div
-			className={`pb-4 pt-4 first:pt-0 last:pb-0 border-l ${
-				isComplete ? "border-orange" : "border-prim"
-			}`}
-		>
-			{milestone_media && (
-				<div className="pl-6 sm:pl-8">
-					<Image src={milestone_media} className="h-60 w-full rounded" />
-				</div>
-			)}
+  return (
+    <div
+      className={`pb-4 pt-4 first:pt-0 last:pb-0 border-l ${
+        isComplete ? "border-orange" : "border-prim"
+      }`}
+    >
+      {milestone_media && (
+        <div className="pl-6 sm:pl-8">
+          <Image src={milestone_media} className="h-60 w-full rounded" />
+        </div>
+      )}
 
-			<p className="mt-4 pl-6 sm:pl-8 mb-3 text-gray-d1 dark:text-gray text-xs">
-				{new Date(milestone_date).toLocaleDateString()}
-			</p>
-			<h6 className="pl-6 sm:pl-8 font-bold font-work mb-3 relative">
-				{milestone_title}
-				<span className="bg-white dark:bg-blue-d6 w-4 h-6 absolute left-[-0.5px] top-1/2 -translate-y-1/2 -translate-x-1/2" />
-				<span
-					className={`${
-						isComplete ? "bg-orange" : "bg-gray-l3 dark:bg-bluegray"
-					} w-4 h-4 rounded-full absolute left-[-0.5px] top-1/2 -translate-y-1/2 -translate-x-1/2`}
-				/>
-			</h6>
-			<div className="pl-6 sm:pl-8">
-				<RichText
-					content={{ value: milestone_description }}
-					readOnly
-					classes={{
-						container: "text-gray-d1 dark:text-gray text-sm w-full",
-					}}
-				/>
-			</div>
-		</div>
-	);
+      <p className="mt-4 pl-6 sm:pl-8 mb-3 text-gray-d1 dark:text-gray text-xs">
+        {new Date(milestone_date).toLocaleDateString()}
+      </p>
+      <h6 className="pl-6 sm:pl-8 font-bold font-work mb-3 relative">
+        {milestone_title}
+        <span className="bg-white dark:bg-blue-d6 w-4 h-6 absolute left-[-0.5px] top-1/2 -translate-y-1/2 -translate-x-1/2" />
+        <span
+          className={`${
+            isComplete ? "bg-orange" : "bg-gray-l3 dark:bg-bluegray"
+          } w-4 h-4 rounded-full absolute left-[-0.5px] top-1/2 -translate-y-1/2 -translate-x-1/2`}
+        />
+      </h6>
+      <div className="pl-6 sm:pl-8">
+        <RichText
+          content={{ value: milestone_description }}
+          readOnly
+          classes={{
+            container: "text-gray-d1 dark:text-gray text-sm w-full",
+          }}
+        />
+      </div>
+    </div>
+  );
 }

--- a/src/pages/Profile/Body/Program/Program.tsx
+++ b/src/pages/Profile/Body/Program/Program.tsx
@@ -24,7 +24,7 @@ export default function Program({ className = "" }) {
 				>
 					<Container title={p.program_title} expanded>
 						<RichText
-							content={{ value: p.program_description, length: 0 }}
+							content={{ value: p.program_description }}
 							readOnly
 							classes={{ container: "m-6" }}
 						/>

--- a/src/pages/Profile/Body/Program/Program.tsx
+++ b/src/pages/Profile/Body/Program/Program.tsx
@@ -8,49 +8,49 @@ import Container from "../common/Container";
 import Milestones from "./Milestones";
 
 export default function Program({ className = "" }) {
-	const { id: endowId } = useProfileContext();
-	const { id: programId = "" } = useParams();
-	const query = useProgramQuery({ endowId, programId }, { skip: !programId });
+  const { id: endowId } = useProfileContext();
+  const { id: programId = "" } = useParams();
+  const query = useProgramQuery({ endowId, programId }, { skip: !programId });
 
-	return (
-		<QueryLoader
-			queryState={query}
-			classes={{ container: className }}
-			messages={{ loading: <Skeleton className={className} /> }}
-		>
-			{(p) => (
-				<div
-					className={`${className} grid items-start grid-rows-[auto_auto] gap-8 w-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
-				>
-					<Container title={p.program_title} expanded>
-						<RichText
-							content={{ value: p.program_description }}
-							readOnly
-							classes={{ container: "m-6" }}
-						/>
-					</Container>
-					<Milestones
-						classes="self-start lg:sticky lg:top-28"
-						milestones={p.program_milestones}
-					/>
-				</div>
-			)}
-		</QueryLoader>
-	);
+  return (
+    <QueryLoader
+      queryState={query}
+      classes={{ container: className }}
+      messages={{ loading: <Skeleton className={className} /> }}
+    >
+      {(p) => (
+        <div
+          className={`${className} grid items-start grid-rows-[auto_auto] gap-8 w-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
+        >
+          <Container title={p.program_title} expanded>
+            <RichText
+              content={{ value: p.program_description }}
+              readOnly
+              classes={{ container: "m-6" }}
+            />
+          </Container>
+          <Milestones
+            classes="self-start lg:sticky lg:top-28"
+            milestones={p.program_milestones}
+          />
+        </div>
+      )}
+    </QueryLoader>
+  );
 }
 
 function Skeleton({ className = "" }) {
-	return (
-		<div
-			className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
-		>
-			<ContentLoader className="h-80" />
-			<div className="self-start lg:sticky lg:top-28 flex flex-col gap-8 w-full lg:w-[29.75rem] p-8 border border-prim rounded">
-				<ContentLoader className="h-40" />
-				<ContentLoader className="h-40" />
-				<ContentLoader className="h-40" />
-				<ContentLoader className="h-40" />
-			</div>
-		</div>
-	);
+  return (
+    <div
+      className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
+    >
+      <ContentLoader className="h-80" />
+      <div className="self-start lg:sticky lg:top-28 flex flex-col gap-8 w-full lg:w-[29.75rem] p-8 border border-prim rounded">
+        <ContentLoader className="h-40" />
+        <ContentLoader className="h-40" />
+        <ContentLoader className="h-40" />
+        <ContentLoader className="h-40" />
+      </div>
+    </div>
+  );
 }

--- a/src/pages/Profile/Body/Program/Program.tsx
+++ b/src/pages/Profile/Body/Program/Program.tsx
@@ -8,49 +8,49 @@ import Container from "../common/Container";
 import Milestones from "./Milestones";
 
 export default function Program({ className = "" }) {
-  const { id: endowId } = useProfileContext();
-  const { id: programId = "" } = useParams();
-  const query = useProgramQuery({ endowId, programId }, { skip: !programId });
+	const { id: endowId } = useProfileContext();
+	const { id: programId = "" } = useParams();
+	const query = useProgramQuery({ endowId, programId }, { skip: !programId });
 
-  return (
-    <QueryLoader
-      queryState={query}
-      classes={{ container: className }}
-      messages={{ loading: <Skeleton className={className} /> }}
-    >
-      {(p) => (
-        <div
-          className={`${className} grid items-start grid-rows-[auto_auto] gap-8 w-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
-        >
-          <Container title={p.program_title} expanded>
-            <RichText
-              content={p.program_description}
-              readOnly
-              classes={{ container: "m-6" }}
-            />
-          </Container>
-          <Milestones
-            classes="self-start lg:sticky lg:top-28"
-            milestones={p.program_milestones}
-          />
-        </div>
-      )}
-    </QueryLoader>
-  );
+	return (
+		<QueryLoader
+			queryState={query}
+			classes={{ container: className }}
+			messages={{ loading: <Skeleton className={className} /> }}
+		>
+			{(p) => (
+				<div
+					className={`${className} grid items-start grid-rows-[auto_auto] gap-8 w-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
+				>
+					<Container title={p.program_title} expanded>
+						<RichText
+							content={{ value: p.program_description, length: 0 }}
+							readOnly
+							classes={{ container: "m-6" }}
+						/>
+					</Container>
+					<Milestones
+						classes="self-start lg:sticky lg:top-28"
+						milestones={p.program_milestones}
+					/>
+				</div>
+			)}
+		</QueryLoader>
+	);
 }
 
 function Skeleton({ className = "" }) {
-  return (
-    <div
-      className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
-    >
-      <ContentLoader className="h-80" />
-      <div className="self-start lg:sticky lg:top-28 flex flex-col gap-8 w-full lg:w-[29.75rem] p-8 border border-prim rounded">
-        <ContentLoader className="h-40" />
-        <ContentLoader className="h-40" />
-        <ContentLoader className="h-40" />
-        <ContentLoader className="h-40" />
-      </div>
-    </div>
-  );
+	return (
+		<div
+			className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
+		>
+			<ContentLoader className="h-80" />
+			<div className="self-start lg:sticky lg:top-28 flex flex-col gap-8 w-full lg:w-[29.75rem] p-8 border border-prim rounded">
+				<ContentLoader className="h-40" />
+				<ContentLoader className="h-40" />
+				<ContentLoader className="h-40" />
+				<ContentLoader className="h-40" />
+			</div>
+		</div>
+	);
 }

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -1,30 +1,53 @@
-import { lazy, object, string } from "yup";
-import { SchemaShape } from "./types";
-import { OptionType } from "types/components";
+import { OptionType, RichTextContent } from "types/components";
 import type { TokenWithAmount as TWA } from "types/tx";
+import { lazy, mixed, object, string } from "yup";
 import { tokenConstraint } from "./number";
 import { requiredString } from "./string";
+import { SchemaShape } from "./types";
 
 type Key = keyof TWA;
 type Min = TWA["min_donation_amnt"];
 const minKey: Key = "min_donation_amnt";
 
 export const tokenShape = (withMin = true): SchemaShape<TWA> => ({
-  token_id: string().required("select token"),
-  amount: lazy((amount: string) =>
-    amount === ""
-      ? requiredString
-      : tokenConstraint.when([minKey], (values, schema) => {
-          const [minAmount] = values as [Min];
-          return withMin && !!minAmount
-            ? schema.min(minAmount || 0, `amount must be at least ${minAmount}`)
-            : schema;
-        })
-  ),
+	token_id: string().required("select token"),
+	amount: lazy((amount: string) =>
+		amount === ""
+			? requiredString
+			: tokenConstraint.when([minKey], (values, schema) => {
+					const [minAmount] = values as [Min];
+					return withMin && !!minAmount
+						? schema.min(minAmount || 0, `amount must be at least ${minAmount}`)
+						: schema;
+			  }),
+	),
 });
 
 export const optionType = ({ required } = { required: false }) =>
-  object<any, SchemaShape<OptionType<string>>>({
-    label: required ? requiredString : string(),
-    value: required ? requiredString : string(),
-  });
+	object<any, SchemaShape<OptionType<string>>>({
+		label: required ? requiredString : string(),
+		value: required ? requiredString : string(),
+	});
+
+export function richTextContent(options: {
+	maxChars: number;
+	required?: boolean;
+}) {
+	const { maxChars, required = false } = options;
+
+	let schema = mixed<RichTextContent>().test({
+		name: "must be below character limit",
+		message: `max length is ${maxChars} chars`,
+		test: (descr) => (descr?.length || 0) <= maxChars,
+	});
+
+	if (required) {
+		schema = schema.test({
+			name: "required",
+			message: "required",
+			test: (descr) => !!descr?.value,
+		});
+	}
+
+	return schema;
+}

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -19,7 +19,7 @@ export const tokenShape = (withMin = true): SchemaShape<TWA> => ({
           return withMin && !!minAmount
             ? schema.min(minAmount || 0, `amount must be at least ${minAmount}`)
             : schema;
-        }),
+        })
   ),
 });
 

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -43,14 +43,14 @@ export function richTextContent(
     schema = schema.test({
       name: "must be below character limit",
       message: `max length is ${maxChars} chars`,
-      test: (descr) => (descr?.length || 0) <= maxChars,
+      test: (content) => (content?.length || 0) <= maxChars,
     });
   }
   if (required) {
     schema = schema.test({
       name: "required",
       message: "required",
-      test: (descr) => !!descr?.value,
+      test: (content) => !!content?.value,
     });
   }
 

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -1,9 +1,9 @@
+import { lazy, mixed, object, string } from "yup";
+import { SchemaShape } from "./types";
 import { OptionType, RichTextContent } from "types/components";
 import type { TokenWithAmount as TWA } from "types/tx";
-import { lazy, mixed, object, string } from "yup";
 import { tokenConstraint } from "./number";
 import { requiredString } from "./string";
-import { SchemaShape } from "./types";
 
 type Key = keyof TWA;
 type Min = TWA["min_donation_amnt"];
@@ -33,7 +33,7 @@ export function richTextContent(
   options: {
     maxChars?: number;
     required?: boolean;
-  } = {},
+  } = {}
 ) {
   const { maxChars, required = false } = options;
 

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -10,49 +10,49 @@ type Min = TWA["min_donation_amnt"];
 const minKey: Key = "min_donation_amnt";
 
 export const tokenShape = (withMin = true): SchemaShape<TWA> => ({
-	token_id: string().required("select token"),
-	amount: lazy((amount: string) =>
-		amount === ""
-			? requiredString
-			: tokenConstraint.when([minKey], (values, schema) => {
-					const [minAmount] = values as [Min];
-					return withMin && !!minAmount
-						? schema.min(minAmount || 0, `amount must be at least ${minAmount}`)
-						: schema;
-			  }),
-	),
+  token_id: string().required("select token"),
+  amount: lazy((amount: string) =>
+    amount === ""
+      ? requiredString
+      : tokenConstraint.when([minKey], (values, schema) => {
+          const [minAmount] = values as [Min];
+          return withMin && !!minAmount
+            ? schema.min(minAmount || 0, `amount must be at least ${minAmount}`)
+            : schema;
+        }),
+  ),
 });
 
 export const optionType = ({ required } = { required: false }) =>
-	object<any, SchemaShape<OptionType<string>>>({
-		label: required ? requiredString : string(),
-		value: required ? requiredString : string(),
-	});
+  object<any, SchemaShape<OptionType<string>>>({
+    label: required ? requiredString : string(),
+    value: required ? requiredString : string(),
+  });
 
 export function richTextContent(
-	options: {
-		maxChars?: number;
-		required?: boolean;
-	} = {},
+  options: {
+    maxChars?: number;
+    required?: boolean;
+  } = {},
 ) {
-	const { maxChars, required = false } = options;
+  const { maxChars, required = false } = options;
 
-	let schema = mixed<RichTextContent>();
+  let schema = mixed<RichTextContent>();
 
-	if (maxChars != null) {
-		schema = schema.test({
-			name: "must be below character limit",
-			message: `max length is ${maxChars} chars`,
-			test: (descr) => (descr?.length || 0) <= maxChars,
-		});
-	}
-	if (required) {
-		schema = schema.test({
-			name: "required",
-			message: "required",
-			test: (descr) => !!descr?.value,
-		});
-	}
+  if (maxChars != null) {
+    schema = schema.test({
+      name: "must be below character limit",
+      message: `max length is ${maxChars} chars`,
+      test: (descr) => (descr?.length || 0) <= maxChars,
+    });
+  }
+  if (required) {
+    schema = schema.test({
+      name: "required",
+      message: "required",
+      test: (descr) => !!descr?.value,
+    });
+  }
 
-	return schema;
+  return schema;
 }

--- a/src/schemas/shape.ts
+++ b/src/schemas/shape.ts
@@ -29,18 +29,23 @@ export const optionType = ({ required } = { required: false }) =>
 		value: required ? requiredString : string(),
 	});
 
-export function richTextContent(options: {
-	maxChars: number;
-	required?: boolean;
-}) {
+export function richTextContent(
+	options: {
+		maxChars?: number;
+		required?: boolean;
+	} = {},
+) {
 	const { maxChars, required = false } = options;
 
-	let schema = mixed<RichTextContent>().test({
-		name: "must be below character limit",
-		message: `max length is ${maxChars} chars`,
-		test: (descr) => (descr?.length || 0) <= maxChars,
-	});
+	let schema = mixed<RichTextContent>();
 
+	if (maxChars != null) {
+		schema = schema.test({
+			name: "must be below character limit",
+			message: `max length is ${maxChars} chars`,
+			test: (descr) => (descr?.length || 0) <= maxChars,
+		});
+	}
 	if (required) {
 		schema = schema.test({
 			name: "required",

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -6,18 +6,18 @@ export type OptionType<V> = { label: string; value: V };
 
 //dropzone
 export type FileDropzoneAsset = {
-	previews: FileObject[]; //from previous submission
-	files: File[]; //new files
+  previews: FileObject[]; //from previous submission
+  files: File[]; //new files
 };
 
 //country selector
 export type Country = {
-	name: string;
-	flag: string;
-	code: string;
+  name: string;
+  flag: string;
+  code: string;
 };
 
 export type RichTextContent = {
-	value: string;
-	length?: number;
+  value: string;
+  length?: number;
 };

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -6,13 +6,18 @@ export type OptionType<V> = { label: string; value: V };
 
 //dropzone
 export type FileDropzoneAsset = {
-  previews: FileObject[]; //from previous submission
-  files: File[]; //new files
+	previews: FileObject[]; //from previous submission
+	files: File[]; //new files
 };
 
 //country selector
 export type Country = {
-  name: string;
-  flag: string;
-  code: string;
+	name: string;
+	flag: string;
+	code: string;
+};
+
+export type RichTextContent = {
+	value: string;
+	length: number;
 };

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -19,5 +19,5 @@ export type Country = {
 
 export type RichTextContent = {
 	value: string;
-	length: number;
+	length?: number;
 };

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -17,7 +17,22 @@ export type Country = {
   code: string;
 };
 
+/**
+ * Rich text strings contain not only the user input itself, but is a
+ * stringified object that describes the styling of particular parts of
+ * the text (bolding, italics, lists etc.), which complicates getting the
+ * plain character length for checking whether the user has passed the max
+ * char. threshold.
+ * In order to avoid having to extract and calculate the plain text characters
+ * after they have been included in the rich text string, we save the character
+ * length as the text is being typed as a separate parameter and use *it* for
+ * any validation necessary.
+ */
 export type RichTextContent = {
   value: string;
+  /**
+   * Optional because we don't set the length manually, it is calculated
+   * by the RichText component itself and updated on every change.
+   */
   length?: number;
 };


### PR DESCRIPTION
## Explanation of the solution
Closes BG-1147

Source of the problem was obvious - rich text strings contain more than plain user input; they are actually a stringified object that contains styling-related fields and subfields. Calculating the char length for rich texts would require parsing the rich text string, iterating over all of its fields, accessing the appropriate subfields, removing trailing newline chars.

Instead, we can use the fact that we already calculate the exact char length in `RichText`, so just passed this value up as part of the `onChange` hook.

Added a comment explaining this [to the type itself](https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/2744/files#diff-21bebfd3054f5334cdbb7e9249a7ffd6b118b46ecced5f45ef61d54aefd519f0R21).
 
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- sign in with an account that has an associated endowment where you can edit profile and/or add/edit programs
- go to http://localhost:4200/admin/{{ID}}/program-editor/new
- scroll down to description editor
- paste the text that failed validation (see issue's description for the Loom link)
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Viverra maecenas accumsan lacus vel facilisis volutpat. Laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean. Vitae aliquet nec ullamcorper sit. Eget velit aliquet sagittis id consectetur purus ut. Blandit volutpat maecenas volutpat blandit aliquam. Lectus sit amet est placerat. Amet dictum sit amet justo donec. Tortor condimentum lacinia quis vel eros
```
- **verify the issue no longer appears**
