### PR TITLE
BG-1179: reduce top padding for DonateFiatThanks

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -38,9 +38,7 @@ export default function App() {
           <Route path=":id" element={<DonateWidget />} />
           <Route
             path={donateWidgetRoutes.donate_fiat_thanks}
-            element={
-              <DonateFiatThanks widgetVersion className="py-8 sm:py-20" />
-            }
+            element={<DonateFiatThanks widgetVersion />}
           />
           <Route
             path={donateWidgetRoutes.stripe_payment_status}
@@ -76,9 +74,7 @@ export default function App() {
           <Route path={`${appRoutes.donate}/:id`} element={<Donate />} />
           <Route
             path={appRoutes.donate_fiat_thanks}
-            element={
-              <DonateFiatThanks className="pt-28 sm:pt-44 pb-8 sm:pb-20" />
-            }
+            element={<DonateFiatThanks />}
           />
           <Route
             path={appRoutes.stripe_payment_status}

--- a/src/pages/DonateFiatThanks.tsx
+++ b/src/pages/DonateFiatThanks.tsx
@@ -6,19 +6,9 @@ import { appRoutes } from "constants/routes";
 import { confetti } from "helpers/confetti";
 import { Link } from "react-router-dom";
 
-type Props = {
-  className?: string;
-  widgetVersion?: boolean;
-};
-
-export default function DonateFiatThanks({
-  widgetVersion = false,
-  className = "",
-}: Props) {
+export default function DonateFiatThanks({ widgetVersion = false }) {
   return (
-    <div
-      className={`grid justify-self-center m-auto max-w-[35rem] px-4 scroll-mt-6 ${className}`}
-    >
+    <div className="grid justify-self-center m-auto max-w-[35rem] px-4 py-8 sm:py-20 scroll-mt-6">
       <div
         className="mb-6 justify-self-center"
         ref={async (node) => {


### PR DESCRIPTION
## Explanation of the solution
Top padding was too big, leftover from when header was floating on the page.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to http://localhost:4200/donate-fiat-thanks

## UI changes for review

Before:
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/19427053/4f71e1ed-7c21-4265-ab09-503e038ab7ae)

After:
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/19427053/90acdfc0-bbad-452e-b132-7580bf7ff102)

