### PR TITLE
Log error on paypal checkout button loading 

### DIFF
--- a/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Paypal.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Paypal.tsx
@@ -1,6 +1,8 @@
 import { PayPalScriptProvider } from "@paypal/react-paypal-js";
 import ContentLoader from "components/ContentLoader";
 import { PAYPAL_CLIENT_ID } from "constants/env";
+import { logger } from "helpers";
+import { useEffect } from "react";
 import { usePaypalOrderQuery } from "services/apes";
 import { StripeCheckoutStep } from "slices/donation";
 import Checkout from "./Checkout";
@@ -14,6 +16,7 @@ export default function Paypal(props: StripeCheckoutStep) {
     data: orderId,
     isLoading,
     isError,
+    error,
   } = usePaypalOrderQuery({
     amount: +details.amount,
     currency: details.currency.code,
@@ -21,6 +24,12 @@ export default function Paypal(props: StripeCheckoutStep) {
     email: props.donor.email,
     splitLiq: liquidSplitPct.toString(),
   });
+
+  useEffect(() => {
+    if (error) {
+      logger.error(error);
+    }
+  }, [error]);
 
   return isLoading ? (
     <ContentLoader className="rounded h-10 w-40" />

--- a/src/contexts/ErrorContext/ErrorContext.tsx
+++ b/src/contexts/ErrorContext/ErrorContext.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/react";
 import Prompt from "components/Prompt";
 import { GENERIC_ERROR_MESSAGE } from "constants/common";
 import { APError, AP_ERROR_DISCRIMINATOR } from "errors/errors";
@@ -22,7 +21,6 @@ export default function ErrorContext(props: PropsWithChildren<{}>) {
 
   const handleError = useCallback(
     (error: any, displayMessage?: string) => {
-      Sentry.captureException(error);
       logger.error(error);
 
       if (displayMessage) {

--- a/src/errors/ErrorBoundary.tsx
+++ b/src/errors/ErrorBoundary.tsx
@@ -20,7 +20,7 @@ export default class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    logger.error("Caught error:", error, errorInfo);
+    logger.error(`Caught error: ${error}, error info: ${errorInfo}`);
   }
 
   render() {

--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -1,7 +1,8 @@
+import * as Sentry from "@sentry/react";
 import { IS_TEST } from "constants/env";
 
 type Logger = {
-  error: (...data: any[]) => void;
+  error: (message: any) => void;
   info: (...data: any[]) => void;
   log: (...data: any[]) => void;
 };
@@ -10,7 +11,10 @@ export const logger: Logger = IS_TEST
   ? {
       // using console.log for .error and .info funcs as console.error and
       // console.info are undefined while testing for some reason
-      error: (...data) => console.log(...data),
+      error: (message) => {
+        Sentry.captureException(message);
+        console.log(message);
+      },
       info: (...data) => console.log(...data),
       log: (...data) => console.log(...data),
     }


### PR DESCRIPTION
## Explanation of the solution
Builds upon work done in https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/2745#discussion_r1505611023.
We should be logging the error even though nothing is shown to the users, so that we know some issue occurred while loading PayPal.
Related to this, Sentry logging should be moved from ErrorContext into logger, as it allows for more flexibility in logging errors.

Related to BG-1153

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp