### PR TITLE
Fix bugs #2744

### DIFF
--- a/src/components/RichText/RichText.tsx
+++ b/src/components/RichText/RichText.tsx
@@ -48,10 +48,6 @@ export default function RichText(props: Props) {
         const numChars = quill.getLength() - 1;
         setNumChars(numChars);
 
-        if (props.charLimit && numChars > props.charLimit) {
-          return props.onError(`character limit reached`);
-        }
-
         props.onChange({
           //quill clean state has residual `\n`
           value: numChars <= 0 ? "" : JSON.stringify(quill.getContents()),

--- a/src/components/RichText/RichTextEditor.tsx
+++ b/src/components/RichText/RichTextEditor.tsx
@@ -17,7 +17,6 @@ export function RichTextEditor<T extends FieldValues>(
   } & Pick<Editable, "charLimit" | "placeHolder">
 ) {
   const {
-    setError,
     formState: { isSubmitting },
   } = useFormContext<T>();
   const {
@@ -32,9 +31,6 @@ export function RichTextEditor<T extends FieldValues>(
       <RichText
         content={value}
         onChange={onChange}
-        onError={(error) => {
-          setError(props.fieldName, { message: error });
-        }}
         placeHolder={props.placeHolder}
         charLimit={props.charLimit}
         classes={props.classes}

--- a/src/components/RichText/types.ts
+++ b/src/components/RichText/types.ts
@@ -8,7 +8,6 @@ type ReadOnly = {
 export type Editable = {
   readOnly?: never;
   onChange(content: Required<RichTextContent>): void;
-  onError(error: string): void;
   placeHolder?: string;
   charLimit?: number;
   disabled?: boolean;


### PR DESCRIPTION
## Explanation of the solution
Fixes bugs on:
* #2744
- going back to limits, should remove error
- submission shoudn't pass when exceeding max chars

since validation is now explicity set via `richTextContent`, need to remove implicit `setError` validation so that it doesn't clear form errors set by `richTextContent` on submission



## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
