### PR TITLE
Towards BG-1133: Map text/border colors to new default

### DIFF
--- a/src/App/Footer/Newsletter/SubscriptionForm.tsx
+++ b/src/App/Footer/Newsletter/SubscriptionForm.tsx
@@ -52,7 +52,7 @@ export default function SubscriptionForm() {
         <input
           {...register("email")}
           id="email"
-          className="flex items-center border border-gray-l3 rounded-sm text-xs text-black outline-none w-full h-10 px-3 bg-white placeholder:text-gray-d1 disabled:bg-gray-100 disabled:text-gray-800 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 dark:placeholder:text-gray xl:text-sm"
+          className="flex items-center border border-gray-l3 rounded-sm text-xs text-black outline-none w-full h-10 px-3 bg-white placeholder:text-navy-l1 disabled:bg-gray disabled:text-gray focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 dark:placeholder:text-gray xl:text-sm"
           placeholder="Enter your email address here"
           disabled={isSubmitting}
         />

--- a/src/App/Footer/Newsletter/SubscriptionForm.tsx
+++ b/src/App/Footer/Newsletter/SubscriptionForm.tsx
@@ -52,7 +52,7 @@ export default function SubscriptionForm() {
         <input
           {...register("email")}
           id="email"
-          className="flex items-center border border-gray-l3 rounded-sm text-xs text-black outline-none w-full h-10 px-3 bg-white placeholder:text-navy-l1 disabled:bg-gray disabled:text-gray focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 dark:placeholder:text-gray xl:text-sm"
+          className="flex items-center border border-gray-l3 rounded-sm text-xs text-black outline-none w-full h-10 px-3 bg-white placeholder:text-navy-l1 disabled:bg-gray disabled:text-navy-l2 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 dark:placeholder:text-navy-l2 xl:text-sm"
           placeholder="Enter your email address here"
           disabled={isSubmitting}
         />

--- a/src/App/Header/NavDropdown.tsx
+++ b/src/App/Header/NavDropdown.tsx
@@ -23,8 +23,8 @@ export default function NavDropdown({ links }: Props) {
               type="Menu"
               size={24}
               className={`${
-                open ? "text-gray" : "text-gray/70"
-              } sm:hidden transition duration-150 ease-in-out group-hover:text-gray/80`}
+                open ? "text-navy-l2" : "text-navy-l2/70"
+              } sm:hidden transition duration-150 ease-in-out group-hover:text-navy-l2/80`}
               aria-hidden="true"
             />
             <Icon

--- a/src/App/Header/UserMenu/Menu.tsx
+++ b/src/App/Header/UserMenu/Menu.tsx
@@ -34,7 +34,7 @@ export default function Menu({ classes = "", user, signOut }: Props) {
         </div>*/}
 
         <div className="hidden [&:has(a)]:grid mt-6 gap-2">
-          <h5 className="uppercase text-xs text-gray-d1 -mb-1">
+          <h5 className="uppercase text-xs text-navy-l1 -mb-1">
             My Organizations
           </h5>
           {user.endowments.map((endowId) => (
@@ -43,7 +43,7 @@ export default function Menu({ classes = "", user, signOut }: Props) {
         </div>
 
         <div className="hidden [&:has(a)]:block mt-6">
-          <h5 className="uppercase text-xs text-gray-d1 mb-1">BG Admin</h5>
+          <h5 className="uppercase text-xs text-navy-l1 mb-1">BG Admin</h5>
           {user.groups.includes(groups["ap-admin"]) && (
             <Link
               to={appRoutes.applications}

--- a/src/App/Header/UserMenu/Menu.tsx
+++ b/src/App/Header/UserMenu/Menu.tsx
@@ -28,7 +28,7 @@ export default function Menu({ classes = "", user, signOut }: Props) {
           <Icon type="Money" className="text-lg" />
           <span>My Donations</span>
         </Link>
-        {/*<div className="mt-2 text-sm flex items-center gap-2 text-gray">
+        {/*<div className="mt-2 text-sm flex items-center gap-2 text-navy-l2">
           <Icon type="User" className="text-lg" />
           <span>My profile (coming soon!)</span>
         </div>*/}

--- a/src/App/Header/UserMenu/Menu.tsx
+++ b/src/App/Header/UserMenu/Menu.tsx
@@ -16,7 +16,7 @@ export default function Menu({ classes = "", user, signOut }: Props) {
     <Popover.Panel
       className={`${classes} shadow-xl bg-gray-l6 dark:bg-blue-d6 w-max rounded overflow-hidden`}
     >
-      <p className="text-sm p-3 bg-orange-l6 border-b border-prim">
+      <p className="text-sm p-3 bg-orange-l6 border-b border-gray-l4">
         Welcome, {user.firstName || user.email}!
       </p>
 

--- a/src/App/Header/UserMenu/UserMenu.tsx
+++ b/src/App/Header/UserMenu/UserMenu.tsx
@@ -43,7 +43,11 @@ export default function UserMenu() {
   return (
     <Popover className="relative">
       <Popover.Button className="cursor-pointer contents">
-        <Icon size={24} type="User" className="text-blue disabled:text-gray" />
+        <Icon
+          size={24}
+          type="User"
+          className="text-blue disabled:text-navy-l2"
+        />
       </Popover.Button>
 
       <Menu

--- a/src/components/BankDetails/ExpectedFunds.tsx
+++ b/src/components/BankDetails/ExpectedFunds.tsx
@@ -29,7 +29,7 @@ export default function ExpectedFunds(props: Props) {
         disabled={props.disabled}
         inputMode="numeric"
       />
-      <p className="text-gray-d1 text-sm my-2 italic">
+      <p className="text-navy-l1 text-sm my-2 italic">
         Depending on how much you expect to receive each month via {APP_NAME},
         different details are required. At this point, we recommend using a
         conservative figure - Maybe $1000 per month.

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -183,7 +183,7 @@ export default function RecipientDetailsForm({
                     className={`relative border ${
                       !!getFieldState(f.key).error
                         ? "border-red"
-                        : "border-prim"
+                        : "border-gray-l4"
                     } rounded px-4 py-3.5 text-sm has-[:checked]:border-orange has-[:disabled]:bg-gray-l5 w-32 h-10 focus-within:ring-1 focus-within:ring-gray-d1`}
                   >
                     <input
@@ -300,7 +300,7 @@ export default function RecipientDetailsForm({
           id="bank__statement"
           type="file"
           // `!py-0 !pl-0` removes padding added by `field > field-input`
-          className="!py-0 !pl-0 file:border-none file:border-r file:border-prim file:py-3.5 file:px-4 file:bg-blue-l4 file:text-gray-d2 text-gray-d1"
+          className="!py-0 !pl-0 file:border-none file:border-r file:border-gray-l4 file:py-3.5 file:px-4 file:bg-blue-l4 file:text-gray-d2 text-gray-d1"
           {...register("bankStatement", {
             validate(value?: FileList) {
               //multile:false

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -123,7 +123,7 @@ export default function RecipientDetailsForm({
           handleError(err);
         }
       })}
-      className="grid gap-5 text-gray-d2"
+      className="grid gap-5 text-navy-d4"
     >
       {fields.map((f) => {
         const labelRequired = f.required ? true : undefined;
@@ -300,7 +300,7 @@ export default function RecipientDetailsForm({
           id="bank__statement"
           type="file"
           // `!py-0 !pl-0` removes padding added by `field > field-input`
-          className="!py-0 !pl-0 file:border-none file:border-r file:border-gray-l4 file:py-3.5 file:px-4 file:bg-blue-l4 file:text-gray-d2 text-navy-l1"
+          className="!py-0 !pl-0 file:border-none file:border-r file:border-gray-l4 file:py-3.5 file:px-4 file:bg-blue-l4 file:text-navy-d4 text-navy-l1"
           {...register("bankStatement", {
             validate(value?: FileList) {
               //multile:false

--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -300,7 +300,7 @@ export default function RecipientDetailsForm({
           id="bank__statement"
           type="file"
           // `!py-0 !pl-0` removes padding added by `field > field-input`
-          className="!py-0 !pl-0 file:border-none file:border-r file:border-gray-l4 file:py-3.5 file:px-4 file:bg-blue-l4 file:text-gray-d2 text-gray-d1"
+          className="!py-0 !pl-0 file:border-none file:border-r file:border-gray-l4 file:py-3.5 file:px-4 file:bg-blue-l4 file:text-gray-d2 text-navy-l1"
           {...register("bankStatement", {
             validate(value?: FileList) {
               //multile:false

--- a/src/components/CurrencySelector/CurrencyOptions.tsx
+++ b/src/components/CurrencySelector/CurrencyOptions.tsx
@@ -44,7 +44,7 @@ export default function CurrencyOptions({
       classes={{
         container:
           classes +
-          " bg-white w-full rounded border border-prim p-2 text-sm text-gray-d1 shadow-lg",
+          " bg-white w-full rounded border border-gray-l4 p-2 text-sm text-gray-d1 shadow-lg",
       }}
     >
       {(currencies) => (

--- a/src/components/CurrencySelector/CurrencyOptions.tsx
+++ b/src/components/CurrencySelector/CurrencyOptions.tsx
@@ -44,7 +44,7 @@ export default function CurrencyOptions({
       classes={{
         container:
           classes +
-          " bg-white w-full rounded border border-gray-l4 p-2 text-sm text-gray-d1 shadow-lg",
+          " bg-white w-full rounded border border-gray-l4 p-2 text-sm text-navy-l1 shadow-lg",
       }}
     >
       {(currencies) => (

--- a/src/components/CurrencySelector/CurrencySelector.tsx
+++ b/src/components/CurrencySelector/CurrencySelector.tsx
@@ -48,7 +48,7 @@ export default function CurrencySelector<T extends CurrencyOption>({
       >
         <Combobox.Input
           id="wise__currency"
-          className="w-full border-r border-gray-l3 dark:border-navy px-4 py-3.5 text-sm leading-5 text-gray-900 focus:ring-0"
+          className="w-full border-r border-gray-l3 dark:border-navy px-4 py-3.5 text-sm leading-5 focus:ring-0"
           displayValue={(currency: T) =>
             !!currency.name
               ? `${currency.code.toUpperCase()} - ${currency.name}`
@@ -69,9 +69,7 @@ export default function CurrencySelector<T extends CurrencyOption>({
               <DrawerIcon
                 isOpen={open}
                 size={25}
-                className={`h-full w-full text-gray-400 ${
-                  isCurrencyError ? "text-red" : "text-gray-400"
-                }`}
+                className={`h-full w-full ${isCurrencyError ? "text-red" : ""}`}
                 aria-hidden
               />
             )

--- a/src/components/CurrencySelector/CurrencySelector.tsx
+++ b/src/components/CurrencySelector/CurrencySelector.tsx
@@ -62,7 +62,7 @@ export default function CurrencySelector<T extends CurrencyOption>({
             isCurrencyLoading ? (
               <Icon
                 type="Loading"
-                className="text-gray animate-spin"
+                className="text-navy-l2 animate-spin"
                 size={20}
               />
             ) : (

--- a/src/components/FileDropzone/DropzoneText.tsx
+++ b/src/components/FileDropzone/DropzoneText.tsx
@@ -17,7 +17,7 @@ export default function DropzoneText({
 
   if (isFilesEmpty && isPreviewsEmpty) {
     return (
-      <span className="grid justify-items-center text-sm text-navy-l1 dark:text-gray">
+      <span className="grid justify-items-center text-sm text-navy-l1 dark:text-navy-l2">
         <Icon type="FileUpload" size={24} className="mb-[1.125rem]" />
         <p className="font-semibold mb-1">Upload file</p>
         <span>Click to Browse or Drag &amp; Drop</span>

--- a/src/components/FileDropzone/DropzoneText.tsx
+++ b/src/components/FileDropzone/DropzoneText.tsx
@@ -17,7 +17,7 @@ export default function DropzoneText({
 
   if (isFilesEmpty && isPreviewsEmpty) {
     return (
-      <span className="grid justify-items-center text-sm text-gray-d1 dark:text-gray">
+      <span className="grid justify-items-center text-sm text-navy-l1 dark:text-gray">
         <Icon type="FileUpload" size={24} className="mb-[1.125rem]" />
         <p className="font-semibold mb-1">Upload file</p>
         <span>Click to Browse or Drag &amp; Drop</span>

--- a/src/components/FileDropzone/FileDropzone.tsx
+++ b/src/components/FileDropzone/FileDropzone.tsx
@@ -47,7 +47,7 @@ export default function FileDropzone<
               ? "border-gray-d1 dark:border-gray"
               : invalid
                 ? "border-red focus:shadow-focus"
-                : "border-prim focus:border-orange-l2 focus:dark:border-blue-d1"
+                : "border-gray-l4 focus:border-orange-l2 focus:dark:border-blue-d1"
           } ${
             disabled
               ? "cursor-default bg-gray-l5 dark:bg-navy-d3"

--- a/src/components/FileDropzone/FileDropzone.tsx
+++ b/src/components/FileDropzone/FileDropzone.tsx
@@ -59,7 +59,7 @@ export default function FileDropzone<
         <input {...getInputProps({ id: props.name })} />
         <DropzoneText {...value} fieldName={props.name} formErrors={errors} />
       </div>
-      <p className="text-xs text-navy-l1 dark:text-gray mt-2">
+      <p className="text-xs text-navy-l1 dark:text-navy-l2 mt-2">
         Valid types are:
         {props.specs.mimeTypes
           .map((m) => m.split("/")[1].toUpperCase())

--- a/src/components/FileDropzone/FileDropzone.tsx
+++ b/src/components/FileDropzone/FileDropzone.tsx
@@ -59,7 +59,7 @@ export default function FileDropzone<
         <input {...getInputProps({ id: props.name })} />
         <DropzoneText {...value} fieldName={props.name} formErrors={errors} />
       </div>
-      <p className="text-xs text-gray-d1 dark:text-gray mt-2">
+      <p className="text-xs text-navy-l1 dark:text-gray mt-2">
         Valid types are:
         {props.specs.mimeTypes
           .map((m) => m.split("/")[1].toUpperCase())

--- a/src/components/Group.tsx
+++ b/src/components/Group.tsx
@@ -12,7 +12,7 @@ export default function Group({
 }>) {
   return (
     <div
-      className={`grid w-full gap-6 p-6 border border-prim rounded bg-white dark:bg-blue-d6 ${className}`}
+      className={`grid w-full gap-6 p-6 border border-gray-l4 rounded bg-white dark:bg-blue-d6 ${className}`}
     >
       {title && <h3 className="text-2xl">{title}</h3>}
       {description && (

--- a/src/components/HeaderButton.tsx
+++ b/src/components/HeaderButton.tsx
@@ -32,7 +32,7 @@ export function HeaderButton<T>(
         }
         className={`w-4 h-4 shrink-0 ${
           _activeSortKey === _sortKey
-            ? "text-gray-d2 dark:text-white"
+            ? "text-navy-d4 dark:text-white"
             : "text-navy-l2 dark:text-white"
         }`}
       />

--- a/src/components/HeaderButton.tsx
+++ b/src/components/HeaderButton.tsx
@@ -33,7 +33,7 @@ export function HeaderButton<T>(
         className={`w-4 h-4 shrink-0 ${
           _activeSortKey === _sortKey
             ? "text-gray-d2 dark:text-white"
-            : "text-gray dark:text-white"
+            : "text-navy-l2 dark:text-white"
         }`}
       />
     </button>

--- a/src/components/ImgEditor/ImgCropper.tsx
+++ b/src/components/ImgEditor/ImgCropper.tsx
@@ -50,7 +50,7 @@ export default function ImgCropper({
       <div className="bg-white flex items-center justify-end gap-2 p-1">
         <button
           type="button"
-          className="text-gray-d2 hover:text-blue"
+          className="text-navy-d4 hover:text-blue"
           onClick={handleSave}
         >
           <Icon type="Save" size={24} />

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -76,7 +76,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
         {noneUploaded ? (
           <button
             type="button"
-            className="absolute-center grid justify-items-center text-sm text-gray-d1 dark:text-gray"
+            className="absolute-center grid justify-items-center text-sm text-navy-l1 dark:text-gray"
             tabIndex={-1}
           >
             <Icon type="FileUpload" size={24} className="mb-[1.125rem]" />
@@ -110,7 +110,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
           </div>
         )}
       </div>
-      <p className="text-xs text-gray-d1 dark:text-gray mt-2">
+      <p className="text-xs text-navy-l1 dark:text-gray mt-2">
         <span>
           Valid types are:{" "}
           {accept.map((m) => m.split("/")[1].toUpperCase()).join(", ")}.{" "}

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -76,7 +76,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
         {noneUploaded ? (
           <button
             type="button"
-            className="absolute-center grid justify-items-center text-sm text-navy-l1 dark:text-gray"
+            className="absolute-center grid justify-items-center text-sm text-navy-l1 dark:text-navy-l2"
             tabIndex={-1}
           >
             <Icon type="FileUpload" size={24} className="mb-[1.125rem]" />
@@ -110,7 +110,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
           </div>
         )}
       </div>
-      <p className="text-xs text-navy-l1 dark:text-gray mt-2">
+      <p className="text-xs text-navy-l1 dark:text-navy-l2 mt-2">
         <span>
           Valid types are:{" "}
           {accept.map((m) => m.split("/")[1].toUpperCase()).join(", ")}.{" "}

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -58,7 +58,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
               ? "border-gray-d1 dark:border-gray"
               : invalid
                 ? ""
-                : "border-prim focus:border-orange-l2 focus:dark:border-blue-d1"
+                : "border-gray-l4 focus:border-orange-l2 focus:dark:border-blue-d1"
           } ${
             isSubmitting
               ? "cursor-default bg-gray-l5 dark:bg-navy-d3"

--- a/src/components/KYCForm/Form/index.tsx
+++ b/src/components/KYCForm/Form/index.tsx
@@ -9,7 +9,7 @@ import { FormValues as FV, Props } from "../types";
 import Tooltip from "./Tooltip";
 import { states } from "./us-states";
 
-export const formStyle = "w-full text-gray-d2 dark:text-white p-3";
+export const formStyle = "w-full text-navy-d4 dark:text-white p-3";
 
 export default function Form({ classes = "", ...props }: Props) {
   const {

--- a/src/components/Prompt/Prompt.tsx
+++ b/src/components/Prompt/Prompt.tsx
@@ -33,7 +33,7 @@ export default function Prompt({
           {title}
         </h3>
       )}
-      <div className="px-6 pb-4 text-center text-gray-d1 dark:text-gray">
+      <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray">
         {children}
       </div>
       <div className="p-3 sm:px-8 sm:py-4 empty:h-12 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-gray-l4">

--- a/src/components/Prompt/Prompt.tsx
+++ b/src/components/Prompt/Prompt.tsx
@@ -21,7 +21,7 @@ export default function Prompt({
         {isDismissible && (
           <button
             onClick={closeModal}
-            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-navy-l5 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" size={24} />
           </button>

--- a/src/components/Prompt/Prompt.tsx
+++ b/src/components/Prompt/Prompt.tsx
@@ -33,7 +33,7 @@ export default function Prompt({
           {title}
         </h3>
       )}
-      <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray">
+      <div className="px-6 pb-4 text-center text-navy-l1 dark:text-navy-l2">
         {children}
       </div>
       <div className="p-3 sm:px-8 sm:py-4 empty:h-12 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-gray-l4">

--- a/src/components/Prompt/Prompt.tsx
+++ b/src/components/Prompt/Prompt.tsx
@@ -13,7 +13,7 @@ export default function Prompt({
   const { closeModal, isDismissible } = useModalContext();
 
   return (
-    <Modal className="fixed-center z-10 grid text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden">
+    <Modal className="fixed-center z-10 grid text-navy-d4 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden">
       <div className="relative">
         <p className="empty:h-16 text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">
           {headline}

--- a/src/components/Prompt/Prompt.tsx
+++ b/src/components/Prompt/Prompt.tsx
@@ -15,13 +15,13 @@ export default function Prompt({
   return (
     <Modal className="fixed-center z-10 grid text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden">
       <div className="relative">
-        <p className="empty:h-16 text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-prim p-5">
+        <p className="empty:h-16 text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">
           {headline}
         </p>
         {isDismissible && (
           <button
             onClick={closeModal}
-            className="border border-prim p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" size={24} />
           </button>
@@ -36,7 +36,7 @@ export default function Prompt({
       <div className="px-6 pb-4 text-center text-gray-d1 dark:text-gray">
         {children}
       </div>
-      <div className="p-3 sm:px-8 sm:py-4 empty:h-12 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-prim">
+      <div className="p-3 sm:px-8 sm:py-4 empty:h-12 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-gray-l4">
         {isDismissible && (
           <button
             type="button"

--- a/src/components/Selector/MultiSelector.tsx
+++ b/src/components/Selector/MultiSelector.tsx
@@ -171,7 +171,7 @@ function SelectedOption<T extends ValKey>({
     onChange(selected.filter((s) => s.value !== value));
 
   return (
-    <div className="flex items-center px-3 gap-2 h-10 bg-blue-l4 dark:bg-blue-d4 border border-prim rounded font-semibold text-gray-d1 dark:text-gray uppercase">
+    <div className="flex items-center px-3 gap-2 h-10 bg-blue-l4 dark:bg-blue-d4 border border-gray-l4 rounded font-semibold text-gray-d1 dark:text-gray uppercase">
       <span className="max-w-[200px] truncate">{option.label}</span>
       <button
         type="button"

--- a/src/components/Selector/MultiSelector.tsx
+++ b/src/components/Selector/MultiSelector.tsx
@@ -85,7 +85,7 @@ export function MultiSelector<
                   />
                 ))}
                 {searchable ? (
-                  <div className="inline-flex items-center gap-2 text-navy-l1 dark:text-gray pl-3 bg-white/5 rounded">
+                  <div className="inline-flex items-center gap-2 text-navy-l1 dark:text-navy-l2 pl-3 bg-white/5 rounded">
                     <Icon type="Search" size={20} />
                     <Combobox.Input
                       className="appearance-none bg-transparent first:pl-3 focus:outline-none h-10"
@@ -104,7 +104,7 @@ export function MultiSelector<
               <DrawerIcon
                 isOpen={open}
                 size={25}
-                className="justify-self-end dark:text-gray shrink-0"
+                className="justify-self-end dark:text-navy-l2 shrink-0"
               />
             </>
           )}
@@ -139,7 +139,7 @@ export function MultiSelector<
               </Combobox.Option>
             ))}
           {!optionsAvailable && (
-            <p className="text-navy-l1 dark:text-gray text-sm px-4 py-2">
+            <p className="text-navy-l1 dark:text-navy-l2 text-sm px-4 py-2">
               No options found
             </p>
           )}
@@ -171,7 +171,7 @@ function SelectedOption<T extends ValKey>({
     onChange(selected.filter((s) => s.value !== value));
 
   return (
-    <div className="flex items-center px-3 gap-2 h-10 bg-blue-l4 dark:bg-blue-d4 border border-gray-l4 rounded font-semibold text-navy-l1 dark:text-gray uppercase">
+    <div className="flex items-center px-3 gap-2 h-10 bg-blue-l4 dark:bg-blue-d4 border border-gray-l4 rounded font-semibold text-navy-l1 dark:text-navy-l2 uppercase">
       <span className="max-w-[200px] truncate">{option.label}</span>
       <button
         type="button"

--- a/src/components/Selector/MultiSelector.tsx
+++ b/src/components/Selector/MultiSelector.tsx
@@ -85,7 +85,7 @@ export function MultiSelector<
                   />
                 ))}
                 {searchable ? (
-                  <div className="inline-flex items-center gap-2 text-gray-d1 dark:text-gray pl-3 bg-white/5 rounded">
+                  <div className="inline-flex items-center gap-2 text-navy-l1 dark:text-gray pl-3 bg-white/5 rounded">
                     <Icon type="Search" size={20} />
                     <Combobox.Input
                       className="appearance-none bg-transparent first:pl-3 focus:outline-none h-10"
@@ -139,7 +139,7 @@ export function MultiSelector<
               </Combobox.Option>
             ))}
           {!optionsAvailable && (
-            <p className="text-gray-d1 dark:text-gray text-sm px-4 py-2">
+            <p className="text-navy-l1 dark:text-gray text-sm px-4 py-2">
               No options found
             </p>
           )}
@@ -171,7 +171,7 @@ function SelectedOption<T extends ValKey>({
     onChange(selected.filter((s) => s.value !== value));
 
   return (
-    <div className="flex items-center px-3 gap-2 h-10 bg-blue-l4 dark:bg-blue-d4 border border-gray-l4 rounded font-semibold text-gray-d1 dark:text-gray uppercase">
+    <div className="flex items-center px-3 gap-2 h-10 bg-blue-l4 dark:bg-blue-d4 border border-gray-l4 rounded font-semibold text-navy-l1 dark:text-gray uppercase">
       <span className="max-w-[200px] truncate">{option.label}</span>
       <button
         type="button"

--- a/src/components/Selector/NativeSelect.tsx
+++ b/src/components/Selector/NativeSelect.tsx
@@ -40,7 +40,7 @@ export const NativeSelect = forwardRef(function Select<V extends ValKey>(
             <DrawerIcon
               isOpen={open}
               size={25}
-              className="justify-self-end dark:text-gray shrink-0"
+              className="justify-self-end dark:text-navy-l2 shrink-0"
             />
           </>
         )}

--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -54,7 +54,7 @@ export function Selector<
               <DrawerIcon
                 isOpen={open}
                 size={25}
-                className="justify-self-end dark:text-gray shrink-0"
+                className="justify-self-end dark:text-navy-l2 shrink-0"
               />
             </>
           )}

--- a/src/components/Selector/constants.ts
+++ b/src/components/Selector/constants.ts
@@ -17,5 +17,5 @@ export const styles = {
           : ""
     }`,
   options:
-    "rounded-sm text-sm border border-prim absolute top-full mt-2 z-10 bg-gray-l6 dark:bg-blue-d6 w-full max-h-[10rem] overflow-y-auto scroller",
+    "rounded-sm text-sm border border-gray-l4 absolute top-full mt-2 z-10 bg-gray-l6 dark:bg-blue-d6 w-full max-h-[10rem] overflow-y-auto scroller",
 };

--- a/src/components/Status/Info.tsx
+++ b/src/components/Status/Info.tsx
@@ -9,7 +9,7 @@ export default function Info({ classes = "", children }: Props) {
   return (
     <Status
       inline
-      classes={classes + " text-sm text-navy-l1 dark:text-gray mr-2"}
+      classes={classes + " text-sm text-navy-l1 dark:text-navy-l2 mr-2"}
       icon="Info"
       iconOptions={{
         size: 16,

--- a/src/components/Status/Info.tsx
+++ b/src/components/Status/Info.tsx
@@ -9,7 +9,7 @@ export default function Info({ classes = "", children }: Props) {
   return (
     <Status
       inline
-      classes={classes + " text-sm text-gray-d1 dark:text-gray mr-2"}
+      classes={classes + " text-sm text-navy-l1 dark:text-gray mr-2"}
       icon="Info"
       iconOptions={{
         size: 16,

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -45,7 +45,7 @@ export default function Toggle<T extends FV>({
           disabled={disabled || isSubmitting}
           checked={value}
           onChange={onChange}
-          className="border border-prim peer relative inline-flex h-8 w-14 items-center rounded-full transition-colors"
+          className="border border-gray-l4 peer relative inline-flex h-8 w-14 items-center rounded-full transition-colors"
         >
           <span
             className={`${

--- a/src/components/TokenField/TokenField.tsx
+++ b/src/components/TokenField/TokenField.tsx
@@ -63,7 +63,7 @@ export default function TokenField<T extends FieldValues, K extends Path<T>>({
           autoComplete="off"
           id="amount"
           type="text"
-          className="text-sm py-3.5 dark:text-gray"
+          className="text-sm py-3.5 dark:text-navy-l2"
         />
         <TokenSelector
           selectedChainId={selectedChainId}

--- a/src/components/TokenField/TokenOptions.tsx
+++ b/src/components/TokenField/TokenOptions.tsx
@@ -33,7 +33,7 @@ export default function TokenOptions({ classes = "", selectedChainId }: Props) {
   if (isLoading || isFetching) {
     return (
       <Combobox.Options className={`${classes} ${container}`}>
-        <LoadingStatus classes="text-sm text-gray-d2 dark:text-navy-l2 p-2">
+        <LoadingStatus classes="text-sm text-navy-d4 dark:text-navy-l2 p-2">
           Loading..
         </LoadingStatus>
       </Combobox.Options>

--- a/src/components/TokenField/TokenOptions.tsx
+++ b/src/components/TokenField/TokenOptions.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 
 const container =
-  "border border-prim p-1 max-h-60 w-max overflow-y-auto rounded-md bg-gray-l5 dark:bg-blue-d7 shadow-lg focus:outline-none";
+  "border border-gray-l4 p-1 max-h-60 w-max overflow-y-auto rounded-md bg-gray-l5 dark:bg-blue-d7 shadow-lg focus:outline-none";
 export default function TokenOptions({ classes = "", selectedChainId }: Props) {
   const [searchText, setSearchText] = useState("");
   const {
@@ -50,7 +50,7 @@ export default function TokenOptions({ classes = "", selectedChainId }: Props) {
 
   return (
     <Combobox.Options className={`${classes} ${container}`}>
-      <div className="flex p-2 gap-2 border border-prim rounded mb-1">
+      <div className="flex p-2 gap-2 border border-gray-l4 rounded mb-1">
         <Icon type="Search" size={20} />
         <Combobox.Input
           placeholder="Search..."

--- a/src/components/TokenField/TokenOptions.tsx
+++ b/src/components/TokenField/TokenOptions.tsx
@@ -33,7 +33,7 @@ export default function TokenOptions({ classes = "", selectedChainId }: Props) {
   if (isLoading || isFetching) {
     return (
       <Combobox.Options className={`${classes} ${container}`}>
-        <LoadingStatus classes="text-sm text-gray-d2 dark:text-gray p-2">
+        <LoadingStatus classes="text-sm text-gray-d2 dark:text-navy-l2 p-2">
           Loading..
         </LoadingStatus>
       </Combobox.Options>

--- a/src/components/TokenField/TokenSelector.tsx
+++ b/src/components/TokenField/TokenSelector.tsx
@@ -13,7 +13,7 @@ export default function TokenSelector({
       value={selectedToken}
       onChange={onChange}
       as="div"
-      className="flex items-center gap-1 w-full dark:text-gray"
+      className="flex items-center gap-1 w-full dark:text-navy-l2"
     >
       <span className="text-sm">{selectedToken.symbol}</span>
 

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -46,7 +46,7 @@ export default function Tooltip<T extends HTMLElement>({
       leave="transition-opacity duration-150"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
-      className="absolute -translate-x-1/2 -translate-y-full -mt-2 ml-2.5 z-50 flex items-center justify-center px-3 py-2 rounded bg-gray-d2 dark:bg-white font-normal text-sm w-max max-w-[200px] text-white dark:text-gray-d2 after:content-[''] after:absolute after:top-full after:left-1/2 after:-ml-1 after:-translate-y-1/2 after:w-2 after:h-2 after:bg-gray-d2 after:dark:bg-white after:rotate-45"
+      className="absolute -translate-x-1/2 -translate-y-full -mt-2 ml-2.5 z-50 flex items-center justify-center px-3 py-2 rounded bg-gray-d2 dark:bg-white font-normal text-sm w-max max-w-[200px] text-white dark:text-navy-d4 after:content-[''] after:absolute after:top-full after:left-1/2 after:-ml-1 after:-translate-y-1/2 after:w-2 after:h-2 after:bg-gray-d2 after:dark:bg-white after:rotate-45"
       // had to move top+left position calculations to the props.style as the expected behavior wasn't there when setting these values
       // in className using tailwind
       style={{

--- a/src/components/admin/TemplateContainer.tsx
+++ b/src/components/admin/TemplateContainer.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from "react";
 
 const containerClass =
-  "w-full p-6 rounded-md grid content-start gap-6 rounded bg-white dark:bg-blue-d6 border border-prim group";
+  "w-full p-6 rounded-md grid content-start gap-6 rounded bg-white dark:bg-blue-d6 border border-gray-l4 group";
 
 export function DivContainer({
   disabled,

--- a/src/components/donation/AdvancedOptions.tsx
+++ b/src/components/donation/AdvancedOptions.tsx
@@ -19,7 +19,9 @@ export default function AdvancedOptions({
   if (display === "hidden") return null;
 
   return (
-    <div className={`grid ${classes} border border-prim rounded overflow-clip`}>
+    <div
+      className={`grid ${classes} border border-gray-l4 rounded overflow-clip`}
+    >
       <div className="flex items-center justify-between px-4 py-2 bg-orange-l6 dark:bg-blue-d7">
         <span className="font-bold py-2">
           {isOpen && "Hide"} Advanced Options
@@ -27,13 +29,13 @@ export default function AdvancedOptions({
         <button
           type="button"
           onClick={toggle}
-          className="border border-prim h-full aspect-square rounded grid place-items-center"
+          className="border border-gray-l4 h-full aspect-square rounded grid place-items-center"
         >
           <Icon type={isOpen ? "Dash" : "Plus"} size={15} />
         </button>
       </div>
       {isOpen && (
-        <div className="grid p-6 pt-4 font-heading border-t border-prim">
+        <div className="grid p-6 pt-4 font-heading border-t border-gray-l4">
           <p className="text-xs uppercase font-bold mb-2">Split</p>
           {splitComponent}
         </div>

--- a/src/components/donation/Steps/DonateMethods/Daf/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Daf/Form.tsx
@@ -67,7 +67,7 @@ export default function Form({ widgetConfig, details }: Props) {
           tooltip="The minimum donation amount will depend on your DAF provider."
         />
 
-        <p className="text-sm text-gray-d2 dark:text-gray mt-4">
+        <p className="text-sm text-gray-d2 dark:text-navy-l2 mt-4">
           Please click the button below and follow the instructions provided to
           complete your donation
         </p>

--- a/src/components/donation/Steps/DonateMethods/Daf/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Daf/Form.tsx
@@ -67,7 +67,7 @@ export default function Form({ widgetConfig, details }: Props) {
           tooltip="The minimum donation amount will depend on your DAF provider."
         />
 
-        <p className="text-sm text-gray-d2 dark:text-navy-l2 mt-4">
+        <p className="text-sm text-navy-d4 dark:text-navy-l2 mt-4">
           Please click the button below and follow the instructions provided to
           complete your donation
         </p>

--- a/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
+++ b/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
@@ -33,7 +33,7 @@ const tabIdx = (method?: DonationDetails["method"]) => {
 const tabClasses = (selected: boolean) =>
   `${
     selected
-      ? "font-semibold bg-blue @md:bg-white text-white @md:text-black"
+      ? "font-semibold bg-blue-l4 text-navy-d4"
       : "border border-gray-l4 @md:border-none"
   } text-sm flex items-center gap-2 p-2 @md:px-3 @md:py-4 focus:outline-none @md:w-28 rounded @md:rounded-none`;
 
@@ -49,7 +49,7 @@ export default function DonateMethods({ donaterConfig, state }: Props) {
       <Label className="p-4 pb-0 col-span-full @md:hidden font-bold">
         Payment method
       </Label>
-      <Tab.List className="grid grid-cols-2 gap-2 @md:gap-0 p-4 @md:p-0 @md:grid-cols-1 content-start @md:bg-blue-l4 @md:divide-y @md:divide-white">
+      <Tab.List className="grid grid-cols-2 gap-2 @md:gap-0 p-4 @md:p-0 @md:grid-cols-1 content-start @md:divide-y @md:divide-white @md:border-r border-gray-l4">
         <Tab className={({ selected }) => tabClasses(selected)}>
           <Icon type="CreditCard" size={16} />
           <span>Card</span>

--- a/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
+++ b/src/components/donation/Steps/DonateMethods/DonateMethods.tsx
@@ -34,7 +34,7 @@ const tabClasses = (selected: boolean) =>
   `${
     selected
       ? "font-semibold bg-blue @md:bg-white text-white @md:text-black"
-      : "border border-prim @md:border-none"
+      : "border border-gray-l4 @md:border-none"
   } text-sm flex items-center gap-2 p-2 @md:px-3 @md:py-4 focus:outline-none @md:w-28 rounded @md:rounded-none`;
 
 export default function DonateMethods({ donaterConfig, state }: Props) {

--- a/src/components/donation/Steps/DonateMethods/Stocks/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stocks/Form.tsx
@@ -68,7 +68,7 @@ export default function Form(props: StockFormStep) {
           contributions when you transfer securities through Better.Giving:
         </p>
         <div className="grid rounded bg-gray-l5 dark:bg-navy-d3 p-2 my-4">
-          <span className="text-sm text-gray">
+          <span className="text-sm text-navy-l2">
             NOTE: This is not financial advice! Please speak to your tax advisor
             or broker about your specific situation and country's tax laws.
           </span>

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -81,7 +81,7 @@ export default function Form({ widgetConfig, details }: Props) {
           tooltip={createTooltip(currency)}
         />
 
-        <p className="text-sm text-gray-d2 dark:text-gray mt-4">
+        <p className="text-sm text-gray-d2 dark:text-navy-l2 mt-4">
           Please click the button below and follow the instructions provided to
           complete your donation
         </p>

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -81,7 +81,7 @@ export default function Form({ widgetConfig, details }: Props) {
           tooltip={createTooltip(currency)}
         />
 
-        <p className="text-sm text-gray-d2 dark:text-navy-l2 mt-4">
+        <p className="text-sm dark:text-navy-l2 mt-4">
           Please click the button below and follow the instructions provided to
           complete your donation
         </p>

--- a/src/components/donation/Steps/Result/Success/Share.tsx
+++ b/src/components/donation/Steps/Result/Success/Share.tsx
@@ -45,19 +45,19 @@ function Prompt({ type, iconSize, recipient: { name } }: Props) {
   }, []);
 
   return (
-    <Modal className="grid content-start fixed-center z-20 border border-prim bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white w-[91%] sm:w-full max-w-[39rem] rounded overflow-hidden">
-      <div className="grid place-items-center relative h-16 font-heading font-bold bg-orange-l5 dark:bg-blue-d7 border-b border-prim">
+    <Modal className="grid content-start fixed-center z-20 border border-gray-l4 bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white w-[91%] sm:w-full max-w-[39rem] rounded overflow-hidden">
+      <div className="grid place-items-center relative h-16 font-heading font-bold bg-orange-l5 dark:bg-blue-d7 border-b border-gray-l4">
         Share on {type === "FacebookCircle" ? "Facebook" : type}
         <button
           onClick={closeModal}
-          className="absolute top-1/2 transform -translate-y-1/2 right-4 w-10 h-10 border border-prim rounded "
+          className="absolute top-1/2 transform -translate-y-1/2 right-4 w-10 h-10 border border-gray-l4 rounded "
         >
           <Icon type="Close" className="absolute-center" size={28} />
         </button>
       </div>
       <p
         ref={msgRef}
-        className="my-6 sm:my-10 mx-4 sm:mx-12 text-sm leading-normal p-3 border dark:bg-blue-d6 border-prim rounded"
+        className="my-6 sm:my-10 mx-4 sm:mx-12 text-sm leading-normal p-3 border dark:bg-blue-d6 border-gray-l4 rounded"
       >
         I just donated to <span className="font-bold">{name}</span> on{" "}
         <span className="font-bold">"@angelgiving_</span>!{" "}

--- a/src/components/donation/Steps/Result/Success/Share.tsx
+++ b/src/components/donation/Steps/Result/Success/Share.tsx
@@ -45,7 +45,7 @@ function Prompt({ type, iconSize, recipient: { name } }: Props) {
   }, []);
 
   return (
-    <Modal className="grid content-start fixed-center z-20 border border-gray-l4 bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white w-[91%] sm:w-full max-w-[39rem] rounded overflow-hidden">
+    <Modal className="grid content-start fixed-center z-20 border border-gray-l4 bg-gray-l6 dark:bg-blue-d5 text-navy-d4 dark:text-white w-[91%] sm:w-full max-w-[39rem] rounded overflow-hidden">
       <div className="grid place-items-center relative h-16 font-heading font-bold bg-orange-l5 dark:bg-blue-d7 border-b border-gray-l4">
         Share on {type === "FacebookCircle" ? "Facebook" : type}
         <button

--- a/src/components/donation/Steps/Result/Success/index.tsx
+++ b/src/components/donation/Steps/Result/Success/index.tsx
@@ -32,7 +32,7 @@ export default function Success({
         The donation process is complete, and we are grateful for your support.
       </p>
 
-      <h2 className="mt-16 border-t border-prim w-full pt-2 text-center font-medium">
+      <h2 className="mt-16 border-t border-gray-l4 w-full pt-2 text-center font-medium">
         Spread the word!
       </h2>
       <p className="text-center text-gray-d1 text-sm max-w-sm">

--- a/src/components/donation/Steps/Result/Success/index.tsx
+++ b/src/components/donation/Steps/Result/Success/index.tsx
@@ -28,14 +28,14 @@ export default function Success({
       <h3 className="text-xl sm:text-2xl mb-2 text-center leading-relaxed text-balance">
         Your generosity knows no bounds! Thank you for making a difference!
       </h3>
-      <p className="text-center text-gray-d1">
+      <p className="text-center text-navy-l1">
         The donation process is complete, and we are grateful for your support.
       </p>
 
       <h2 className="mt-16 border-t border-gray-l4 w-full pt-2 text-center font-medium">
         Spread the word!
       </h2>
-      <p className="text-center text-gray-d1 text-sm max-w-sm">
+      <p className="text-center text-navy-l1 text-sm max-w-sm">
         Encourage your friends to join in and contribute, making a collective
         impact through donations.
       </p>

--- a/src/components/donation/Steps/Splits/Splits.tsx
+++ b/src/components/donation/Steps/Splits/Splits.tsx
@@ -43,7 +43,7 @@ export default function Split({
     <div className="grid content-start p-4 @md:p-8">
       <BackBtn type="button" onClick={() => dispatch(setStep("donate-form"))} />
       <h4 className="mt-4">Split donation</h4>
-      <p className="text-gray-d1">
+      <p className="text-navy-l1">
         Create a sustainable impact by dividing funds
       </p>
 
@@ -80,7 +80,7 @@ export default function Split({
       {/** amount breakdown */}
       <div className="flex justify-between mt-1">
         <dl>
-          <dt className="text-gray-d1 text-xs">Compounded Forever</dt>
+          <dt className="text-navy-l1 text-xs">Compounded Forever</dt>
           <dd>
             <span className="text-xs font-medium mr-1">
               {symbol.toUpperCase()}
@@ -89,7 +89,7 @@ export default function Split({
           </dd>
         </dl>
         <dl>
-          <dt className="text-gray-d1 text-xs">Instantly Available</dt>
+          <dt className="text-navy-l1 text-xs">Instantly Available</dt>
           <dd className="text-right">
             <span className="text-xs font-medium mr-1">
               {symbol.toUpperCase()}
@@ -99,7 +99,7 @@ export default function Split({
         </dl>
       </div>
 
-      <p className="text-sm text-gray-d1 mt-6">
+      <p className="text-sm text-navy-l1 mt-6">
         With splitting your donation into sustainable funds, you align
         investments with personal values, improving long-term financial
         performance, reducing risk exposure, and contributing to global

--- a/src/components/donation/Steps/Submit/Crypto/Checkout.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/Checkout.tsx
@@ -18,7 +18,7 @@ export default function Checkout({ classes = "", ...props }: Props) {
   if (wallet === "loading") {
     return (
       <Container classes={classes} donation={props}>
-        <LoadingStatus classes="py-2 mb-6 text-sm text-gray-d1">
+        <LoadingStatus classes="py-2 mb-6 text-sm text-navy-l1">
           Connecting wallet..
         </LoadingStatus>
       </Container>

--- a/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
@@ -37,12 +37,12 @@ export default function Crypto(props: CryptoSubmitStep) {
               className="ml-auto object-cover h-4 w-4 rounded-full mr-1"
               src={details.token.logo}
             />
-            <dd className="text-gray-d2">{details.token.symbol}</dd>
+            <dd className="text-navy-d4">{details.token.symbol}</dd>
           </dl>
 
           <dl className="text-navy-l1 py-3 flex items-center justify-between">
             <dt className="mr-auto">Blockchain</dt>
-            <dd className="text-gray-d2">
+            <dd className="text-navy-d4">
               {chains[details.chainId.value].name}
             </dd>
           </dl>

--- a/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
@@ -31,7 +31,7 @@ export default function Crypto(props: CryptoSubmitStep) {
       }
       preSplitContent={
         <>
-          <dl className="text-gray-d1 py-3 flex items-center justify-between border-b border-prim">
+          <dl className="text-gray-d1 py-3 flex items-center justify-between border-b border-gray-l4">
             <dt className="mr-auto">Currency</dt>
             <Image
               className="ml-auto object-cover h-4 w-4 rounded-full mr-1"

--- a/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
@@ -31,7 +31,7 @@ export default function Crypto(props: CryptoSubmitStep) {
       }
       preSplitContent={
         <>
-          <dl className="text-gray-d1 py-3 flex items-center justify-between border-b border-gray-l4">
+          <dl className="text-navy-l1 py-3 flex items-center justify-between border-b border-gray-l4">
             <dt className="mr-auto">Currency</dt>
             <Image
               className="ml-auto object-cover h-4 w-4 rounded-full mr-1"
@@ -40,7 +40,7 @@ export default function Crypto(props: CryptoSubmitStep) {
             <dd className="text-gray-d2">{details.token.symbol}</dd>
           </dl>
 
-          <dl className="text-gray-d1 py-3 flex items-center justify-between">
+          <dl className="text-navy-l1 py-3 flex items-center justify-between">
             <dt className="mr-auto">Blockchain</dt>
             <dd className="text-gray-d2">
               {chains[details.chainId.value].name}

--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
@@ -34,11 +34,11 @@ export default function TxSubmit({ wallet, donation, classes = "" }: Props) {
       {/** estimate tooltip */}
       {estimate &&
         (estimate === "loading" ? (
-          <LoadingStatus classes="text-sm text-gray-d1">
+          <LoadingStatus classes="text-sm text-navy-l1">
             Simulating tx..
           </LoadingStatus>
         ) : isSuccess(estimate) ? (
-          <p className="text-sm text-gray-d1 flex items-center gap-1">
+          <p className="text-sm text-navy-l1 flex items-center gap-1">
             <Icon type="GasStation" className="text-base" />
             <span>
               {humanize(estimate.fee.amount, 6)} {estimate.fee.symbol}

--- a/src/components/donation/Steps/Submit/Crypto/Wallet.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/Wallet.tsx
@@ -3,7 +3,7 @@ import { DisconnectedWallet } from "types/wallet";
 
 export default function Wallet({ connect, logo, name }: DisconnectedWallet) {
   return (
-    <div className="flex items-center gap-2 border border-prim rounded p-3">
+    <div className="flex items-center gap-2 border border-gray-l4 rounded p-3">
       <Image src={logo} className="size-7 rounded-full" />
       <span className="capitalize">{name}</span>
       <button

--- a/src/components/donation/Steps/Submit/DAFCheckout/ManualDonation.tsx
+++ b/src/components/donation/Steps/Submit/DAFCheckout/ManualDonation.tsx
@@ -7,7 +7,7 @@ export default function ManualDonation(props: DafCheckoutStep) {
 
   return (
     <>
-      <p className="text-center text-gray-d1 uppercase mt-4">
+      <p className="text-center text-navy-l1 uppercase mt-4">
         Manual DAF donation
       </p>
       <p className="text-center">

--- a/src/components/donation/Steps/Submit/Stocks.tsx
+++ b/src/components/donation/Steps/Submit/Stocks.tsx
@@ -11,7 +11,7 @@ export default function Stocks(props: StockCheckoutStep) {
   return (
     <div className="grid content-start p-4 @md:p-8">
       <BackBtn type="button" onClick={() => dispatch(setStep("donate-form"))} />
-      <p className="mt-4 text-center text-gray-d1 uppercase">
+      <p className="mt-4 text-center text-navy-l1 uppercase">
         Donation pending
       </p>
       <p className="mt-4 text-center">

--- a/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
@@ -59,7 +59,7 @@ export default function StripeCheckout(props: StripeCheckoutStep) {
         </div>
       </div>
       <div className="relative border border-gray-l4 h-px w-full mb-8 mt-6 grid place-items-center peer-has-[.hidden]:hidden">
-        <span className="absolute bg-white px-4 text-gray text-xs">OR</span>
+        <span className="absolute bg-white px-4 text-navy-l2 text-xs">OR</span>
       </div>
       {isLoading ? (
         <Loader msg="Loading payment form.." />

--- a/src/components/donation/Steps/Tip/Tip.tsx
+++ b/src/components/donation/Steps/Tip/Tip.tsx
@@ -98,7 +98,7 @@ export default function Tip({
         Choose a Donation for{" "}
         <Image src={bgIcon} className="inline-block size-5" /> Better.giving
       </h4>
-      <p className="text-gray-d1">
+      <p className="text-navy-l1">
         We are completely free, and rely on donations
       </p>
 
@@ -128,7 +128,7 @@ export default function Tip({
               <span className="mr-0.5">
                 {humanize(tip.amount || "0", decimals)}
               </span>
-              <span className="text-gray-d1 text-xs">
+              <span className="text-navy-l1 text-xs">
                 ({(Number(tip.pct) * 100).toFixed(0)}%)
               </span>
             </div>
@@ -184,7 +184,7 @@ export default function Tip({
         </p>
       </div>
 
-      <p className="text-sm text-gray-d1 mt-6">
+      <p className="text-sm text-navy-l1 mt-6">
         Assist us in advancing our mission to connect with global organizations
         and propagate our timeless message:{" "}
         <span className="font-medium block">Give today, give forever.</span>

--- a/src/components/donation/Steps/common/BackBtn.tsx
+++ b/src/components/donation/Steps/common/BackBtn.tsx
@@ -8,7 +8,7 @@ export default function BackBtn({
   return (
     <button
       {...props}
-      className={`flex items-center gap-1 font-semibold text-blue hover:text-blue-l1 active:text-blue-d1 disabled:text-gray-l3 aria-disabled:text-gray-l3 ${className}`}
+      className={`flex items-center gap-1 font-semibold text-blue hover:text-blue-l1 active:text-blue-d1 disabled:text-navy-l5 aria-disabled:text-navy-l5 ${className}`}
     >
       <Icon type="ArrowBack" strokeWidth={20} />
       <span>Back</span>

--- a/src/components/donation/Steps/common/Summary.tsx
+++ b/src/components/donation/Steps/common/Summary.tsx
@@ -38,12 +38,12 @@ export default function Summary({ Amount, ...props }: Props) {
       <dl
         className={`text-navy-l1 py-3 gap-y-2 grid grid-cols-[1fr_auto] items-center justify-between border-y border-gray-l4 ${splitClass}`}
       >
-        <dt className="mr-auto text-gray-d2">
+        <dt className="mr-auto text-navy-d4">
           {props.tip
             ? `Donation for ${props.tip.charityName}`
             : "Total donation"}
         </dt>
-        <Amount amount={props.amount} classes="text-gray-d2" />
+        <Amount amount={props.amount} classes="text-navy-d4" />
         <div className="flex items-center justify-between col-span-full">
           <dt className="mr-auto text-sm">Sustainable Fund</dt>
           <Amount classes="text-sm" amount={locked} />
@@ -60,7 +60,7 @@ export default function Summary({ Amount, ...props }: Props) {
         )}
         {props.tip && (
           <div className="col-span-full grid grid-cols-[1fr_auto] pt-1 font-medium">
-            <dt className="mr-auto text-gray-d2">Total charge</dt>
+            <dt className="mr-auto text-navy-d4">Total charge</dt>
             <Amount amount={props.amount + props.tip.value} />
           </div>
         )}

--- a/src/components/donation/Steps/common/Summary.tsx
+++ b/src/components/donation/Steps/common/Summary.tsx
@@ -36,7 +36,7 @@ export default function Summary({ Amount, ...props }: Props) {
       {props.preSplitContent}
 
       <dl
-        className={`text-gray-d1 py-3 gap-y-2 grid grid-cols-[1fr_auto] items-center justify-between border-y border-prim ${splitClass}`}
+        className={`text-gray-d1 py-3 gap-y-2 grid grid-cols-[1fr_auto] items-center justify-between border-y border-gray-l4 ${splitClass}`}
       >
         <dt className="mr-auto text-gray-d2">
           {props.tip
@@ -53,7 +53,7 @@ export default function Summary({ Amount, ...props }: Props) {
           <Amount classes="text-sm" amount={liq} />
         </div>
         {props.tip && (
-          <div className="col-span-full grid grid-cols-[1fr_auto] border-y border-prim py-3">
+          <div className="col-span-full grid grid-cols-[1fr_auto] border-y border-gray-l4 py-3">
             <dt className="mr-auto">Donation for Better.giving</dt>
             <Amount classes="text-sm" amount={props.tip.value} />
           </div>

--- a/src/components/donation/Steps/common/Summary.tsx
+++ b/src/components/donation/Steps/common/Summary.tsx
@@ -36,7 +36,7 @@ export default function Summary({ Amount, ...props }: Props) {
       {props.preSplitContent}
 
       <dl
-        className={`text-gray-d1 py-3 gap-y-2 grid grid-cols-[1fr_auto] items-center justify-between border-y border-gray-l4 ${splitClass}`}
+        className={`text-navy-l1 py-3 gap-y-2 grid grid-cols-[1fr_auto] items-center justify-between border-y border-gray-l4 ${splitClass}`}
       >
         <dt className="mr-auto text-gray-d2">
           {props.tip

--- a/src/components/form/DateInput.tsx
+++ b/src/components/form/DateInput.tsx
@@ -15,7 +15,7 @@ export default function DateInput<T extends FieldValues>({
       <input
         {...register(name)}
         type="date"
-        className="date-input uppercase text-sm relative w-full px-4 py-3 border border-prim rounded-md border-collapse dark:bg-blue-d6"
+        className="date-input uppercase text-sm relative w-full px-4 py-3 border border-gray-l4 rounded-md border-collapse dark:bg-blue-d6"
       />
       <ErrorMessage
         errors={errors}

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -62,7 +62,7 @@ export function Field<T extends FieldValues, K extends InputType = InputType>({
 
       {(tooltip && ( //tooltip in normal flow
         <p className={error + " text-left mt-2 left-0 text-xs"}>
-          <span className="text-navy-l1 dark:text-gray">{tooltip}</span>{" "}
+          <span className="text-navy-l1 dark:text-navy-l2">{tooltip}</span>{" "}
           <ErrorMessage
             errors={errors}
             name={name}

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -62,7 +62,7 @@ export function Field<T extends FieldValues, K extends InputType = InputType>({
 
       {(tooltip && ( //tooltip in normal flow
         <p className={error + " text-left mt-2 left-0 text-xs"}>
-          <span className="text-gray-d1 dark:text-gray">{tooltip}</span>{" "}
+          <span className="text-navy-l1 dark:text-gray">{tooltip}</span>{" "}
           <ErrorMessage
             errors={errors}
             name={name}

--- a/src/components/form/Label.tsx
+++ b/src/components/form/Label.tsx
@@ -19,7 +19,7 @@ export function Label({
         required !== undefined
           ? required
             ? "after:content-['*'] after:text-red"
-            : "after:content-['(optional)'] after:text-gray-d1 after:dark:text-gray"
+            : "after:content-['(optional)'] after:text-navy-l1 after:dark:text-gray"
           : ""
       }`}
     >

--- a/src/components/form/Label.tsx
+++ b/src/components/form/Label.tsx
@@ -19,7 +19,7 @@ export function Label({
         required !== undefined
           ? required
             ? "after:content-['*'] after:text-red"
-            : "after:content-['(optional)'] after:text-navy-l1 after:dark:text-gray"
+            : "after:content-['(optional)'] after:text-navy-l1 after:dark:text-navy-l2"
           : ""
       }`}
     >

--- a/src/components/registration/Separator.tsx
+++ b/src/components/registration/Separator.tsx
@@ -6,7 +6,7 @@ export function Separator({
 }: PropsWithChildren<{ classes?: string }>) {
   return (
     <p
-      className={`flex items-center text-navy-l1 dark:text-gray text-sm before:content-[''] before:h-px before:w-full after:content-[''] after:h-px after:w-full before:bg-gray-d1 after:bg-gray-d1 before:dark:bg-gray after:dark:bg-gray ${classes}`}
+      className={`flex items-center text-navy-l1 dark:text-navy-l2 text-sm before:content-[''] before:h-px before:w-full after:content-[''] after:h-px after:w-full before:bg-gray-d1 after:bg-gray-d1 before:dark:bg-gray after:dark:bg-gray ${classes}`}
     >
       {children}
     </p>

--- a/src/components/registration/Separator.tsx
+++ b/src/components/registration/Separator.tsx
@@ -6,7 +6,7 @@ export function Separator({
 }: PropsWithChildren<{ classes?: string }>) {
   return (
     <p
-      className={`flex items-center text-gray-d1 dark:text-gray text-sm before:content-[''] before:h-px before:w-full after:content-[''] after:h-px after:w-full before:bg-gray-d1 after:bg-gray-d1 before:dark:bg-gray after:dark:bg-gray ${classes}`}
+      className={`flex items-center text-navy-l1 dark:text-gray text-sm before:content-[''] before:h-px before:w-full after:content-[''] after:h-px after:w-full before:bg-gray-d1 after:bg-gray-d1 before:dark:bg-gray after:dark:bg-gray ${classes}`}
     >
       {children}
     </p>

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/DeletePrompt.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/DeletePrompt.tsx
@@ -62,7 +62,7 @@ export default function DeletePrompt({
       </div>
       <Icon type="ExclamationCircleFill" size={80} className="mt-6 text-red" />
 
-      <div className="p-6 text-center text-gray-d1 dark:text-gray-l3">
+      <div className="p-6 text-center text-navy-l1 dark:text-gray-l3">
         {message}
       </div>
 

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/DeletePrompt.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/DeletePrompt.tsx
@@ -47,14 +47,14 @@ export default function DeletePrompt({
   return (
     <Modal className="fixed-center z-10 grid content-start justify-items-center text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden">
       <div className="relative w-full">
-        <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-prim p-5">
+        <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">
           Delete payout method
         </p>
         {isDismissible && (
           <button
             onClick={closeModal}
             disabled={isLoading}
-            className="border border-prim p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" className="text-lg sm:text-2xl" />
           </button>
@@ -67,7 +67,7 @@ export default function DeletePrompt({
       </div>
 
       {canProceed && (
-        <div className="p-3 sm:px-8 sm:py-4 flex items-center justify-end gap-4 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-prim">
+        <div className="p-3 sm:px-8 sm:py-4 flex items-center justify-end gap-4 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-gray-l4">
           <button
             disabled={isLoading}
             type="button"

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/DeletePrompt.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/DeletePrompt.tsx
@@ -45,7 +45,7 @@ export default function DeletePrompt({
   };
 
   return (
-    <Modal className="fixed-center z-10 grid content-start justify-items-center text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden">
+    <Modal className="fixed-center z-10 grid content-start justify-items-center text-navy-d4 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden">
       <div className="relative w-full">
         <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">
           Delete payout method

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/DeletePrompt.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/DeletePrompt.tsx
@@ -54,7 +54,7 @@ export default function DeletePrompt({
           <button
             onClick={closeModal}
             disabled={isLoading}
-            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-navy-l5 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" className="text-lg sm:text-2xl" />
           </button>
@@ -62,7 +62,7 @@ export default function DeletePrompt({
       </div>
       <Icon type="ExclamationCircleFill" size={80} className="mt-6 text-red" />
 
-      <div className="p-6 text-center text-navy-l1 dark:text-gray-l3">
+      <div className="p-6 text-center text-navy-l1 dark:text-navy-l5">
         {message}
       </div>
 

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/Loaded.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/Loaded.tsx
@@ -75,7 +75,7 @@ export default function Loaded(props: BankingApplicationDetails) {
         </p>
       )}
 
-      <dl className="grid sm:grid-cols-[auto_auto_1fr] border border-prim rounded mt-2">
+      <dl className="grid sm:grid-cols-[auto_auto_1fr] border border-gray-l4 rounded mt-2">
         <Row label="Currency">{props.currency}</Row>
         <Row label="Country">{props.country}</Row>
         <Row label="Recipient name">{props.name.fullName}</Row>
@@ -140,14 +140,14 @@ function Row(props: Props) {
       </dt>
       <div
         aria-hidden={true}
-        className="max-sm:hidden w-px border-r border-prim last:border-none"
+        className="max-sm:hidden w-px border-r border-gray-l4 last:border-none"
       />
       <dd className="px-3 max-sm:pb-3 sm:p-3 flex items-center text-sm">
         {props.children}
       </dd>
       <div
         aria-hidden={true}
-        className="h-px col-span-full border-b border-prim last:border-none"
+        className="h-px col-span-full border-b border-gray-l4 last:border-none"
       />
     </>
   );

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
@@ -80,12 +80,12 @@ export default function Prompt({ verdict, uuid }: Props) {
           </button>
         )}
       </div>
-      <p className="px-6 pb-4 text-center text-gray-d1 dark:text-gray-l3 mt-4 font-semibold">
+      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3 mt-4 font-semibold">
         You are about to {verdict} this banking application.
       </p>
 
       {verdict === "approve" ? (
-        <div className="px-6 pb-4 text-center text-gray-d1 dark:text-gray-l3">
+        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3">
           This will immediately payout all pending funds to newly linked bank
           account and is irreversible.
         </div>

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
@@ -64,7 +64,7 @@ export default function Prompt({ verdict, uuid }: Props) {
     <Modal
       as="form"
       onSubmit={methods.handleSubmit(onSubmit)}
-      className="fixed-center z-10 grid content-start justify-items-center text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
+      className="fixed-center z-10 grid content-start justify-items-center text-navy-d4 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
     >
       <div className="relative w-full">
         <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
@@ -74,18 +74,18 @@ export default function Prompt({ verdict, uuid }: Props) {
           <button
             onClick={closeModal}
             disabled={isLoading}
-            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-navy-l5 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" className="text-lg sm:text-2xl" />
           </button>
         )}
       </div>
-      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3 mt-4 font-semibold">
+      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-navy-l5 mt-4 font-semibold">
         You are about to {verdict} this banking application.
       </p>
 
       {verdict === "approve" ? (
-        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3">
+        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-navy-l5">
           This will immediately payout all pending funds to newly linked bank
           account and is irreversible.
         </div>

--- a/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethod/Prompt.tsx
@@ -67,14 +67,14 @@ export default function Prompt({ verdict, uuid }: Props) {
       className="fixed-center z-10 grid content-start justify-items-center text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
     >
       <div className="relative w-full">
-        <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-prim p-5">
+        <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">
           Banking application
         </p>
         {isDismissible && (
           <button
             onClick={closeModal}
             disabled={isLoading}
-            className="border border-prim p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" className="text-lg sm:text-2xl" />
           </button>
@@ -114,7 +114,7 @@ export default function Prompt({ verdict, uuid }: Props) {
         </FormProvider>
       )}
 
-      <div className="p-3 sm:px-8 sm:py-4 flex items-center justify-end gap-4 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-prim">
+      <div className="p-3 sm:px-8 sm:py-4 flex items-center justify-end gap-4 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-gray-l4">
         <button
           disabled={isLoading}
           type="button"

--- a/src/pages/Admin/Charity/Banking/PayoutMethods/PayoutMethods.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethods/PayoutMethods.tsx
@@ -26,7 +26,7 @@ export default function PayoutMethods() {
 
       <QueryLoader
         queryState={queryState}
-        classes={{ container: "mt-4 border-t pt-4 border-prim" }}
+        classes={{ container: "mt-4 border-t pt-4 border-gray-l4" }}
         messages={{
           loading: <Skeleton />,
           error: "Failed to get payout methods",

--- a/src/pages/Admin/Charity/Banking/PayoutMethods/Table.tsx
+++ b/src/pages/Admin/Charity/Banking/PayoutMethods/Table.tsx
@@ -11,7 +11,7 @@ type Props = {
 export default function Table({ methods, classes = "" }: Props) {
   return (
     <table
-      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-prim`}
+      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-gray-l4`}
     >
       <TableSection
         type="thead"
@@ -37,7 +37,7 @@ export default function Table({ methods, classes = "" }: Props) {
           <Cells
             key={row.wiseRecipientID}
             type="td"
-            cellClass="p-3 border-t border-prim max-w-[256px] truncate first:rounded-bl last:rounded-br"
+            cellClass="p-3 border-t border-gray-l4 max-w-[256px] truncate first:rounded-bl last:rounded-br"
           >
             <>{new Date(row.dateCreated).toLocaleDateString()}</>
             <>{row.bankSummary}</>

--- a/src/pages/Admin/Charity/Dashboard/Balance.tsx
+++ b/src/pages/Admin/Charity/Dashboard/Balance.tsx
@@ -29,7 +29,7 @@ function Amount({
 }: PropsWithChildren<{ classes?: string; title: string }>) {
   return (
     <div className={classes}>
-      <p className="text-2xs @xs:text-xs text-gray-d1 dark:text-gray @xs:mb-1 uppercase">
+      <p className="text-2xs @xs:text-xs text-navy-l1 dark:text-gray @xs:mb-1 uppercase">
         {props.title}
       </p>
       <span className="font-bold text-sm @xs:text-xl font-heading">

--- a/src/pages/Admin/Charity/Dashboard/Balance.tsx
+++ b/src/pages/Admin/Charity/Dashboard/Balance.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export default function Balance({ type, current, pending, paidOut }: Props) {
   return (
-    <div className="@container rounded border border-prim bg-orange-l6 dark:bg-blue-d6 p-4">
+    <div className="@container rounded border border-gray-l4 bg-orange-l6 dark:bg-blue-d6 p-4">
       <h4 className="uppercase text-sm @xs:text-xl font-bold mb-5">{type}</h4>
       <div className="grid @xs:grid-cols-[auto_1fr] gap-y-5 justify-self-start gap-x-2 @xs:gap-x-8">
         <Amount title="Total Contributions" classes="col-span-full @xs:mr-auto">

--- a/src/pages/Admin/Charity/Dashboard/Balance.tsx
+++ b/src/pages/Admin/Charity/Dashboard/Balance.tsx
@@ -29,7 +29,7 @@ function Amount({
 }: PropsWithChildren<{ classes?: string; title: string }>) {
   return (
     <div className={classes}>
-      <p className="text-2xs @xs:text-xs text-navy-l1 dark:text-gray @xs:mb-1 uppercase">
+      <p className="text-2xs @xs:text-xs text-navy-l1 dark:text-navy-l2 @xs:mb-1 uppercase">
         {props.title}
       </p>
       <span className="font-bold text-sm @xs:text-xl font-heading">

--- a/src/pages/Admin/Charity/Dashboard/Dashboard.tsx
+++ b/src/pages/Admin/Charity/Dashboard/Dashboard.tsx
@@ -103,7 +103,7 @@ function LoaderSkeleton() {
 
 function DataPart({ children }: PropsWithChildren<{}>) {
   return (
-    <div className="flex justify-center items-center gap-5 p-4 rounded border border-prim bg-orange-l6 dark:bg-blue-d6 font-bold text-sm @sm:text-base font-heading">
+    <div className="flex justify-center items-center gap-5 p-4 rounded border border-gray-l4 bg-orange-l6 dark:bg-blue-d6 font-bold text-sm @sm:text-base font-heading">
       {children}
     </div>
   );

--- a/src/pages/Admin/Charity/Donations/Table.tsx
+++ b/src/pages/Admin/Charity/Donations/Table.tsx
@@ -140,7 +140,7 @@ export default function Table({
                   type="button"
                   onClick={onLoadMore}
                   disabled={disabled}
-                  className="flex items-center justify-center gap-3 uppercase text-sm font-bold rounded-b w-full h-12 enabled:hover:bg-orange-l5 enabled:dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-gray aria-disabled:bg-gray-l3 aria-disabled:dark:bg-navy disabled:dark:bg-navy"
+                  className="flex items-center justify-center gap-3 uppercase text-sm font-bold rounded-b w-full h-12 enabled:hover:bg-orange-l5 enabled:dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-navy-l2 aria-disabled:bg-gray-l3 aria-disabled:dark:bg-navy disabled:dark:bg-navy"
                 >
                   {isLoading ? "Loading..." : "Load More"}
                 </button>

--- a/src/pages/Admin/Charity/Donations/Table.tsx
+++ b/src/pages/Admin/Charity/Donations/Table.tsx
@@ -28,7 +28,7 @@ export default function Table({
   );
 
   return (
-    <table className="w-full text-sm rounded border border-separate border-spacing-0 border-prim">
+    <table className="w-full text-sm rounded border border-separate border-spacing-0 border-gray-l4">
       <TableSection
         type="thead"
         rowClass="bg-orange-l6 dark:bg-blue-d7 divide-x divide-prim"
@@ -86,7 +86,7 @@ export default function Table({
               <Cells
                 key={hash}
                 type="td"
-                cellClass={`p-3 border-t border-prim max-w-[256px] truncate ${
+                cellClass={`p-3 border-t border-gray-l4 max-w-[256px] truncate ${
                   hasMore ? "" : "first:rounded-bl last:rounded-br"
                 }`}
               >
@@ -134,7 +134,7 @@ export default function Table({
               <td
                 colSpan={9}
                 key="load-more-btn"
-                className="border-t border-prim rounded-b"
+                className="border-t border-gray-l4 rounded-b"
               >
                 <button
                   type="button"

--- a/src/pages/Admin/Charity/EditProfile/Form.tsx
+++ b/src/pages/Admin/Charity/EditProfile/Form.tsx
@@ -112,7 +112,7 @@ export default function Form() {
             container:
               "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
             error: "static field-error -mt-4",
-            charCounter: "text-gray-d1 dark:text-gray",
+            charCounter: "text-navy-l1 dark:text-gray",
           }}
         />
         <Field<FV>

--- a/src/pages/Admin/Charity/EditProfile/Form.tsx
+++ b/src/pages/Admin/Charity/EditProfile/Form.tsx
@@ -110,7 +110,7 @@ export default function Form() {
           charLimit={MAX_CHARS}
           classes={{
             container:
-              "rich-text-toolbar border border-prim text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
+              "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
             error: "static field-error -mt-4",
             charCounter: "text-gray-d1 dark:text-gray",
           }}

--- a/src/pages/Admin/Charity/EditProfile/Form.tsx
+++ b/src/pages/Admin/Charity/EditProfile/Form.tsx
@@ -112,7 +112,7 @@ export default function Form() {
             container:
               "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
             error: "static field-error -mt-4",
-            charCounter: "text-navy-l1 dark:text-gray",
+            charCounter: "text-navy-l1 dark:text-navy-l2",
           }}
         />
         <Field<FV>

--- a/src/pages/Admin/Charity/Members/AddForm.tsx
+++ b/src/pages/Admin/Charity/Members/AddForm.tsx
@@ -80,7 +80,7 @@ export default function AddForm({ added, endowID }: Props) {
     <Modal
       onSubmit={handleSubmit(submit)}
       as="form"
-      className="p-6 fixed-center z-10 grid gap-4 text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
+      className="p-6 fixed-center z-10 grid gap-4 text-navy-d4 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
     >
       <h4 className="text-center text-xl font-bold mb-4">Invite User</h4>
       <FormProvider {...methods}>

--- a/src/pages/Admin/Charity/Members/List.tsx
+++ b/src/pages/Admin/Charity/Members/List.tsx
@@ -59,7 +59,7 @@ function Loaded({ members, classes = "" }: LoadedProps) {
 
   return (
     <table
-      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-prim`}
+      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-gray-l4`}
     >
       <TableSection
         type="thead"
@@ -82,7 +82,7 @@ function Loaded({ members, classes = "" }: LoadedProps) {
           <Cells
             key={member}
             type="td"
-            cellClass="p-3 border-t border-prim max-w-[256px] truncate first:rounded-bl last:rounded-br"
+            cellClass="p-3 border-t border-gray-l4 max-w-[256px] truncate first:rounded-bl last:rounded-br"
           >
             <td className="relative">
               <button

--- a/src/pages/Admin/Charity/Members/List.tsx
+++ b/src/pages/Admin/Charity/Members/List.tsx
@@ -89,7 +89,7 @@ function Loaded({ members, classes = "" }: LoadedProps) {
                 disabled={isLoading}
                 onClick={() => handleRemove(member)}
                 type="button"
-                className=" disabled:text-gray hover:text-red active:text-red absolute-center"
+                className=" disabled:text-navy-l2 hover:text-red active:text-red absolute-center"
               >
                 <Icon type="Delete" size={16} />
               </button>

--- a/src/pages/Admin/Charity/ProgramEditor/Form.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Form.tsx
@@ -43,7 +43,7 @@ export default function Form() {
           charLimit={MAX_CHARS}
           classes={{
             container:
-              "rich-text-toolbar border border-prim text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
+              "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
             error: "static field-error -mt-4",
             charCounter: "text-gray-d1 dark:text-gray",
           }}

--- a/src/pages/Admin/Charity/ProgramEditor/Form.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Form.tsx
@@ -45,7 +45,7 @@ export default function Form() {
             container:
               "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
             error: "static field-error -mt-4",
-            charCounter: "text-navy-l1 dark:text-gray",
+            charCounter: "text-navy-l1 dark:text-navy-l2",
           }}
         />
       </Group>

--- a/src/pages/Admin/Charity/ProgramEditor/Form.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Form.tsx
@@ -45,7 +45,7 @@ export default function Form() {
             container:
               "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
             error: "static field-error -mt-4",
-            charCounter: "text-gray-d1 dark:text-gray",
+            charCounter: "text-navy-l1 dark:text-gray",
           }}
         />
       </Group>

--- a/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestone.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestone.tsx
@@ -79,7 +79,7 @@ export default function Milestone({
             container:
               "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
             error: "static field-error -mt-4",
-            charCounter: "text-navy-l1 dark:text-gray",
+            charCounter: "text-navy-l1 dark:text-navy-l2",
           }}
         />
         <button

--- a/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestone.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestone.tsx
@@ -79,7 +79,7 @@ export default function Milestone({
             container:
               "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
             error: "static field-error -mt-4",
-            charCounter: "text-gray-d1 dark:text-gray",
+            charCounter: "text-navy-l1 dark:text-gray",
           }}
         />
         <button

--- a/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestone.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestone.tsx
@@ -25,7 +25,7 @@ export default function Milestone({
       as="div"
       className={`border ${
         //helps distinguish erroneous milestone just in case user collapses dropdown with errors left
-        milestoneError ? "border-red" : "border-prim"
+        milestoneError ? "border-red" : "border-gray-l4"
       } rounded overflow-hidden`}
     >
       <div className="relative py-3 px-4 text-center bg-orange-l6 dark:bg-blue-d7">
@@ -41,7 +41,7 @@ export default function Milestone({
         as="div"
         className={({ open }) =>
           `${
-            open ? "border-t border-prim" : ""
+            open ? "border-t border-gray-l4" : ""
           } bg-white dark:bg-blue-d6 py-6 px-4 grid content-start gap-6`
         }
       >
@@ -77,7 +77,7 @@ export default function Milestone({
           charLimit={MAX_CHARS}
           classes={{
             container:
-              "rich-text-toolbar border border-prim text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
+              "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_1fr] rounded bg-gray-l6 dark:bg-blue-d5 p-3 min-h-[15rem]",
             error: "static field-error -mt-4",
             charCounter: "text-gray-d1 dark:text-gray",
           }}

--- a/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestones.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestones.tsx
@@ -40,7 +40,7 @@ export default function Milestones() {
       </div>
       {!isEmpty(fields) ? (
         <>
-          <span className="text-sm text-gray-d1 dark:text-gray">
+          <span className="text-sm text-navy-l1 dark:text-gray">
             Milestones will be publicly displayed in descending order by their
             date.
           </span>

--- a/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestones.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestones.tsx
@@ -40,7 +40,7 @@ export default function Milestones() {
       </div>
       {!isEmpty(fields) ? (
         <>
-          <span className="text-sm text-navy-l1 dark:text-gray">
+          <span className="text-sm text-navy-l1 dark:text-navy-l2">
             Milestones will be publicly displayed in descending order by their
             date.
           </span>

--- a/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestones.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestones.tsx
@@ -14,7 +14,7 @@ export default function Milestones() {
   const onRemove = (idx: number) => remove(idx);
 
   return (
-    <div className="@container grid gap-6 p-4 @lg:p-6 border border-prim rounded bg-white dark:bg-blue-d6">
+    <div className="@container grid gap-6 p-4 @lg:p-6 border border-gray-l4 rounded bg-white dark:bg-blue-d6">
       <div className="flex flex-col @md:flex-row items-center gap-3 justify-between">
         <h4 className="text-2xl">Milestones</h4>
         <button

--- a/src/pages/Admin/Charity/Programs/List.tsx
+++ b/src/pages/Admin/Charity/Programs/List.tsx
@@ -19,7 +19,7 @@ export default function List() {
       }}
     >
       {(programs) => (
-        <div className="@container grid gap-3 p-4 @lg:p-8 border border-prim rounded bg-white dark:bg-blue-d6">
+        <div className="@container grid gap-3 p-4 @lg:p-8 border border-gray-l4 rounded bg-white dark:bg-blue-d6">
           {programs.map((p) => (
             <Program {...p} key={p.program_id} />
           ))}
@@ -31,7 +31,7 @@ export default function List() {
 
 function Skeleton() {
   return (
-    <div className="grid gap-3 p-8 mt-8 border border-prim">
+    <div className="grid gap-3 p-8 mt-8 border border-gray-l4">
       <ContentLoader className="h-24 w-full rounded" />
       <ContentLoader className="h-24 w-full rounded" />
       <ContentLoader className="h-24 w-full rounded" />

--- a/src/pages/Admin/Charity/Programs/Program.tsx
+++ b/src/pages/Admin/Charity/Programs/Program.tsx
@@ -26,7 +26,7 @@ export function Program(props: TProgram) {
   };
 
   return (
-    <div className="p-6 border border-prim rounded bg-gray-l6 dark:bg-blue-d5 grid @lg:flex items-center gap-x-4 gap-y-8">
+    <div className="p-6 border border-gray-l4 rounded bg-gray-l6 dark:bg-blue-d5 grid @lg:flex items-center gap-x-4 gap-y-8">
       <div className="flex items-center gap-x-4 @lg:contents">
         <Image
           src={props.program_banner}

--- a/src/pages/Admin/Sidebar/Header/Header.tsx
+++ b/src/pages/Admin/Sidebar/Header/Header.tsx
@@ -8,7 +8,7 @@ export default function Header() {
 
   return (
     <div
-      className={`flex flex-col gap-1 w-full py-6 px-5 border-b border-prim`}
+      className={`flex flex-col gap-1 w-full py-6 px-5 border-b border-gray-l4`}
     >
       <div className="flex justify-between">
         <Image

--- a/src/pages/Admin/Sidebar/Header/MyEndowments.tsx
+++ b/src/pages/Admin/Sidebar/Header/MyEndowments.tsx
@@ -13,7 +13,7 @@ export default function MyEndowments({ endowments, showEndowments }: Props) {
       } overflow-hidden transition-max-height duration-500 ease-in-out`}
     >
       <div className="grid py-2 mt-5 gap-3">
-        <p className="text-sm text-navy-l1 dark:text-gray font-bold">
+        <p className="text-sm text-navy-l1 dark:text-navy-l2 font-bold">
           Other Organizations
         </p>
         <div className="overflow-y-auto max-h-40 scroller grid gap-3">

--- a/src/pages/Admin/Sidebar/Header/MyEndowments.tsx
+++ b/src/pages/Admin/Sidebar/Header/MyEndowments.tsx
@@ -24,7 +24,7 @@ export default function MyEndowments({ endowments, showEndowments }: Props) {
             >
               <Image
                 src={endowment.logo}
-                className="w-10 h-10 border border-prim rounded-full"
+                className="w-10 h-10 border border-gray-l4 rounded-full"
               />
               <Link
                 to={`${appRoutes.admin}/${endowment.endowId}`}

--- a/src/pages/Admin/Sidebar/Header/MyEndowments.tsx
+++ b/src/pages/Admin/Sidebar/Header/MyEndowments.tsx
@@ -13,7 +13,7 @@ export default function MyEndowments({ endowments, showEndowments }: Props) {
       } overflow-hidden transition-max-height duration-500 ease-in-out`}
     >
       <div className="grid py-2 mt-5 gap-3">
-        <p className="text-sm text-gray-d1 dark:text-gray font-bold">
+        <p className="text-sm text-navy-l1 dark:text-gray font-bold">
           Other Organizations
         </p>
         <div className="overflow-y-auto max-h-40 scroller grid gap-3">

--- a/src/pages/Admin/Sidebar/Sidebar.tsx
+++ b/src/pages/Admin/Sidebar/Sidebar.tsx
@@ -18,7 +18,7 @@ export default function Sidebar({
 }: Props) {
   return (
     <div
-      className={`flex flex-col w-72 md:w-64 h-full bg-white dark:bg-blue-d6 border-r border-prim ${className}`}
+      className={`flex flex-col w-72 md:w-64 h-full bg-white dark:bg-blue-d6 border-r border-gray-l4 ${className}`}
     >
       <Header />
 

--- a/src/pages/Admin/Sidebar/Sidebar.tsx
+++ b/src/pages/Admin/Sidebar/Sidebar.tsx
@@ -26,7 +26,7 @@ export default function Sidebar({
         {linkGroups.map((group) => (
           <React.Fragment key={`link_group-${group.title}`}>
             {group.title && (
-              <h6 className="pt-5 px-5 pb-1 font-bold text-xs uppercase text-gray-l1 tracking-wide">
+              <h6 className="pt-5 px-5 pb-1 font-bold text-xs uppercase text-navy-l3 tracking-wide">
                 {group.title}
               </h6>
             )}

--- a/src/pages/Admin/Sidebar/Sidebar.tsx
+++ b/src/pages/Admin/Sidebar/Sidebar.tsx
@@ -51,6 +51,6 @@ export default function Sidebar({
 }
 
 const linkClassName = createNavLinkStyler(
-  "flex items-center gap-2 py-3 px-5 font-bold text-sm hover:text-orange-l1 active:text-orange transition ease-in-out duration-300 aria-disabled:text-gray aria-disabled:pointer-events-none",
+  "flex items-center gap-2 py-3 px-5 font-bold text-sm hover:text-orange-l1 active:text-orange transition ease-in-out duration-300 aria-disabled:text-navy-l2 aria-disabled:pointer-events-none",
   "pointer-events-none text-orange"
 );

--- a/src/pages/Admin/Sidebar/SidebarOpener/SidebarOpener.tsx
+++ b/src/pages/Admin/Sidebar/SidebarOpener/SidebarOpener.tsx
@@ -11,7 +11,7 @@ export function SidebarOpener({ className = "", linkGroups }: Props) {
     <button
       type="button"
       onClick={open}
-      className={`flex items-center gap-2 py-5 px-6 dark:bg-blue-d6 border-b border-prim font-bold text-sm text-orange ${className}`}
+      className={`flex items-center gap-2 py-5 px-6 dark:bg-blue-d6 border-b border-gray-l4 font-bold text-sm text-orange ${className}`}
     >
       <Icon {...activeLink.icon} />
       {activeLink.title}

--- a/src/pages/Application/Container.tsx
+++ b/src/pages/Application/Container.tsx
@@ -11,12 +11,12 @@ export default function Container({ title, children, classes = "" }: Props) {
 
   return (
     <div
-      className={`w-full border border-prim rounded dark:bg-blue-d6 divide-y divide-prim ${classes}`}
+      className={`w-full border border-gray-l4 rounded dark:bg-blue-d6 divide-y divide-prim ${classes}`}
     >
       <div className="flex items-center gap-x-3 p-3">
         <button
           onClick={() => setOpen((prev) => !prev)}
-          className="flex items-center justify-center p-px w-6 h-6 border border-prim rounded"
+          className="flex items-center justify-center p-px w-6 h-6 border border-gray-l4 rounded"
           aria-label="toggle section content's visibility"
         >
           <Icon type={isOpen ? "Dash" : "Plus"} />

--- a/src/pages/Application/Loaded.tsx
+++ b/src/pages/Application/Loaded.tsx
@@ -147,14 +147,14 @@ function Row(props: Props) {
       </dt>
       <div
         aria-hidden={true}
-        className="max-sm:hidden w-px border-r border-prim last:border-none"
+        className="max-sm:hidden w-px border-r border-gray-l4 last:border-none"
       />
       <dd className="px-3 max-sm:pb-3 sm:p-3 flex items-center text-sm">
         {props.children}
       </dd>
       <div
         aria-hidden={true}
-        className="h-px col-span-full border-b border-prim last:border-none"
+        className="h-px col-span-full border-b border-gray-l4 last:border-none"
       />
     </>
   );

--- a/src/pages/Application/Prompt.tsx
+++ b/src/pages/Application/Prompt.tsx
@@ -68,14 +68,14 @@ export default function Prompt({ verdict, orgName, uuid }: Props) {
       className="fixed-center z-10 grid content-start justify-items-center text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
     >
       <div className="relative w-full">
-        <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-prim p-5">
+        <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">
           Changing Application Status
         </p>
         {isDismissible && (
           <button
             onClick={closeModal}
             disabled={isLoading}
-            className="border border-prim p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" className="text-lg sm:text-2xl" />
           </button>
@@ -130,7 +130,7 @@ export default function Prompt({ verdict, orgName, uuid }: Props) {
         </FormProvider>
       )}
 
-      <div className="p-3 sm:px-8 sm:py-4 flex items-center justify-end gap-4 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-prim">
+      <div className="p-3 sm:px-8 sm:py-4 flex items-center justify-end gap-4 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-gray-l4">
         <button
           disabled={isLoading}
           type="button"

--- a/src/pages/Application/Prompt.tsx
+++ b/src/pages/Application/Prompt.tsx
@@ -75,7 +75,7 @@ export default function Prompt({ verdict, orgName, uuid }: Props) {
           <button
             onClick={closeModal}
             disabled={isLoading}
-            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-navy-l5 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" className="text-lg sm:text-2xl" />
           </button>
@@ -88,7 +88,7 @@ export default function Prompt({ verdict, orgName, uuid }: Props) {
         <div>Nonprofit</div>
       </h3>
 
-      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3 mt-4">
+      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-navy-l5 mt-4">
         <span className="block">
           You are about to {verdict} the Application for
         </span>
@@ -96,13 +96,13 @@ export default function Prompt({ verdict, orgName, uuid }: Props) {
       </p>
 
       {verdict === "approve" ? (
-        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3">
+        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-navy-l5">
           This will immediately payout all pending funds to newly linked bank
           account and is irreversible.
         </div>
       ) : null}
 
-      <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3 font-bold">
+      <div className="px-6 pb-4 text-center text-navy-l1 dark:text-navy-l5 font-bold">
         Please ensure you have confirmed all submitted details and supporting
         documentation before proceeding!
       </div>

--- a/src/pages/Application/Prompt.tsx
+++ b/src/pages/Application/Prompt.tsx
@@ -88,7 +88,7 @@ export default function Prompt({ verdict, orgName, uuid }: Props) {
         <div>Nonprofit</div>
       </h3>
 
-      <p className="px-6 pb-4 text-center text-gray-d1 dark:text-gray-l3 mt-4">
+      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3 mt-4">
         <span className="block">
           You are about to {verdict} the Application for
         </span>
@@ -96,13 +96,13 @@ export default function Prompt({ verdict, orgName, uuid }: Props) {
       </p>
 
       {verdict === "approve" ? (
-        <div className="px-6 pb-4 text-center text-gray-d1 dark:text-gray-l3">
+        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3">
           This will immediately payout all pending funds to newly linked bank
           account and is irreversible.
         </div>
       ) : null}
 
-      <div className="px-6 pb-4 text-center text-gray-d1 dark:text-gray-l3 font-bold">
+      <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3 font-bold">
         Please ensure you have confirmed all submitted details and supporting
         documentation before proceeding!
       </div>

--- a/src/pages/Application/Prompt.tsx
+++ b/src/pages/Application/Prompt.tsx
@@ -65,7 +65,7 @@ export default function Prompt({ verdict, orgName, uuid }: Props) {
     <Modal
       as="form"
       onSubmit={methods.handleSubmit(onSubmit)}
-      className="fixed-center z-10 grid content-start justify-items-center text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
+      className="fixed-center z-10 grid content-start justify-items-center text-navy-d4 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
     >
       <div className="relative w-full">
         <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">

--- a/src/pages/Applications/Applications.tsx
+++ b/src/pages/Applications/Applications.tsx
@@ -30,7 +30,7 @@ function Applications() {
         <Icon
           type="Search"
           size={24}
-          className="text-gray-d2 dark:text-navy-l2 absolute top-1/2 -translate-y-1/2 left-3"
+          className="text-navy-d4 dark:text-navy-l2 absolute top-1/2 -translate-y-1/2 left-3"
         />
         <input
           disabled={isError}

--- a/src/pages/Applications/Applications.tsx
+++ b/src/pages/Applications/Applications.tsx
@@ -34,7 +34,7 @@ function Applications() {
         />
         <input
           disabled={isError}
-          className="p-3 pl-10 placeholder:text-gray-d1 dark:placeholder:text-gray bg-transparent w-full outline-none disabled:bg-gray-l3 dark:disabled:bg-navy-d3"
+          className="p-3 pl-10 placeholder:text-navy-l1 dark:placeholder:text-gray bg-transparent w-full outline-none disabled:bg-gray-l3 dark:disabled:bg-navy-d3"
           type="text"
           placeholder="Search applications"
           value={query}

--- a/src/pages/Applications/Applications.tsx
+++ b/src/pages/Applications/Applications.tsx
@@ -30,11 +30,11 @@ function Applications() {
         <Icon
           type="Search"
           size={24}
-          className="text-gray-d2 dark:text-gray absolute top-1/2 -translate-y-1/2 left-3"
+          className="text-gray-d2 dark:text-navy-l2 absolute top-1/2 -translate-y-1/2 left-3"
         />
         <input
           disabled={isError}
-          className="p-3 pl-10 placeholder:text-navy-l1 dark:placeholder:text-gray bg-transparent w-full outline-none disabled:bg-gray-l3 dark:disabled:bg-navy-d3"
+          className="p-3 pl-10 placeholder:text-navy-l1 dark:placeholder:text-navy-l2 bg-transparent w-full outline-none disabled:bg-gray-l3 dark:disabled:bg-navy-d3"
           type="text"
           placeholder="Search applications"
           value={query}

--- a/src/pages/Applications/Applications.tsx
+++ b/src/pages/Applications/Applications.tsx
@@ -26,7 +26,7 @@ function Applications() {
       <h1 className="text-center text-3xl col-span-full max-lg:mb-4">
         Applications Review - Dashboard
       </h1>
-      <div className="relative flex gap-x-3 items-center border border-prim w-full bg-white dark:bg-blue-d6 rounded">
+      <div className="relative flex gap-x-3 items-center border border-gray-l4 w-full bg-white dark:bg-blue-d6 rounded">
         <Icon
           type="Search"
           size={24}

--- a/src/pages/Applications/Filter/Form.tsx
+++ b/src/pages/Applications/Filter/Form.tsx
@@ -19,7 +19,7 @@ const Form: FC<Props> = ({ onReset, submit, classes = "" }) => {
       as="form"
       onSubmit={submit}
       onReset={onReset}
-      className={`${classes} grid content-start gap-4 w-full rounded border border-prim bg-white dark:bg-blue-d5`}
+      className={`${classes} grid content-start gap-4 w-full rounded border border-gray-l4 bg-white dark:bg-blue-d5`}
     >
       <div className="lg:hidden relative text-[1.25rem] px-4 py-3 -mb-4 font-bold uppercase">
         <span className="text-orange">Filters</span>
@@ -50,7 +50,7 @@ const Form: FC<Props> = ({ onReset, submit, classes = "" }) => {
 
       <RegStatusDropdown classes="px-4 lg:px-6 max-lg:mb-4" />
 
-      <div className="max-lg:row-start-2 flex gap-x-4 items-center justify-between max-lg:px-4 max-lg:py-3 p-6 lg:mt-2 bg-orange-l6 dark:bg-blue-d7 border-y lg:border-t border-prim">
+      <div className="max-lg:row-start-2 flex gap-x-4 items-center justify-between max-lg:px-4 max-lg:py-3 p-6 lg:mt-2 bg-orange-l6 dark:bg-blue-d7 border-y lg:border-t border-gray-l4">
         <h3 className="uppercase lg:hidden">Filter by</h3>
         <button
           type="reset"

--- a/src/pages/Applications/Filter/index.tsx
+++ b/src/pages/Applications/Filter/index.tsx
@@ -70,7 +70,7 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
       <Popover.Button
         ref={buttonRef}
         disabled={isDisabled}
-        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-navy-l1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
+        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-navy-l2 lg:text-navy-l1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
       >
         {({ open }) => (
           <>

--- a/src/pages/Applications/Filter/index.tsx
+++ b/src/pages/Applications/Filter/index.tsx
@@ -70,7 +70,7 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
       <Popover.Button
         ref={buttonRef}
         disabled={isDisabled}
-        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
+        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-navy-l1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
       >
         {({ open }) => (
           <>

--- a/src/pages/Applications/Filter/index.tsx
+++ b/src/pages/Applications/Filter/index.tsx
@@ -70,7 +70,7 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
       <Popover.Button
         ref={buttonRef}
         disabled={isDisabled}
-        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-prim"
+        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
       >
         {({ open }) => (
           <>

--- a/src/pages/Applications/LoadMoreBtn.tsx
+++ b/src/pages/Applications/LoadMoreBtn.tsx
@@ -14,7 +14,7 @@ export default function LoadMoreBtn({
       type="button"
       onClick={onLoadMore}
       disabled={disabled}
-      className="flex items-center justify-center gap-3 uppercase text-sm font-bold rounded-b w-full h-12 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-gray aria-disabled:bg-gray-l3 aria-disabled:dark:bg-navy disabled:dark:bg-navy"
+      className="flex items-center justify-center gap-3 uppercase text-sm font-bold rounded-b w-full h-12 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-navy-l2 aria-disabled:bg-gray-l3 aria-disabled:dark:bg-navy disabled:dark:bg-navy"
     >
       {isLoading ? (
         <>

--- a/src/pages/Applications/Table.tsx
+++ b/src/pages/Applications/Table.tsx
@@ -23,7 +23,7 @@ export default function Table({
 
   return (
     <table
-      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-prim`}
+      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-gray-l4`}
     >
       <TableSection
         type="thead"
@@ -80,7 +80,7 @@ export default function Table({
             <Cells
               key={row.PK}
               type="td"
-              cellClass={`p-3 border-t border-prim max-w-[256px] truncate ${
+              cellClass={`p-3 border-t border-gray-l4 max-w-[256px] truncate ${
                 hasMore ? "" : "first:rounded-bl last:rounded-br"
               }`}
             >
@@ -108,7 +108,7 @@ export default function Table({
               <td
                 colSpan={9}
                 key="load-more-btn"
-                className="border-t border-prim rounded-b"
+                className="border-t border-gray-l4 rounded-b"
               >
                 <LoadMoreBtn
                   onLoadMore={onLoadMore}

--- a/src/pages/BankingApplication/Loaded.tsx
+++ b/src/pages/BankingApplication/Loaded.tsx
@@ -42,7 +42,7 @@ export default function Loaded(props: BankingApplicationDetails) {
         </span>
       </div>
 
-      <dl className="grid sm:grid-cols-[auto_auto_1fr] border border-prim rounded">
+      <dl className="grid sm:grid-cols-[auto_auto_1fr] border border-gray-l4 rounded">
         <Row label="Currency">{props.currency}</Row>
         <Row label="Country">{props.country}</Row>
         <Row label="Recipient name">{props.name.fullName}</Row>
@@ -108,14 +108,14 @@ function Row(props: Props) {
       </dt>
       <div
         aria-hidden={true}
-        className="max-sm:hidden w-px border-r border-prim last:border-none"
+        className="max-sm:hidden w-px border-r border-gray-l4 last:border-none"
       />
       <dd className="px-3 max-sm:pb-3 sm:p-3 flex items-center text-sm">
         {props.children}
       </dd>
       <div
         aria-hidden={true}
-        className="h-px col-span-full border-b border-prim last:border-none"
+        className="h-px col-span-full border-b border-gray-l4 last:border-none"
       />
     </>
   );

--- a/src/pages/BankingApplication/Prompt.tsx
+++ b/src/pages/BankingApplication/Prompt.tsx
@@ -80,12 +80,12 @@ export default function Prompt({ verdict, uuid }: Props) {
           </button>
         )}
       </div>
-      <p className="px-6 pb-4 text-center text-gray-d1 dark:text-gray-l3 mt-4 font-semibold">
+      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3 mt-4 font-semibold">
         You are about to {verdict} this banking application.
       </p>
 
       {verdict === "approve" ? (
-        <div className="px-6 pb-4 text-center text-gray-d1 dark:text-gray-l3">
+        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3">
           This will immediately payout all pending funds to newly linked bank
           account and is irreversible.
         </div>

--- a/src/pages/BankingApplication/Prompt.tsx
+++ b/src/pages/BankingApplication/Prompt.tsx
@@ -64,7 +64,7 @@ export default function Prompt({ verdict, uuid }: Props) {
     <Modal
       as="form"
       onSubmit={methods.handleSubmit(onSubmit)}
-      className="fixed-center z-10 grid content-start justify-items-center text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
+      className="fixed-center z-10 grid content-start justify-items-center text-navy-d4 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
     >
       <div className="relative w-full">
         <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">

--- a/src/pages/BankingApplication/Prompt.tsx
+++ b/src/pages/BankingApplication/Prompt.tsx
@@ -74,18 +74,18 @@ export default function Prompt({ verdict, uuid }: Props) {
           <button
             onClick={closeModal}
             disabled={isLoading}
-            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-navy-l5 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" className="text-lg sm:text-2xl" />
           </button>
         )}
       </div>
-      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3 mt-4 font-semibold">
+      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-navy-l5 mt-4 font-semibold">
         You are about to {verdict} this banking application.
       </p>
 
       {verdict === "approve" ? (
-        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3">
+        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-navy-l5">
           This will immediately payout all pending funds to newly linked bank
           account and is irreversible.
         </div>

--- a/src/pages/BankingApplication/Prompt.tsx
+++ b/src/pages/BankingApplication/Prompt.tsx
@@ -67,14 +67,14 @@ export default function Prompt({ verdict, uuid }: Props) {
       className="fixed-center z-10 grid content-start justify-items-center text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
     >
       <div className="relative w-full">
-        <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-prim p-5">
+        <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">
           Banking application
         </p>
         {isDismissible && (
           <button
             onClick={closeModal}
             disabled={isLoading}
-            className="border border-prim p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" className="text-lg sm:text-2xl" />
           </button>
@@ -114,7 +114,7 @@ export default function Prompt({ verdict, uuid }: Props) {
         </FormProvider>
       )}
 
-      <div className="p-3 sm:px-8 sm:py-4 flex items-center justify-end gap-4 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-prim">
+      <div className="p-3 sm:px-8 sm:py-4 flex items-center justify-end gap-4 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-gray-l4">
         <button
           disabled={isLoading}
           type="button"

--- a/src/pages/BankingApplications/Filter/Form.tsx
+++ b/src/pages/BankingApplications/Filter/Form.tsx
@@ -17,7 +17,7 @@ const Form: FC<Props> = ({ onReset, submit, classes = "" }) => {
       as="form"
       onSubmit={submit}
       onReset={onReset}
-      className={`${classes} grid content-start gap-4 w-full rounded border border-prim bg-white dark:bg-blue-d5`}
+      className={`${classes} grid content-start gap-4 w-full rounded border border-gray-l4 bg-white dark:bg-blue-d5`}
     >
       <div className="lg:hidden relative text-[1.25rem] px-4 py-3 -mb-4 font-bold uppercase">
         <span className="text-orange">Filters</span>
@@ -32,7 +32,7 @@ const Form: FC<Props> = ({ onReset, submit, classes = "" }) => {
       />
       <StatusDropdown classes="px-4 lg:px-6 max-lg:mb-4" />
 
-      <div className="max-lg:row-start-2 flex gap-x-4 items-center justify-between max-lg:px-4 max-lg:py-3 p-6 lg:mt-2 bg-orange-l6 dark:bg-blue-d7 border-y lg:border-t border-prim">
+      <div className="max-lg:row-start-2 flex gap-x-4 items-center justify-between max-lg:px-4 max-lg:py-3 p-6 lg:mt-2 bg-orange-l6 dark:bg-blue-d7 border-y lg:border-t border-gray-l4">
         <h3 className="uppercase lg:hidden">Filter by</h3>
         <button
           type="reset"

--- a/src/pages/BankingApplications/Filter/index.tsx
+++ b/src/pages/BankingApplications/Filter/index.tsx
@@ -61,7 +61,7 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
       <Popover.Button
         ref={buttonRef}
         disabled={isDisabled}
-        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-prim"
+        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
       >
         {({ open }) => (
           <>

--- a/src/pages/BankingApplications/Filter/index.tsx
+++ b/src/pages/BankingApplications/Filter/index.tsx
@@ -61,7 +61,7 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
       <Popover.Button
         ref={buttonRef}
         disabled={isDisabled}
-        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
+        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-navy-l1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
       >
         {({ open }) => (
           <>

--- a/src/pages/BankingApplications/Filter/index.tsx
+++ b/src/pages/BankingApplications/Filter/index.tsx
@@ -61,7 +61,7 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
       <Popover.Button
         ref={buttonRef}
         disabled={isDisabled}
-        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-navy-l1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
+        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-navy-l2 lg:text-navy-l1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
       >
         {({ open }) => (
           <>

--- a/src/pages/BankingApplications/LoadMoreBtn.tsx
+++ b/src/pages/BankingApplications/LoadMoreBtn.tsx
@@ -14,7 +14,7 @@ export default function LoadMoreBtn({
       type="button"
       onClick={onLoadMore}
       disabled={disabled}
-      className="flex items-center justify-center gap-3 uppercase text-sm font-bold rounded-b w-full h-12 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-gray aria-disabled:bg-gray-l3 aria-disabled:dark:bg-navy disabled:dark:bg-navy"
+      className="flex items-center justify-center gap-3 uppercase text-sm font-bold rounded-b w-full h-12 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-navy-l2 aria-disabled:bg-gray-l3 aria-disabled:dark:bg-navy disabled:dark:bg-navy"
     >
       {isLoading ? (
         <>

--- a/src/pages/BankingApplications/Prompt.tsx
+++ b/src/pages/BankingApplications/Prompt.tsx
@@ -80,12 +80,12 @@ export default function Prompt({ verdict, uuid }: Props) {
           </button>
         )}
       </div>
-      <p className="px-6 pb-4 text-center text-gray-d1 dark:text-gray-l3 mt-4 font-semibold">
+      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3 mt-4 font-semibold">
         You are about to {verdict} this banking application.
       </p>
 
       {verdict === "approve" ? (
-        <div className="px-6 pb-4 text-center text-gray-d1 dark:text-gray-l3">
+        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3">
           This will immediately payout all pending funds to newly linked bank
           account and is irreversible.
         </div>

--- a/src/pages/BankingApplications/Prompt.tsx
+++ b/src/pages/BankingApplications/Prompt.tsx
@@ -64,7 +64,7 @@ export default function Prompt({ verdict, uuid }: Props) {
     <Modal
       as="form"
       onSubmit={methods.handleSubmit(onSubmit)}
-      className="fixed-center z-10 grid content-start justify-items-center text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
+      className="fixed-center z-10 grid content-start justify-items-center text-navy-d4 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
     >
       <div className="relative w-full">
         <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">

--- a/src/pages/BankingApplications/Prompt.tsx
+++ b/src/pages/BankingApplications/Prompt.tsx
@@ -74,18 +74,18 @@ export default function Prompt({ verdict, uuid }: Props) {
           <button
             onClick={closeModal}
             disabled={isLoading}
-            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-navy-l5 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" className="text-lg sm:text-2xl" />
           </button>
         )}
       </div>
-      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3 mt-4 font-semibold">
+      <p className="px-6 pb-4 text-center text-navy-l1 dark:text-navy-l5 mt-4 font-semibold">
         You are about to {verdict} this banking application.
       </p>
 
       {verdict === "approve" ? (
-        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-gray-l3">
+        <div className="px-6 pb-4 text-center text-navy-l1 dark:text-navy-l5">
           This will immediately payout all pending funds to newly linked bank
           account and is irreversible.
         </div>

--- a/src/pages/BankingApplications/Prompt.tsx
+++ b/src/pages/BankingApplications/Prompt.tsx
@@ -67,14 +67,14 @@ export default function Prompt({ verdict, uuid }: Props) {
       className="fixed-center z-10 grid content-start justify-items-center text-gray-d2 dark:text-white bg-white dark:bg-blue-d4 sm:w-full w-[90vw] sm:max-w-lg rounded overflow-hidden"
     >
       <div className="relative w-full">
-        <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-prim p-5">
+        <p className="sm:text-xl font-bold text-center border-b bg-orange-l6 dark:bg-blue-d7 border-gray-l4 p-5">
           Banking application
         </p>
         {isDismissible && (
           <button
             onClick={closeModal}
             disabled={isLoading}
-            className="border border-prim p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
+            className="border border-gray-l4 p-2 rounded-md absolute top-1/2 right-4 transform -translate-y-1/2 disabled:text-gray-l3 dark:disabled:text-navy-d3 disabled:dark:border-navy-d3"
           >
             <Icon type="Close" className="text-lg sm:text-2xl" />
           </button>
@@ -114,7 +114,7 @@ export default function Prompt({ verdict, uuid }: Props) {
         </FormProvider>
       )}
 
-      <div className="p-3 sm:px-8 sm:py-4 flex items-center justify-end gap-4 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-prim">
+      <div className="p-3 sm:px-8 sm:py-4 flex items-center justify-end gap-4 w-full text-center sm:text-right bg-orange-l6 dark:bg-blue-d7 border-t border-gray-l4">
         <button
           disabled={isLoading}
           type="button"

--- a/src/pages/BankingApplications/Table.tsx
+++ b/src/pages/BankingApplications/Table.tsx
@@ -16,7 +16,7 @@ export default function Table({
 }: TableProps) {
   return (
     <table
-      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-prim`}
+      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-gray-l4`}
     >
       <TableSection
         type="thead"
@@ -43,7 +43,7 @@ export default function Table({
             <Cells
               key={row.wiseRecipientID}
               type="td"
-              cellClass={`p-3 border-t border-prim max-w-[256px] truncate ${
+              cellClass={`p-3 border-t border-gray-l4 max-w-[256px] truncate ${
                 hasMore ? "" : "first:rounded-bl last:rounded-br"
               }`}
             >
@@ -71,7 +71,7 @@ export default function Table({
               <td
                 colSpan={9}
                 key="load-more-btn"
-                className="border-t border-prim rounded-b"
+                className="border-t border-gray-l4 rounded-b"
               >
                 <LoadMoreBtn
                   onLoadMore={onLoadMore}

--- a/src/pages/Donate/Content.tsx
+++ b/src/pages/Donate/Content.tsx
@@ -63,7 +63,7 @@ function Content(props: Props) {
           />
         </div>
         <FAQ classes="max-md:px-4 mt-4 col-start-1 md:row-start-3 md:row-span-4 md:col-start-1 md:w-64 xl:w-80 lg:row-start-2 lg:col-start-3 lg:mt-0" />
-        <p className="max-md:px-4 mt-4 text-xs leading-normal text-left text-gray-d1 dark:text-gray col-start-1 md:col-start-2 md:row-start-4 lg:row-start-3">
+        <p className="max-md:px-4 mt-4 text-xs leading-normal text-left text-navy-l1 dark:text-gray col-start-1 md:col-start-2 md:row-start-4 lg:row-start-3">
           By making a donation to {APP_NAME}, you agree to our{" "}
           <A href={TERMS_OF_USE_DONOR}>Terms of Service</A>,{" "}
           <A href={PRIVACY_POLICY}>Privacy Policy</A>, and{" "}
@@ -75,7 +75,7 @@ function Content(props: Props) {
           unrestricted basis, regardless of any designations or restrictions
           made by you. <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
         </p>
-        <p className="max-md:px-4 mt-4 text-xs leading-normal text-left text-gray-d1 dark:text-gray col-start-1 md:col-start-2 md:row-start-5 lg:row-start-4">
+        <p className="max-md:px-4 mt-4 text-xs leading-normal text-left text-navy-l1 dark:text-gray col-start-1 md:col-start-2 md:row-start-5 lg:row-start-4">
           <span className="block mb-0.5">
             Need help? See{" "}
             <Link to="./#faqs" className="hover:underline font-medium">

--- a/src/pages/Donate/Content.tsx
+++ b/src/pages/Donate/Content.tsx
@@ -63,7 +63,7 @@ function Content(props: Props) {
           />
         </div>
         <FAQ classes="max-md:px-4 mt-4 col-start-1 md:row-start-3 md:row-span-4 md:col-start-1 md:w-64 xl:w-80 lg:row-start-2 lg:col-start-3 lg:mt-0" />
-        <p className="max-md:px-4 mt-4 text-xs leading-normal text-left text-navy-l1 dark:text-gray col-start-1 md:col-start-2 md:row-start-4 lg:row-start-3">
+        <p className="max-md:px-4 mt-4 text-xs leading-normal text-left text-navy-l1 dark:text-navy-l2 col-start-1 md:col-start-2 md:row-start-4 lg:row-start-3">
           By making a donation to {APP_NAME}, you agree to our{" "}
           <A href={TERMS_OF_USE_DONOR}>Terms of Service</A>,{" "}
           <A href={PRIVACY_POLICY}>Privacy Policy</A>, and{" "}
@@ -75,7 +75,7 @@ function Content(props: Props) {
           unrestricted basis, regardless of any designations or restrictions
           made by you. <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
         </p>
-        <p className="max-md:px-4 mt-4 text-xs leading-normal text-left text-navy-l1 dark:text-gray col-start-1 md:col-start-2 md:row-start-5 lg:row-start-4">
+        <p className="max-md:px-4 mt-4 text-xs leading-normal text-left text-navy-l1 dark:text-navy-l2 col-start-1 md:col-start-2 md:row-start-5 lg:row-start-4">
           <span className="block mb-0.5">
             Need help? See{" "}
             <Link to="./#faqs" className="hover:underline font-medium">

--- a/src/pages/Donate/Content.tsx
+++ b/src/pages/Donate/Content.tsx
@@ -37,7 +37,7 @@ function Content(props: Props) {
 
   return (
     <div
-      className="max-sm:fixed max-sm:inset-0 overflow-y-auto w-full z-20 bg-white py-4 sm:py-10"
+      className="max-sm:fixed max-sm:inset-0 overflow-y-auto w-full z-20 bg-[#F6F7F8] py-4 sm:py-10"
       id={CONTAINER_ID}
     >
       <div className="md:padded-container grid md:grid-cols-[auto_1fr] lg:grid-cols-[auto_1fr_auto] items-start content-start gap-x-6">

--- a/src/pages/Donate/Content.tsx
+++ b/src/pages/Donate/Content.tsx
@@ -56,9 +56,9 @@ function Content(props: Props) {
           classes="mb-4 md:mb-0 md:col-start-1 md:w-64 xl:w-80 md:h-full lg:h-auto"
         />
         {/** small screen but space is still enough to render sidebar */}
-        <div className="mx-0 border-b md:contents min-[445px]:border min-[445px]:mx-4 rounded border-prim">
+        <div className="mx-0 border-b md:contents min-[445px]:border min-[445px]:mx-4 rounded border-gray-l4">
           <Steps
-            className="md:border border-prim col-start-1 md:col-start-2 md:row-start-2 md:row-span-2 lg:row-span-1"
+            className="md:border border-gray-l4 col-start-1 md:col-start-2 md:row-start-2 md:row-span-2 lg:row-span-1"
             donaterConfig={null}
           />
         </div>

--- a/src/pages/Donate/FAQ.tsx
+++ b/src/pages/Donate/FAQ.tsx
@@ -171,7 +171,7 @@ function Em({
           ? "font-medium"
           : intensity === 2
             ? "font-semibold"
-            : "font-semibold text-gray-d2"
+            : "font-semibold text-navy-d4"
       } ${classes}`}
     >
       {children}

--- a/src/pages/Donate/FAQ.tsx
+++ b/src/pages/Donate/FAQ.tsx
@@ -9,7 +9,8 @@ export default function FAQ({ classes = "" }) {
   return (
     <div
       className={
-        classes + " md:border md:border-prim md:p-4 rounded grid gap-2 md:gap-4"
+        classes +
+        " md:border md:border-gray-l4 md:p-4 rounded grid gap-2 md:gap-4"
       }
     >
       <h2 className="text-sm" id="faqs">

--- a/src/pages/Donate/FAQ.tsx
+++ b/src/pages/Donate/FAQ.tsx
@@ -35,7 +35,7 @@ export default function FAQ({ classes = "" }) {
                 <Disclosure.Panel
                   as="div"
                   static
-                  className="text-sm grid gap-3 text-gray-d1 mb-6"
+                  className="text-sm grid gap-3 text-navy-l1 mb-6"
                 >
                   {faq.paragraphs.map((p, idx) => (
                     <Fragment key={idx}>{p}</Fragment>

--- a/src/pages/Donate/FAQ.tsx
+++ b/src/pages/Donate/FAQ.tsx
@@ -10,7 +10,7 @@ export default function FAQ({ classes = "" }) {
     <div
       className={
         classes +
-        " md:border md:border-gray-l4 md:p-4 rounded grid gap-2 md:gap-4"
+        " md:bg-white md:border md:border-gray-l4 md:p-4 rounded grid gap-2 md:gap-4"
       }
     >
       <h2 className="text-sm" id="faqs">

--- a/src/pages/Donate/OrgCard.tsx
+++ b/src/pages/Donate/OrgCard.tsx
@@ -20,7 +20,7 @@ export default function OrgCard({
 }: Props) {
   return (
     <div
-      className={`p-4 max-md:bg-blue-l4 md:p-0 md:rounded md:overflow-clip md:border border-prim ${classes}`}
+      className={`p-4 max-md:bg-blue-l4 md:p-0 md:rounded md:overflow-clip md:border border-gray-l4 ${classes}`}
     >
       <Image
         src={banner}
@@ -29,7 +29,7 @@ export default function OrgCard({
       <div className="hidden md:flex items-center w-full overflow-visible h-0">
         <Image
           src={logo}
-          className="size-14 border border-prim rounded-full object-cover bg-white ml-6"
+          className="size-14 border border-gray-l4 rounded-full object-cover bg-white ml-6"
         />
       </div>
       <div className="md:p-4 md:pt-11">

--- a/src/pages/Donate/OrgCard.tsx
+++ b/src/pages/Donate/OrgCard.tsx
@@ -20,7 +20,7 @@ export default function OrgCard({
 }: Props) {
   return (
     <div
-      className={`p-4 max-md:bg-blue-l4 md:p-0 md:rounded md:overflow-clip md:border border-gray-l4 ${classes}`}
+      className={`p-4 bg-white max-md:bg-blue-l4 md:p-0 md:rounded md:overflow-clip md:border border-gray-l4 ${classes}`}
     >
       <Image
         src={banner}

--- a/src/pages/Donate/OrgCard.tsx
+++ b/src/pages/Donate/OrgCard.tsx
@@ -48,7 +48,7 @@ export default function OrgCard({
             Cancel
           </Link>
         </div>
-        <p className="text-gray-d1 text-sm max-md:hidden">{tagline}</p>
+        <p className="text-navy-l1 text-sm max-md:hidden">{tagline}</p>
       </div>
     </div>
   );

--- a/src/pages/DonateFiatThanks.tsx
+++ b/src/pages/DonateFiatThanks.tsx
@@ -24,14 +24,14 @@ export default function DonateFiatThanks({ widgetVersion = false }) {
       <h3 className="text-xl sm:text-2xl mb-2 text-center leading-relaxed text-balance">
         Your generosity knows no bounds! Thank you for making a difference!
       </h3>
-      <p className="text-center text-gray-d1">
+      <p className="text-center text-navy-l1">
         We'll process your donation to the nonprofit you specified as soon as
         the payment has cleared.
         {widgetVersion
           ? ""
           : " You can safely navigate away using the button below."}
       </p>
-      <p className="text-center text-gray-d1 mt-8 text-[15px]">
+      <p className="text-center text-navy-l1 mt-8 text-[15px]">
         If you need a receipt for your donation, please fill out the KYC form
         for this transaction on your{" "}
         {widgetVersion ? (

--- a/src/pages/DonateWidget/Content.tsx
+++ b/src/pages/DonateWidget/Content.tsx
@@ -59,7 +59,7 @@ export default function Content({
       )}
 
       <Steps
-        className="mt-5 w-full md:w-3/4 border border-prim"
+        className="mt-5 w-full md:w-3/4 border border-gray-l4"
         donaterConfig={configResult.config}
       />
     </div>

--- a/src/pages/Donations/DonationsSection.tsx
+++ b/src/pages/Donations/DonationsSection.tsx
@@ -45,7 +45,7 @@ export default function DonationsSection(
       >
         Export to CSV
       </CsvExporter>
-      <div className="relative flex gap-x-3 items-center border border-prim w-full bg-white dark:bg-blue-d6 rounded">
+      <div className="relative flex gap-x-3 items-center border border-gray-l4 w-full bg-white dark:bg-blue-d6 rounded">
         <Icon
           type="Search"
           size={24}

--- a/src/pages/Donations/DonationsSection.tsx
+++ b/src/pages/Donations/DonationsSection.tsx
@@ -49,11 +49,11 @@ export default function DonationsSection(
         <Icon
           type="Search"
           size={24}
-          className="text-gray-d2 dark:text-gray absolute top-1/2 -translate-y-1/2 left-3"
+          className="text-gray-d2 dark:text-navy-l2 absolute top-1/2 -translate-y-1/2 left-3"
         />
         <input
           disabled={isError}
-          className="p-3 pl-10 placeholder:text-navy-l1 dark:placeholder:text-gray bg-transparent w-full outline-none disabled:bg-gray-l3 dark:disabled:bg-navy-d3"
+          className="p-3 pl-10 placeholder:text-navy-l1 dark:placeholder:text-navy-l2 bg-transparent w-full outline-none disabled:bg-gray-l3 dark:disabled:bg-navy-d3"
           type="text"
           placeholder="Search donations..."
           value={query}

--- a/src/pages/Donations/DonationsSection.tsx
+++ b/src/pages/Donations/DonationsSection.tsx
@@ -53,7 +53,7 @@ export default function DonationsSection(
         />
         <input
           disabled={isError}
-          className="p-3 pl-10 placeholder:text-gray-d1 dark:placeholder:text-gray bg-transparent w-full outline-none disabled:bg-gray-l3 dark:disabled:bg-navy-d3"
+          className="p-3 pl-10 placeholder:text-navy-l1 dark:placeholder:text-gray bg-transparent w-full outline-none disabled:bg-gray-l3 dark:disabled:bg-navy-d3"
           type="text"
           placeholder="Search donations..."
           value={query}

--- a/src/pages/Donations/DonationsSection.tsx
+++ b/src/pages/Donations/DonationsSection.tsx
@@ -49,7 +49,7 @@ export default function DonationsSection(
         <Icon
           type="Search"
           size={24}
-          className="text-gray-d2 dark:text-navy-l2 absolute top-1/2 -translate-y-1/2 left-3"
+          className="text-navy-d4 dark:text-navy-l2 absolute top-1/2 -translate-y-1/2 left-3"
         />
         <input
           disabled={isError}

--- a/src/pages/Donations/Filter/Form.tsx
+++ b/src/pages/Donations/Filter/Form.tsx
@@ -19,7 +19,7 @@ const Form: FC<Props> = ({ onReset, submit, classes = "" }) => {
       as="form"
       onSubmit={submit}
       onReset={onReset}
-      className={`${classes} grid content-start gap-4 w-full rounded border border-prim bg-white dark:bg-blue-d5`}
+      className={`${classes} grid content-start gap-4 w-full rounded border border-gray-l4 bg-white dark:bg-blue-d5`}
     >
       <div className="lg:hidden relative text-[1.25rem] px-4 py-3 -mb-4 font-bold uppercase">
         <span className="text-orange">Filters</span>
@@ -37,7 +37,7 @@ const Form: FC<Props> = ({ onReset, submit, classes = "" }) => {
       {/*<NetworkDropdown classes="px-4 lg:px-6" />*/}
       {/*<CurrencyDropdown classes="px-4 lg:px-6" />*/}
 
-      <div className="max-lg:row-start-2 flex gap-x-4 items-center justify-between max-lg:px-4 max-lg:py-3 p-6 lg:mt-2 bg-orange-l6 dark:bg-blue-d7 border-y lg:border-t border-prim">
+      <div className="max-lg:row-start-2 flex gap-x-4 items-center justify-between max-lg:px-4 max-lg:py-3 p-6 lg:mt-2 bg-orange-l6 dark:bg-blue-d7 border-y lg:border-t border-gray-l4">
         <h3 className="uppercase lg:hidden">Filter by</h3>
         <button
           type="reset"

--- a/src/pages/Donations/Filter/index.tsx
+++ b/src/pages/Donations/Filter/index.tsx
@@ -64,7 +64,7 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
       <Popover.Button
         ref={buttonRef}
         disabled={isDisabled}
-        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-prim"
+        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
       >
         {({ open }) => (
           <>

--- a/src/pages/Donations/Filter/index.tsx
+++ b/src/pages/Donations/Filter/index.tsx
@@ -64,7 +64,7 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
       <Popover.Button
         ref={buttonRef}
         disabled={isDisabled}
-        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-navy-l1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
+        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-navy-l2 lg:text-navy-l1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
       >
         {({ open }) => (
           <>

--- a/src/pages/Donations/Filter/index.tsx
+++ b/src/pages/Donations/Filter/index.tsx
@@ -64,7 +64,7 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
       <Popover.Button
         ref={buttonRef}
         disabled={isDisabled}
-        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-gray-d1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
+        className="w-full lg:w-[22.3rem] flex justify-center items-center p-3 rounded bg-orange text-white lg:dark:text-gray lg:text-navy-l1 lg:bg-white lg:dark:bg-blue-d6 lg:justify-between disabled:bg-gray lg:disabled:bg-gray-l3 lg:dark:disabled:bg-navy-d3 lg:border lg:border-gray-l4"
       >
         {({ open }) => (
           <>

--- a/src/pages/Donations/LoadMoreBtn.tsx
+++ b/src/pages/Donations/LoadMoreBtn.tsx
@@ -14,7 +14,7 @@ export default function LoadMoreBtn({
       type="button"
       onClick={onLoadMore}
       disabled={disabled}
-      className="flex items-center justify-center gap-3 uppercase text-sm font-bold rounded-b w-full h-12 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-gray aria-disabled:bg-gray-l3 aria-disabled:dark:bg-navy disabled:dark:bg-navy"
+      className="flex items-center justify-center gap-3 uppercase text-sm font-bold rounded-b w-full h-12 hover:bg-orange-l5 dark:hover:bg-blue-d3 active:bg-orange-l4 dark:active:bg-blue-d2 disabled:bg-gray-l3 disabled:text-navy-l2 aria-disabled:bg-gray-l3 aria-disabled:dark:bg-navy disabled:dark:bg-navy"
     >
       {isLoading ? (
         <>

--- a/src/pages/Donations/MobileTable.tsx
+++ b/src/pages/Donations/MobileTable.tsx
@@ -20,11 +20,11 @@ export default function MobileTable({
 
   return (
     <div
-      className={`${classes} border border-prim ${
+      className={`${classes} border border-gray-l4 ${
         hasMore ? "rounded-t" : "rounded"
       }`}
     >
-      <div className="grid items-center grid-cols-[auto_1fr_auto] h-12 uppercase text-xs font-bold bg-orange-l6 dark:bg-blue-d7 border-b border-prim divide-x divide-prim rounded-t">
+      <div className="grid items-center grid-cols-[auto_1fr_auto] h-12 uppercase text-xs font-bold bg-orange-l6 dark:bg-blue-d7 border-b border-gray-l4 divide-x divide-prim rounded-t">
         <div className="w-12" />
         <div className="p-4">Recipient</div>
         <div className="p-4 w-28 text-center">Date</div>
@@ -34,7 +34,7 @@ export default function MobileTable({
         <Disclosure
           key={index}
           as="div"
-          className={`text-sm odd:bg-orange-l6 dark:even:bg-blue-d6 dark:odd:bg-blue-d7 w-full border-b last:border-0 border-prim ${
+          className={`text-sm odd:bg-orange-l6 dark:even:bg-blue-d6 dark:odd:bg-blue-d7 w-full border-b last:border-0 border-gray-l4 ${
             hasMore ? "" : "last:rounded-b"
           }`}
         >

--- a/src/pages/Donations/NoDonations.tsx
+++ b/src/pages/Donations/NoDonations.tsx
@@ -11,7 +11,7 @@ export default function NoDonations({ classes = "" }) {
         className="max-sm:place-self-center sm:col-start-2 sm:row-start-1 sm:row-span-2 rounded-full w-48 object-cover object-center"
       />
       <h3 className="text-lg self-end">No donations found.</h3>
-      <p className="self-start text-gray-d1 dark:text-gray">
+      <p className="self-start text-navy-l1 dark:text-gray">
         Sorry! We couldn't find any donations. Try to adjust any filters applied
         or connect with a different user.
       </p>

--- a/src/pages/Donations/NoDonations.tsx
+++ b/src/pages/Donations/NoDonations.tsx
@@ -11,7 +11,7 @@ export default function NoDonations({ classes = "" }) {
         className="max-sm:place-self-center sm:col-start-2 sm:row-start-1 sm:row-span-2 rounded-full w-48 object-cover object-center"
       />
       <h3 className="text-lg self-end">No donations found.</h3>
-      <p className="self-start text-navy-l1 dark:text-gray">
+      <p className="self-start text-navy-l1 dark:text-navy-l2">
         Sorry! We couldn't find any donations. Try to adjust any filters applied
         or connect with a different user.
       </p>

--- a/src/pages/Donations/Table.tsx
+++ b/src/pages/Donations/Table.tsx
@@ -28,7 +28,7 @@ export default function Table({
 
   return (
     <table
-      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-prim`}
+      className={`${classes} w-full text-sm rounded border border-separate border-spacing-0 border-gray-l4`}
     >
       <TableSection
         type="thead"
@@ -94,7 +94,7 @@ export default function Table({
             <Cells
               key={row.hash}
               type="td"
-              cellClass={`p-3 border-t border-prim max-w-[256px] truncate ${
+              cellClass={`p-3 border-t border-gray-l4 max-w-[256px] truncate ${
                 hasMore ? "" : "first:rounded-bl last:rounded-br"
               }`}
             >
@@ -150,7 +150,7 @@ export default function Table({
               <td
                 colSpan={9}
                 key="load-more-btn"
-                className="border-t border-prim rounded-b"
+                className="border-t border-gray-l4 rounded-b"
               >
                 <LoadMoreBtn
                   onLoadMore={onLoadMore}

--- a/src/pages/Gift/Claim/Form.tsx
+++ b/src/pages/Gift/Claim/Form.tsx
@@ -64,7 +64,7 @@ export default function Form({ classes = "" }) {
         {`Redeem ${APP_NAME} Giftcard`}
       </h3>
       <div className="relative grid w-full border border-gray-l4 rounded-lg overflow-clip">
-        <p className="text-xs text-center uppercase text-navy-l1 dark:text-gray p-4 border-b border-gray-l4">
+        <p className="text-xs text-center uppercase text-navy-l1 dark:text-navy-l2 p-4 border-b border-gray-l4">
           Type your giftcard code here:
         </p>
         <textarea

--- a/src/pages/Gift/Claim/Form.tsx
+++ b/src/pages/Gift/Claim/Form.tsx
@@ -63,8 +63,8 @@ export default function Form({ classes = "" }) {
       <h3 className="text-center text-3xl leading-snug">
         {`Redeem ${APP_NAME} Giftcard`}
       </h3>
-      <div className="relative grid w-full border border-prim rounded-lg overflow-clip">
-        <p className="text-xs text-center uppercase text-gray-d1 dark:text-gray p-4 border-b border-prim">
+      <div className="relative grid w-full border border-gray-l4 rounded-lg overflow-clip">
+        <p className="text-xs text-center uppercase text-gray-d1 dark:text-gray p-4 border-b border-gray-l4">
           Type your giftcard code here:
         </p>
         <textarea

--- a/src/pages/Gift/Claim/Form.tsx
+++ b/src/pages/Gift/Claim/Form.tsx
@@ -64,7 +64,7 @@ export default function Form({ classes = "" }) {
         {`Redeem ${APP_NAME} Giftcard`}
       </h3>
       <div className="relative grid w-full border border-gray-l4 rounded-lg overflow-clip">
-        <p className="text-xs text-center uppercase text-gray-d1 dark:text-gray p-4 border-b border-gray-l4">
+        <p className="text-xs text-center uppercase text-navy-l1 dark:text-gray p-4 border-b border-gray-l4">
           Type your giftcard code here:
         </p>
         <textarea

--- a/src/pages/Gift/Mailer/Form.tsx
+++ b/src/pages/Gift/Mailer/Form.tsx
@@ -80,7 +80,7 @@ export default function Form({ classes = "" }) {
           container:
             "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_10rem] rounded bg-white dark:bg-blue-d6 aria-disabled:bg-gray-l5 aria-disabled:dark:bg-navy-d3 p-3 break-words",
           error: "text-right text-red dark:text-red-l1 text-xs -mt-4",
-          charCounter: "text-gray-d1 dark:text-gray",
+          charCounter: "text-navy-l1 dark:text-gray",
         }}
         charLimit={500}
       />

--- a/src/pages/Gift/Mailer/Form.tsx
+++ b/src/pages/Gift/Mailer/Form.tsx
@@ -78,7 +78,7 @@ export default function Form({ classes = "" }) {
         fieldName="message"
         classes={{
           container:
-            "rich-text-toolbar border border-prim text-sm grid grid-rows-[auto_10rem] rounded bg-white dark:bg-blue-d6 aria-disabled:bg-gray-l5 aria-disabled:dark:bg-navy-d3 p-3 break-words",
+            "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_10rem] rounded bg-white dark:bg-blue-d6 aria-disabled:bg-gray-l5 aria-disabled:dark:bg-navy-d3 p-3 break-words",
           error: "text-right text-red dark:text-red-l1 text-xs -mt-4",
           charCounter: "text-gray-d1 dark:text-gray",
         }}

--- a/src/pages/Gift/Mailer/Form.tsx
+++ b/src/pages/Gift/Mailer/Form.tsx
@@ -80,7 +80,7 @@ export default function Form({ classes = "" }) {
           container:
             "rich-text-toolbar border border-gray-l4 text-sm grid grid-rows-[auto_10rem] rounded bg-white dark:bg-blue-d6 aria-disabled:bg-gray-l5 aria-disabled:dark:bg-navy-d3 p-3 break-words",
           error: "text-right text-red dark:text-red-l1 text-xs -mt-4",
-          charCounter: "text-navy-l1 dark:text-gray",
+          charCounter: "text-navy-l1 dark:text-navy-l2",
         }}
         charLimit={500}
       />

--- a/src/pages/Gift/Purchase/Purchaser/Form/Recipient.tsx
+++ b/src/pages/Gift/Purchase/Purchaser/Form/Recipient.tsx
@@ -12,7 +12,7 @@ export default function Recipient({ classes = "" }: { classes?: string }) {
     <div className={`grid field field-gift ${classes}`}>
       <label htmlFor={fieldName} className="font-bold font-heading mb-3">
         Enter recipient address:{" "}
-        <p className="text-sm font-normal text-gray-d1 dark:text-gray w-[90%] mt-1">
+        <p className="text-sm font-normal text-navy-l1 dark:text-gray w-[90%] mt-1">
           You may leave this blank and receive a gift card code - which you can
           send to your recipient.
         </p>

--- a/src/pages/Gift/Purchase/Purchaser/Form/Recipient.tsx
+++ b/src/pages/Gift/Purchase/Purchaser/Form/Recipient.tsx
@@ -12,7 +12,7 @@ export default function Recipient({ classes = "" }: { classes?: string }) {
     <div className={`grid field field-gift ${classes}`}>
       <label htmlFor={fieldName} className="font-bold font-heading mb-3">
         Enter recipient address:{" "}
-        <p className="text-sm font-normal text-navy-l1 dark:text-gray w-[90%] mt-1">
+        <p className="text-sm font-normal text-navy-l1 dark:text-navy-l2 w-[90%] mt-1">
           You may leave this blank and receive a gift card code - which you can
           send to your recipient.
         </p>

--- a/src/pages/Gift/Purchase/Result/Success.tsx
+++ b/src/pages/Gift/Purchase/Result/Success.tsx
@@ -59,7 +59,7 @@ function EmailCode({ secret }: { secret: string }) {
         Send the code below to your chosen recipient.
       </p>
       <div className="grid border border-gray-l4 rounded-lg overflow-clip">
-        <p className="text-xs text-center uppercase text-gray-d1 dark:text-gray p-4 border-b border-gray-l4">
+        <p className="text-xs text-center uppercase text-navy-l1 dark:text-gray p-4 border-b border-gray-l4">
           Your giftcard code:
         </p>
         <p className="bg-orange-l6 dark:bg-blue-d7 p-4 font-bold text-center text-3xl leading-relaxed break-all">

--- a/src/pages/Gift/Purchase/Result/Success.tsx
+++ b/src/pages/Gift/Purchase/Result/Success.tsx
@@ -58,8 +58,8 @@ function EmailCode({ secret }: { secret: string }) {
       <p className="text-center font-heading mt-4 mb-8">
         Send the code below to your chosen recipient.
       </p>
-      <div className="grid border border-prim rounded-lg overflow-clip">
-        <p className="text-xs text-center uppercase text-gray-d1 dark:text-gray p-4 border-b border-prim">
+      <div className="grid border border-gray-l4 rounded-lg overflow-clip">
+        <p className="text-xs text-center uppercase text-gray-d1 dark:text-gray p-4 border-b border-gray-l4">
           Your giftcard code:
         </p>
         <p className="bg-orange-l6 dark:bg-blue-d7 p-4 font-bold text-center text-3xl leading-relaxed break-all">

--- a/src/pages/Gift/Purchase/Result/Success.tsx
+++ b/src/pages/Gift/Purchase/Result/Success.tsx
@@ -59,7 +59,7 @@ function EmailCode({ secret }: { secret: string }) {
         Send the code below to your chosen recipient.
       </p>
       <div className="grid border border-gray-l4 rounded-lg overflow-clip">
-        <p className="text-xs text-center uppercase text-navy-l1 dark:text-gray p-4 border-b border-gray-l4">
+        <p className="text-xs text-center uppercase text-navy-l1 dark:text-navy-l2 p-4 border-b border-gray-l4">
           Your giftcard code:
         </p>
         <p className="bg-orange-l6 dark:bg-blue-d7 p-4 font-bold text-center text-3xl leading-relaxed break-all">

--- a/src/pages/Gift/Purchase/Submit/index.tsx
+++ b/src/pages/Gift/Purchase/Submit/index.tsx
@@ -129,7 +129,7 @@ function Row({
 }: PropsWithChildren<{ classes?: string; title: string }>) {
   return (
     <div
-      className={`${classes} py-3 text-navy-l1 dark:text-gray flex items-center justify-between w-full border-b border-gray-l4 last:border-none`}
+      className={`${classes} py-3 text-navy-l1 dark:text-navy-l2 flex items-center justify-between w-full border-b border-gray-l4 last:border-none`}
     >
       <p className="text-gray-d2 dark:text-white">{title}</p>
       {children}

--- a/src/pages/Gift/Purchase/Submit/index.tsx
+++ b/src/pages/Gift/Purchase/Submit/index.tsx
@@ -131,7 +131,7 @@ function Row({
     <div
       className={`${classes} py-3 text-navy-l1 dark:text-navy-l2 flex items-center justify-between w-full border-b border-gray-l4 last:border-none`}
     >
-      <p className="text-gray-d2 dark:text-white">{title}</p>
+      <p className="text-navy-d4 dark:text-white">{title}</p>
       {children}
     </div>
   );

--- a/src/pages/Gift/Purchase/Submit/index.tsx
+++ b/src/pages/Gift/Purchase/Submit/index.tsx
@@ -129,7 +129,7 @@ function Row({
 }: PropsWithChildren<{ classes?: string; title: string }>) {
   return (
     <div
-      className={`${classes} py-3 text-gray-d1 dark:text-gray flex items-center justify-between w-full border-b border-gray-l4 last:border-none`}
+      className={`${classes} py-3 text-navy-l1 dark:text-gray flex items-center justify-between w-full border-b border-gray-l4 last:border-none`}
     >
       <p className="text-gray-d2 dark:text-white">{title}</p>
       {children}

--- a/src/pages/Gift/Purchase/Submit/index.tsx
+++ b/src/pages/Gift/Purchase/Submit/index.tsx
@@ -129,7 +129,7 @@ function Row({
 }: PropsWithChildren<{ classes?: string; title: string }>) {
   return (
     <div
-      className={`${classes} py-3 text-gray-d1 dark:text-gray flex items-center justify-between w-full border-b border-prim last:border-none`}
+      className={`${classes} py-3 text-gray-d1 dark:text-gray flex items-center justify-between w-full border-b border-gray-l4 last:border-none`}
     >
       <p className="text-gray-d2 dark:text-white">{title}</p>
       {children}

--- a/src/pages/Leaderboard/Table/Row/Amount/Summary.tsx
+++ b/src/pages/Leaderboard/Table/Row/Amount/Summary.tsx
@@ -44,7 +44,7 @@ function Text(props: {
   }
 
   return (
-    <p className="text-xs leading-snug mb-2 text-navy-l1 dark:text-gray-l4">
+    <p className="text-xs leading-snug mb-2 text-navy-l1 dark:text-navy-l5">
       <span className="font-bold">{props.title} :</span> {textBlob}
     </p>
   );

--- a/src/pages/Leaderboard/Table/Row/Amount/Summary.tsx
+++ b/src/pages/Leaderboard/Table/Row/Amount/Summary.tsx
@@ -6,7 +6,7 @@ import { AmountProps } from ".";
 export default function Summary({ locked, liquid, type }: AmountProps) {
   const { closeModal } = useModalContext();
   return (
-    <Modal className="grid content-start bg-gray-l6 dark:bg-blue-d5 text-gray-d2 border border-gray-l4 dark:text-white fixed-center z-20 p-8 rounded-2xl shadow-lg max-w-md">
+    <Modal className="grid content-start bg-gray-l6 dark:bg-blue-d5 text-navy-d4 border border-gray-l4 dark:text-white fixed-center z-20 p-8 rounded-2xl shadow-lg max-w-md">
       <Amount title="principal" value={locked} />
       <Amount title="impact" value={liquid} />
       <button

--- a/src/pages/Leaderboard/Table/Row/Amount/Summary.tsx
+++ b/src/pages/Leaderboard/Table/Row/Amount/Summary.tsx
@@ -44,7 +44,7 @@ function Text(props: {
   }
 
   return (
-    <p className="text-xs leading-snug mb-2 text-gray-d1 dark:text-gray-l4">
+    <p className="text-xs leading-snug mb-2 text-navy-l1 dark:text-gray-l4">
       <span className="font-bold">{props.title} :</span> {textBlob}
     </p>
   );

--- a/src/pages/Leaderboard/Table/Row/Amount/Summary.tsx
+++ b/src/pages/Leaderboard/Table/Row/Amount/Summary.tsx
@@ -6,7 +6,7 @@ import { AmountProps } from ".";
 export default function Summary({ locked, liquid, type }: AmountProps) {
   const { closeModal } = useModalContext();
   return (
-    <Modal className="grid content-start bg-gray-l6 dark:bg-blue-d5 text-gray-d2 border border-prim dark:text-white fixed-center z-20 p-8 rounded-2xl shadow-lg max-w-md">
+    <Modal className="grid content-start bg-gray-l6 dark:bg-blue-d5 text-gray-d2 border border-gray-l4 dark:text-white fixed-center z-20 p-8 rounded-2xl shadow-lg max-w-md">
       <Amount title="principal" value={locked} />
       <Amount title="impact" value={liquid} />
       <button

--- a/src/pages/Leaderboard/Table/index.tsx
+++ b/src/pages/Leaderboard/Table/index.tsx
@@ -10,12 +10,12 @@ type Props = {
 export default function Table({ classes = "", endowments }: Props) {
   return (
     <div
-      className={`${classes} h-[50rem] overflow-y-scroll scroller border border-prim rounded`}
+      className={`${classes} h-[50rem] overflow-y-scroll scroller border border-gray-l4 rounded`}
     >
       <table className="border-collapse table-auto w-full">
         <TableSection
           type="thead"
-          rowClass="border-b border-prim bg-orange-l6 dark:bg-blue-d6"
+          rowClass="border-b border-gray-l4 bg-orange-l6 dark:bg-blue-d6"
         >
           <Cells
             type="th"

--- a/src/pages/Leaderboard/index.tsx
+++ b/src/pages/Leaderboard/index.tsx
@@ -23,7 +23,7 @@ export default function Leaderboard() {
       >
         {(update) => (
           <>
-            <p className="justify-self-end flex gap-2 text-sm font-light text-navy-l1 dark:text-gray">
+            <p className="justify-self-end flex gap-2 text-sm font-light text-navy-l1 dark:text-navy-l2">
               last updated:{" "}
               {new Date(update.last_update).toLocaleString([], {
                 dateStyle: "short",

--- a/src/pages/Leaderboard/index.tsx
+++ b/src/pages/Leaderboard/index.tsx
@@ -23,7 +23,7 @@ export default function Leaderboard() {
       >
         {(update) => (
           <>
-            <p className="justify-self-end flex gap-2 text-sm font-light text-gray-d1 dark:text-gray">
+            <p className="justify-self-end flex gap-2 text-sm font-light text-navy-l1 dark:text-gray">
               last updated:{" "}
               {new Date(update.last_update).toLocaleString([], {
                 dateStyle: "short",

--- a/src/pages/Marketplace/ActiveFilters.tsx
+++ b/src/pages/Marketplace/ActiveFilters.tsx
@@ -89,7 +89,7 @@ function Item({ children, onRemove }: PropsWithChildren<{ onRemove(): void }>) {
     <button
       type="button"
       onClick={onRemove}
-      className="flex items-center gap-2 border select-none rounded-full cursor-pointer capitalize text-xs pt-1 pb-[.3rem] pl-3 pr-1.5 texg-gray-d1 dark:text-gray bg-orange-l6 hover:bg-orange-l5"
+      className="flex items-center gap-2 border select-none rounded-full cursor-pointer capitalize text-xs pt-1 pb-[.3rem] pl-3 pr-1.5 texg-gray-d1 dark:text-navy-l2 bg-orange-l6 hover:bg-orange-l5"
     >
       <span>{children}</span>
       <Icon type="CloseCircle" size={20} />

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -46,12 +46,12 @@ export default function Card({
           <h3 className="text-ellipsis line-clamp-2">{name}</h3>
           {/* TAGLINE */}
           {tagline && tagline !== PLACEHOLDER_TAGLINE ? (
-            <p className="peer text-gray-d1 dark:text-gray text-sm -mt-2">
+            <p className="peer text-navy-l1 dark:text-gray text-sm -mt-2">
               {tagline}
             </p>
           ) : null}
           {/* HQ & ACTIVE-IN COUNTRIES */}
-          <div className="text-gray-d1 dark:text-gray text-sm">
+          <div className="text-navy-l1 dark:text-gray text-sm">
             <p>
               <span className="font-semibold">HQ:</span> {hq_country}
             </p>

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -46,12 +46,12 @@ export default function Card({
           <h3 className="text-ellipsis line-clamp-2">{name}</h3>
           {/* TAGLINE */}
           {tagline && tagline !== PLACEHOLDER_TAGLINE ? (
-            <p className="peer text-navy-l1 dark:text-gray text-sm -mt-2">
+            <p className="peer text-navy-l1 dark:text-navy-l2 text-sm -mt-2">
               {tagline}
             </p>
           ) : null}
           {/* HQ & ACTIVE-IN COUNTRIES */}
-          <div className="text-navy-l1 dark:text-gray text-sm">
+          <div className="text-navy-l1 dark:text-navy-l2 text-sm">
             <p>
               <span className="font-semibold">HQ:</span> {hq_country}
             </p>

--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -24,7 +24,7 @@ export default function Card({
   kyc_donors_only,
 }: EndowmentCard) {
   return (
-    <div className="relative overflow-clip dark:bg-blue-d6 rounded-lg border border-prim hover:border-blue dark:hover:border-blue">
+    <div className="relative overflow-clip dark:bg-blue-d6 rounded-lg border border-gray-l4 hover:border-blue dark:hover:border-blue">
       <div className="absolute top-[14px] left-[14px] right-[14px] flex justify-between gap-3">
         <p className="bg-orange-l1 text-white font-semibold text-2xs rounded-sm uppercase px-2 py-0.5 font-heading">
           {endow_designation}
@@ -85,7 +85,7 @@ function SDG({ num }: { num: UNSDG_NUMS }) {
       <Tooltip anchorRef={ref} content={unsdgs[num].title} />
       <div
         ref={ref}
-        className="whitespace-nowrap bg-blue-l4 hover:bg-blue-l3 dark:bg-blue-d4 hover:dark:bg-blue-d3 px-1 py-1 border border-prim rounded-lg"
+        className="whitespace-nowrap bg-blue-l4 hover:bg-blue-l3 dark:bg-blue-d4 hover:dark:bg-blue-d3 px-1 py-1 border border-gray-l4 rounded-lg"
       >
         SDG #{num}
       </div>

--- a/src/pages/Marketplace/Filter/Countries.tsx
+++ b/src/pages/Marketplace/Filter/Countries.tsx
@@ -51,7 +51,7 @@ export default function Countries() {
           </div>
         </div>
       </Combobox.Button>
-      <Combobox.Options className="rounded-sm text-sm border border-prim absolute top-full mt-2 z-10 bg-gray-l6 dark:bg-blue-d6 w-full max-h-[10rem] overflow-y-auto scroller">
+      <Combobox.Options className="rounded-sm text-sm border border-gray-l4 absolute top-full mt-2 z-10 bg-gray-l6 dark:bg-blue-d6 w-full max-h-[10rem] overflow-y-auto scroller">
         {!isEmpty(filteredOptions) &&
           filteredOptions.map((name) => (
             <Combobox.Option
@@ -90,7 +90,7 @@ function SelectedOption({ selected, onChange, option }: SelectedProps) {
     onChange(selected.filter((s) => s !== value));
 
   return (
-    <div className="flex gap-2 items-center text-xs pt-1 pb-[.3rem] px-2 border-orange text-orange-d4 bg-orange-l5 border border-prim rounded-sm">
+    <div className="flex gap-2 items-center text-xs pt-1 pb-[.3rem] px-2 border-orange text-orange-d4 bg-orange-l5 border border-gray-l4 rounded-sm">
       <span className="max-w-[200px] truncate">{option}</span>
       <button
         type="button"

--- a/src/pages/Marketplace/Filter/Countries.tsx
+++ b/src/pages/Marketplace/Filter/Countries.tsx
@@ -41,7 +41,7 @@ export default function Countries() {
             />
           ))}
 
-          <div className="inline-flex p-1 items-center gap-2 bg-orange-l5 text-navy-l1 dark:text-gray rounded">
+          <div className="inline-flex p-1 items-center gap-2 bg-orange-l5 text-navy-l1 dark:text-navy-l2 rounded">
             <Icon type="Search" size={18} />
             <Combobox.Input
               className="appearance-none bg-transparent focus:outline-none"
@@ -65,7 +65,7 @@ export default function Countries() {
             </Combobox.Option>
           ))}
         {isEmpty(filteredOptions) && (
-          <p className="text-navy-l1 dark:text-gray text-sm px-4 py-2">
+          <p className="text-navy-l1 dark:text-navy-l2 text-sm px-4 py-2">
             No options found
           </p>
         )}

--- a/src/pages/Marketplace/Filter/Countries.tsx
+++ b/src/pages/Marketplace/Filter/Countries.tsx
@@ -41,7 +41,7 @@ export default function Countries() {
             />
           ))}
 
-          <div className="inline-flex p-1 items-center gap-2 bg-orange-l5 text-gray-d1 dark:text-gray rounded">
+          <div className="inline-flex p-1 items-center gap-2 bg-orange-l5 text-navy-l1 dark:text-gray rounded">
             <Icon type="Search" size={18} />
             <Combobox.Input
               className="appearance-none bg-transparent focus:outline-none"
@@ -65,7 +65,7 @@ export default function Countries() {
             </Combobox.Option>
           ))}
         {isEmpty(filteredOptions) && (
-          <p className="text-gray-d1 dark:text-gray text-sm px-4 py-2">
+          <p className="text-navy-l1 dark:text-gray text-sm px-4 py-2">
             No options found
           </p>
         )}

--- a/src/pages/Marketplace/Filter/Filter.tsx
+++ b/src/pages/Marketplace/Filter/Filter.tsx
@@ -22,7 +22,7 @@ export default function Filter({ classes = "" }: { classes?: string }) {
           type="button"
           title="Reset all filters to their default values."
           onClick={() => dispatch(reset())}
-          className="text-navy-l1 dark:text-gray-l3 text-sm mr-4"
+          className="text-navy-l1 dark:text-navy-l5 text-sm mr-4"
         >
           Clear Filters
         </button>

--- a/src/pages/Marketplace/Filter/Filter.tsx
+++ b/src/pages/Marketplace/Filter/Filter.tsx
@@ -14,9 +14,9 @@ export default function Filter({ classes = "" }: { classes?: string }) {
 
   return (
     <Modal
-      className={`${classes} fixed-center z-10 w-full max-w-[95vw] max-h-[95vh] sm:max-w-md overflow-y-auto scroller border border-prim bg-gray-l6 dark:bg-blue-d5 dark:text-white rounded`}
+      className={`${classes} fixed-center z-10 w-full max-w-[95vw] max-h-[95vh] sm:max-w-md overflow-y-auto scroller border border-gray-l4 bg-gray-l6 dark:bg-blue-d5 dark:text-white rounded`}
     >
-      <div className="bg-orange-l6 dark:bg-blue-d7 flex items-center p-4 border-b border-prim">
+      <div className="bg-orange-l6 dark:bg-blue-d7 flex items-center p-4 border-b border-gray-l4">
         <h3 className="uppercase mr-auto">Filters</h3>
         <button
           type="button"

--- a/src/pages/Marketplace/Filter/Filter.tsx
+++ b/src/pages/Marketplace/Filter/Filter.tsx
@@ -22,7 +22,7 @@ export default function Filter({ classes = "" }: { classes?: string }) {
           type="button"
           title="Reset all filters to their default values."
           onClick={() => dispatch(reset())}
-          className="text-gray-d1 dark:text-gray-l3 text-sm mr-4"
+          className="text-navy-l1 dark:text-gray-l3 text-sm mr-4"
         >
           Clear Filters
         </button>

--- a/src/pages/Marketplace/Filter/common/FlatFilter.tsx
+++ b/src/pages/Marketplace/Filter/common/FlatFilter.tsx
@@ -22,7 +22,7 @@ export function FlatFilter<T>(props: GroupProps<T>) {
               `${
                 selected
                   ? "border-orange text-orange-d4 bg-orange-l5"
-                  : "border-prim"
+                  : "border-gray-l4"
               } border select-none rounded-full cursor-pointer capitalize text-xs pt-1 pb-[.3rem] px-4`
             }
           >

--- a/src/pages/Marketplace/Toolbar/Search.tsx
+++ b/src/pages/Marketplace/Toolbar/Search.tsx
@@ -23,7 +23,7 @@ export default function Search({ classes = "" }: { classes?: string }) {
 
   return (
     <div
-      className={`${classes} flex gap-2 items-center  dark:text-gray-l3 border border-prim rounded-lg overflow-clip`}
+      className={`${classes} flex gap-2 items-center  dark:text-gray-l3 border border-gray-l4 rounded-lg overflow-clip`}
     >
       <Icon
         type={isLoading ? "Loading" : "Search"}

--- a/src/pages/Marketplace/Toolbar/Search.tsx
+++ b/src/pages/Marketplace/Toolbar/Search.tsx
@@ -23,7 +23,7 @@ export default function Search({ classes = "" }: { classes?: string }) {
 
   return (
     <div
-      className={`${classes} flex gap-2 items-center  dark:text-gray-l3 border border-gray-l4 rounded-lg overflow-clip`}
+      className={`${classes} flex gap-2 items-center  dark:text-navy-l5 border border-gray-l4 rounded-lg overflow-clip`}
     >
       <Icon
         type={isLoading ? "Loading" : "Search"}
@@ -33,7 +33,7 @@ export default function Search({ classes = "" }: { classes?: string }) {
       <input
         value={query}
         onChange={({ target: { value } }) => setQuery(value)}
-        className="focus:outline-none w-full py-2 pr-3 bg-transparent dark:placeholder:text-gray-l3"
+        className="focus:outline-none w-full py-2 pr-3 bg-transparent dark:placeholder:text-navy-l5"
         placeholder="Search organizations..."
       />
     </div>

--- a/src/pages/Marketplace/Toolbar/Sorter.tsx
+++ b/src/pages/Marketplace/Toolbar/Sorter.tsx
@@ -47,7 +47,7 @@ export default function Sorter() {
       as="div"
       className="relative min-w-[10rem]"
     >
-      <div className="w-full h-full flex items-center justify-between text-[0.9375rem] py-2 pl-3 dark:text-gray-l3 border border-gray-l4 rounded-lg font-bold">
+      <div className="w-full h-full flex items-center justify-between text-[0.9375rem] py-2 pl-3 dark:text-navy-l5 border border-gray-l4 rounded-lg font-bold">
         <Listbox.Button className="upppercase flex items-center justify-between w-full">
           {({ open }) => (
             <>

--- a/src/pages/Marketplace/Toolbar/Sorter.tsx
+++ b/src/pages/Marketplace/Toolbar/Sorter.tsx
@@ -47,7 +47,7 @@ export default function Sorter() {
       as="div"
       className="relative min-w-[10rem]"
     >
-      <div className="w-full h-full flex items-center justify-between text-[0.9375rem] py-2 pl-3 dark:text-gray-l3 border border-prim rounded-lg font-bold">
+      <div className="w-full h-full flex items-center justify-between text-[0.9375rem] py-2 pl-3 dark:text-gray-l3 border border-gray-l4 rounded-lg font-bold">
         <Listbox.Button className="upppercase flex items-center justify-between w-full">
           {({ open }) => (
             <>

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
@@ -22,7 +22,7 @@ function Balance(props: { title: string; amount: number }) {
       <p className="font-heading font-bold text-xs tracking-wider uppercase">
         {props.title}
       </p>
-      <p className="font-normal text-lg text-navy-l1 dark:text-gray">
+      <p className="font-normal text-lg text-navy-l1 dark:text-navy-l2">
         ${humanize(props.amount)}
       </p>
     </div>

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
@@ -22,7 +22,7 @@ function Balance(props: { title: string; amount: number }) {
       <p className="font-heading font-bold text-xs tracking-wider uppercase">
         {props.title}
       </p>
-      <p className="font-normal text-lg text-gray-d1 dark:text-gray">
+      <p className="font-normal text-lg text-navy-l1 dark:text-gray">
         ${humanize(props.amount)}
       </p>
     </div>

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/Balances.tsx
@@ -18,7 +18,7 @@ export default function Balances() {
 
 function Balance(props: { title: string; amount: number }) {
   return (
-    <div className="flex flex-col justify-center items-center gap-2 h-20 w-full py-4 rounded border border-prim dark:bg-blue-d6 md:items-start md:h-28 md:px-6 md:py-04">
+    <div className="flex flex-col justify-center items-center gap-2 h-20 w-full py-4 rounded border border-gray-l4 dark:bg-blue-d6 md:items-start md:h-28 md:px-6 md:py-04">
       <p className="font-heading font-bold text-xs tracking-wider uppercase">
         {props.title}
       </p>

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/DetailsColumn.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/DetailsColumn.tsx
@@ -43,7 +43,7 @@ function Detail(props: PropsWithChildren<{ title: string }>) {
       <p className="font-heading font-bold text-xs tracking-wider uppercase">
         {props.title}
       </p>
-      <span className="font-normal text-base text-gray-d1 dark:text-gray">
+      <span className="font-normal text-base text-navy-l1 dark:text-gray">
         {props.children || "-"}
       </span>
     </div>

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/DetailsColumn.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/DetailsColumn.tsx
@@ -43,7 +43,7 @@ function Detail(props: PropsWithChildren<{ title: string }>) {
       <p className="font-heading font-bold text-xs tracking-wider uppercase">
         {props.title}
       </p>
-      <span className="font-normal text-base text-navy-l1 dark:text-gray">
+      <span className="font-normal text-base text-navy-l1 dark:text-navy-l2">
         {props.children || "-"}
       </span>
     </div>

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/DetailsColumn.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/DetailsColumn.tsx
@@ -14,7 +14,7 @@ export default function DetailsColumn({ className = "" }) {
       <Balances />
 
       <div
-        className={`${className} flex flex-col gap-8 w-full lg:w-96 p-8 border border-prim rounded text-gray-d2 dark:bg-blue-d6  dark:text-white`}
+        className={`${className} flex flex-col gap-8 w-full lg:w-96 p-8 border border-gray-l4 rounded text-gray-d2 dark:bg-blue-d6  dark:text-white`}
       >
         {p.registration_number && (
           <Detail title="registration no.">{p.registration_number}</Detail>

--- a/src/pages/Profile/Body/GeneralInfo/DetailsColumn/DetailsColumn.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/DetailsColumn/DetailsColumn.tsx
@@ -14,7 +14,7 @@ export default function DetailsColumn({ className = "" }) {
       <Balances />
 
       <div
-        className={`${className} flex flex-col gap-8 w-full lg:w-96 p-8 border border-gray-l4 rounded text-gray-d2 dark:bg-blue-d6  dark:text-white`}
+        className={`${className} flex flex-col gap-8 w-full lg:w-96 p-8 border border-gray-l4 rounded text-navy-d4 dark:bg-blue-d6  dark:text-white`}
       >
         {p.registration_number && (
           <Detail title="registration no.">{p.registration_number}</Detail>

--- a/src/pages/Profile/Body/GeneralInfo/Programs.tsx
+++ b/src/pages/Profile/Body/GeneralInfo/Programs.tsx
@@ -17,7 +17,7 @@ export default function Programs() {
 
 function Program(props: TProgram) {
   return (
-    <div className="border border-prim rounded relative group overflow-hidden">
+    <div className="border border-gray-l4 rounded relative group overflow-hidden">
       <Link
         to={`program/${props.program_id}`}
         className="absolute inset-0 group-hover:border group-hover:border-orange dark:group-hover:border-blue"

--- a/src/pages/Profile/Body/Program/Milestones.tsx
+++ b/src/pages/Profile/Body/Program/Milestones.tsx
@@ -41,7 +41,7 @@ function Milestone({
   return (
     <div
       className={`pb-4 pt-4 first:pt-0 last:pb-0 border-l ${
-        isComplete ? "border-orange" : "border-prim"
+        isComplete ? "border-orange" : "border-gray-l4"
       }`}
     >
       {milestone_media && (

--- a/src/pages/Profile/Body/Program/Milestones.tsx
+++ b/src/pages/Profile/Body/Program/Milestones.tsx
@@ -50,7 +50,7 @@ function Milestone({
         </div>
       )}
 
-      <p className="mt-4 pl-6 sm:pl-8 mb-3 text-navy-l1 dark:text-gray text-xs">
+      <p className="mt-4 pl-6 sm:pl-8 mb-3 text-navy-l1 dark:text-navy-l2 text-xs">
         {new Date(milestone_date).toLocaleDateString()}
       </p>
       <h6 className="pl-6 sm:pl-8 font-bold mb-3 relative">
@@ -67,7 +67,7 @@ function Milestone({
           content={{ value: milestone_description }}
           readOnly
           classes={{
-            container: "text-navy-l1 dark:text-gray text-sm w-full",
+            container: "text-navy-l1 dark:text-navy-l2 text-sm w-full",
           }}
         />
       </div>

--- a/src/pages/Profile/Body/Program/Milestones.tsx
+++ b/src/pages/Profile/Body/Program/Milestones.tsx
@@ -50,7 +50,7 @@ function Milestone({
         </div>
       )}
 
-      <p className="mt-4 pl-6 sm:pl-8 mb-3 text-gray-d1 dark:text-gray text-xs">
+      <p className="mt-4 pl-6 sm:pl-8 mb-3 text-navy-l1 dark:text-gray text-xs">
         {new Date(milestone_date).toLocaleDateString()}
       </p>
       <h6 className="pl-6 sm:pl-8 font-bold mb-3 relative">
@@ -67,7 +67,7 @@ function Milestone({
           content={{ value: milestone_description }}
           readOnly
           classes={{
-            container: "text-gray-d1 dark:text-gray text-sm w-full",
+            container: "text-navy-l1 dark:text-gray text-sm w-full",
           }}
         />
       </div>

--- a/src/pages/Profile/Body/Program/Program.tsx
+++ b/src/pages/Profile/Body/Program/Program.tsx
@@ -45,7 +45,7 @@ function Skeleton({ className = "" }) {
       className={`${className} grid grid-rows-[auto_auto] gap-8 w-full h-full lg:grid-rows-1 lg:grid-cols-[1fr_auto]`}
     >
       <ContentLoader className="h-80" />
-      <div className="self-start lg:sticky lg:top-28 flex flex-col gap-8 w-full lg:w-[29.75rem] p-8 border border-prim rounded">
+      <div className="self-start lg:sticky lg:top-28 flex flex-col gap-8 w-full lg:w-[29.75rem] p-8 border border-gray-l4 rounded">
         <ContentLoader className="h-40" />
         <ContentLoader className="h-40" />
         <ContentLoader className="h-40" />

--- a/src/pages/Profile/Body/common/Container.tsx
+++ b/src/pages/Profile/Body/common/Container.tsx
@@ -17,7 +17,7 @@ export default function Container({
 
   return (
     <div
-      className={`flex flex-col gap-px w-full border border-prim rounded dark:bg-blue-d6 ${classes}`}
+      className={`flex flex-col gap-px w-full border border-gray-l4 rounded dark:bg-blue-d6 ${classes}`}
     >
       {expanded ? (
         <StaticHeader title={title} />
@@ -42,7 +42,7 @@ type HeaderProps = {
 function StaticHeader({ title, classes = "", children }: HeaderProps) {
   return (
     <div
-      className={`flex items-center justify-between px-8 py-5 w-full bg-orange-l5 border-prim rounded dark:bg-blue-d7 ${classes}`}
+      className={`flex items-center justify-between px-8 py-5 w-full bg-orange-l5 border-gray-l4 rounded dark:bg-blue-d7 ${classes}`}
     >
       <span className="font-heading font-bold text-xl">{title}</span>
       {children}
@@ -59,7 +59,7 @@ function Header(props: {
     <StaticHeader classes={props.isOpen ? "border-b" : ""} title={props.title}>
       <button
         onClick={props.onClick}
-        className="flex items-center justify-center p-px w-10 h-10 border border-prim rounded"
+        className="flex items-center justify-center p-px w-10 h-10 border border-gray-l4 rounded"
         aria-label="toggle section content's visibility"
       >
         <Icon type={props.isOpen ? "Dash" : "Plus"} />

--- a/src/pages/Profile/index.tsx
+++ b/src/pages/Profile/index.tsx
@@ -66,7 +66,7 @@ function Logo() {
     <div className="padded-container flex justify-center items-center w-full overflow-visible h-0 isolate lg:justify-start">
       <Image
         src={logo}
-        className="h-48 w-48 border border-prim rounded-full object-cover bg-white"
+        className="h-48 w-48 border border-gray-l4 rounded-full object-cover bg-white"
       />
     </div>
   );

--- a/src/pages/Registration/Resume/Form.tsx
+++ b/src/pages/Registration/Resume/Form.tsx
@@ -12,7 +12,7 @@ export default function Form({ classes = "" }: { classes?: string }) {
       className={`${classes} grid padded-container w-full max-w-[37.5rem]`}
     >
       <h3 className="text-3xl text-center">Resume registration</h3>
-      <p className="text-center mt-2 text-gray-d1 dark:text-gray-l2 text-lg">
+      <p className="text-center mt-2 text-navy-l1 dark:text-gray-l2 text-lg">
         Enter your registration reference to resume where you left off
       </p>
 

--- a/src/pages/Registration/Resume/Form.tsx
+++ b/src/pages/Registration/Resume/Form.tsx
@@ -12,7 +12,7 @@ export default function Form({ classes = "" }: { classes?: string }) {
       className={`${classes} grid padded-container w-full max-w-[37.5rem]`}
     >
       <h3 className="text-3xl text-center">Resume registration</h3>
-      <p className="text-center mt-2 text-navy-l1 dark:text-gray-l2 text-lg">
+      <p className="text-center mt-2 text-navy-l1 dark:text-navy-l4 text-lg">
         Enter your registration reference to resume where you left off
       </p>
 

--- a/src/pages/Registration/SigningResult/ErrorPage.tsx
+++ b/src/pages/Registration/SigningResult/ErrorPage.tsx
@@ -37,7 +37,7 @@ export default function ErrorPage(props: ErrorQueryParams) {
         <Icon type="Exclamation" size={30} className="text-white m-5" />
       </div>
       <h1 className="text-2xl uppercase text-center">Signing failed</h1>
-      <p className="bg-orange-l6 dark:bg-blue-d6 p-4 text-sm text-navy-l1 dark:text-gray mt-4">
+      <p className="bg-orange-l6 dark:bg-blue-d6 p-4 text-sm text-navy-l1 dark:text-navy-l2 mt-4">
         {props.error}: {props.message}
       </p>
       <button

--- a/src/pages/Registration/SigningResult/ErrorPage.tsx
+++ b/src/pages/Registration/SigningResult/ErrorPage.tsx
@@ -37,7 +37,7 @@ export default function ErrorPage(props: ErrorQueryParams) {
         <Icon type="Exclamation" size={30} className="text-white m-5" />
       </div>
       <h1 className="text-2xl uppercase text-center">Signing failed</h1>
-      <p className="bg-orange-l6 dark:bg-blue-d6 p-4 text-sm text-gray-d1 dark:text-gray mt-4">
+      <p className="bg-orange-l6 dark:bg-blue-d6 p-4 text-sm text-navy-l1 dark:text-gray mt-4">
         {props.error}: {props.message}
       </p>
       <button

--- a/src/pages/Registration/Steps/Banking/Banking.tsx
+++ b/src/pages/Registration/Steps/Banking/Banking.tsx
@@ -22,7 +22,7 @@ function Banking() {
 
         <p className="mt-6 mb-1">
           <span className="uppercase text-sm font-semibold">account id: </span>
-          <span className="text-gray-d1 ">
+          <span className="text-navy-l1 ">
             {data.banking.wise_recipient_id}
           </span>
         </p>

--- a/src/pages/Registration/Steps/Dashboard/EndowmentStatus.tsx
+++ b/src/pages/Registration/Steps/Dashboard/EndowmentStatus.tsx
@@ -50,7 +50,7 @@ export default function EndowmentStatus({
     case "Under Review":
       return (
         <div
-          className={`max-sm:grid justify-items-center gap-2 text-gray-d1 dark:text-gray ${classes}`}
+          className={`max-sm:grid justify-items-center gap-2 text-navy-l1 dark:text-gray ${classes}`}
         >
           <Icon
             type="HourglassSplit"

--- a/src/pages/Registration/Steps/Dashboard/EndowmentStatus.tsx
+++ b/src/pages/Registration/Steps/Dashboard/EndowmentStatus.tsx
@@ -50,7 +50,7 @@ export default function EndowmentStatus({
     case "Under Review":
       return (
         <div
-          className={`max-sm:grid justify-items-center gap-2 text-navy-l1 dark:text-gray ${classes}`}
+          className={`max-sm:grid justify-items-center gap-2 text-navy-l1 dark:text-navy-l2 ${classes}`}
         >
           <Icon
             type="HourglassSplit"

--- a/src/pages/Registration/Steps/Dashboard/Step.tsx
+++ b/src/pages/Registration/Steps/Dashboard/Step.tsx
@@ -22,7 +22,7 @@ export default function Step({
     <div
       className={`py-6 pl-2 pr-4 grid grid-cols-[1fr_auto_auto] items-center border-b ${
         num === 1 ? "border-t" : ""
-      } border-prim `}
+      } border-gray-l4 `}
     >
       <p className="mr-auto text-left">{title[num]}</p>
 

--- a/src/pages/Registration/Steps/FSAInquiry/FSAInquiry.tsx
+++ b/src/pages/Registration/Steps/FSAInquiry/FSAInquiry.tsx
@@ -49,7 +49,7 @@ function FSAInquiry() {
             </div>
           </>
         ) : (
-          <p className="text-sm text-gray-d1 dark:text-gray leading-relaxed">
+          <p className="text-sm text-navy-l1 dark:text-gray leading-relaxed">
             Great news: Nonprofit Organizations in{" "}
             <span className="font-semibold">{data.orgDetails.HqCountry}</span>{" "}
             can now take advantage of {APP_NAME}’s Fiscal Sponsorship service.
@@ -57,7 +57,7 @@ function FSAInquiry() {
         )}
 
         {!possiblyTaxExempt || answer === "No" ? (
-          <p className="text-sm text-gray-d1 dark:text-gray leading-relaxed mt-4">
+          <p className="text-sm text-navy-l1 dark:text-gray leading-relaxed mt-4">
             {APP_NAME} provides fiscal sponsorship services at market-leading
             cost (2.9%) for our partner organizations worldwide to enable them
             to receive tax efficient donations from the USA. Continue to setup

--- a/src/pages/Registration/Steps/FSAInquiry/FSAInquiry.tsx
+++ b/src/pages/Registration/Steps/FSAInquiry/FSAInquiry.tsx
@@ -49,7 +49,7 @@ function FSAInquiry() {
             </div>
           </>
         ) : (
-          <p className="text-sm text-navy-l1 dark:text-gray leading-relaxed">
+          <p className="text-sm text-navy-l1 dark:text-navy-l2 leading-relaxed">
             Great news: Nonprofit Organizations in{" "}
             <span className="font-semibold">{data.orgDetails.HqCountry}</span>{" "}
             can now take advantage of {APP_NAME}’s Fiscal Sponsorship service.
@@ -57,7 +57,7 @@ function FSAInquiry() {
         )}
 
         {!possiblyTaxExempt || answer === "No" ? (
-          <p className="text-sm text-navy-l1 dark:text-gray leading-relaxed mt-4">
+          <p className="text-sm text-navy-l1 dark:text-navy-l2 leading-relaxed mt-4">
             {APP_NAME} provides fiscal sponsorship services at market-leading
             cost (2.9%) for our partner organizations worldwide to enable them
             to receive tax efficient donations from the USA. Continue to setup

--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -88,7 +88,7 @@ export default function ProgressIndicator({ step, classes = "" }: Props) {
     </>
   );
 
-  const classNames = `py-4 max-md:pr-10 pl-12 md:pl-14 md:mr-14 ${classes} dark:text-gray`;
+  const classNames = `py-4 max-md:pr-10 pl-12 md:pl-14 md:mr-14 ${classes} dark:text-navy-l2`;
 
   if (isDesktop) {
     return <div className={classNames}>{children}</div>;
@@ -132,7 +132,7 @@ function Step({
         />
         <span
           className={`text-sm ${
-            isCurr ? "text-orange" : "text-navy-l1 dark:text-gray"
+            isCurr ? "text-orange" : "text-navy-l1 dark:text-navy-l2"
           }`}
         >
           {children}

--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -120,7 +120,7 @@ function Step({
       {/** line */}
       <div
         className={`h-[22px] border-l ${
-          isDone || isCurr ? "border-orange" : "border-prim"
+          isDone || isCurr ? "border-orange" : "border-gray-l4"
         } my-2 group-first:hidden`}
       />
       <div className="flex items-center">

--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -132,7 +132,7 @@ function Step({
         />
         <span
           className={`text-sm ${
-            isCurr ? "text-orange" : "text-gray-d1 dark:text-gray"
+            isCurr ? "text-orange" : "text-navy-l1 dark:text-gray"
           }`}
         >
           {children}

--- a/src/pages/Registration/Steps/Reference.tsx
+++ b/src/pages/Registration/Steps/Reference.tsx
@@ -11,7 +11,7 @@ export default function Reference({ id, classes = "" }: Props) {
 
   return (
     <div
-      className={`${classes} w-full py-4 px-6 text-sm text-left md:text-center bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white md:text-gray-d1 md:dark:text-gray md:border-t border-prim rounded-b-lg`}
+      className={`${classes} w-full py-4 px-6 text-sm text-left md:text-center bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white md:text-gray-d1 md:dark:text-gray md:border-t border-gray-l4 rounded-b-lg`}
     >
       <div className="relative">
         <span className="font-semibold mr-2">Your registration number:</span>
@@ -51,6 +51,6 @@ function WithTooltip(props: {
     className:
       props.children.props.className +
       ` ${props.classes ?? "" /** control position */} relative before:w-48 before:z-10 before:content-[attr(data-before-content)] hover:before:block before:hidden before:absolute  
-      before:text-xs before:bg-gray-l6 before:dark:bg-blue-d6 before:text-gray-d1 before:dark:text-gray before:border before:border-prim before:p-2 before:rounded`,
+      before:text-xs before:bg-gray-l6 before:dark:bg-blue-d6 before:text-gray-d1 before:dark:text-gray before:border before:border-gray-l4 before:p-2 before:rounded`,
   });
 }

--- a/src/pages/Registration/Steps/Reference.tsx
+++ b/src/pages/Registration/Steps/Reference.tsx
@@ -11,7 +11,7 @@ export default function Reference({ id, classes = "" }: Props) {
 
   return (
     <div
-      className={`${classes} w-full py-4 px-6 text-sm text-left md:text-center bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white md:text-navy-l1 md:dark:text-gray md:border-t border-gray-l4 rounded-b-lg`}
+      className={`${classes} w-full py-4 px-6 text-sm text-left md:text-center bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white md:text-navy-l1 md:dark:text-navy-l2 md:border-t border-gray-l4 rounded-b-lg`}
     >
       <div className="relative">
         <span className="font-semibold mr-2">Your registration number:</span>
@@ -32,7 +32,9 @@ export default function Reference({ id, classes = "" }: Props) {
         </button>
       </div>
       {isTooltipOpen && (
-        <p className="md:hidden mt-4 dark:text-gray text-navy-l1">{tooltip}</p>
+        <p className="md:hidden mt-4 dark:text-navy-l2 text-navy-l1">
+          {tooltip}
+        </p>
       )}
     </div>
   );
@@ -51,6 +53,6 @@ function WithTooltip(props: {
     className:
       props.children.props.className +
       ` ${props.classes ?? "" /** control position */} relative before:w-48 before:z-10 before:content-[attr(data-before-content)] hover:before:block before:hidden before:absolute  
-      before:text-xs before:bg-gray-l6 before:dark:bg-blue-d6 before:text-navy-l1 before:dark:text-gray before:border before:border-gray-l4 before:p-2 before:rounded`,
+      before:text-xs before:bg-gray-l6 before:dark:bg-blue-d6 before:text-navy-l1 before:dark:text-navy-l2 before:border before:border-gray-l4 before:p-2 before:rounded`,
   });
 }

--- a/src/pages/Registration/Steps/Reference.tsx
+++ b/src/pages/Registration/Steps/Reference.tsx
@@ -11,7 +11,7 @@ export default function Reference({ id, classes = "" }: Props) {
 
   return (
     <div
-      className={`${classes} w-full py-4 px-6 text-sm text-left md:text-center bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white md:text-gray-d1 md:dark:text-gray md:border-t border-gray-l4 rounded-b-lg`}
+      className={`${classes} w-full py-4 px-6 text-sm text-left md:text-center bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white md:text-navy-l1 md:dark:text-gray md:border-t border-gray-l4 rounded-b-lg`}
     >
       <div className="relative">
         <span className="font-semibold mr-2">Your registration number:</span>
@@ -32,7 +32,7 @@ export default function Reference({ id, classes = "" }: Props) {
         </button>
       </div>
       {isTooltipOpen && (
-        <p className="md:hidden mt-4 dark:text-gray text-gray-d1">{tooltip}</p>
+        <p className="md:hidden mt-4 dark:text-gray text-navy-l1">{tooltip}</p>
       )}
     </div>
   );
@@ -51,6 +51,6 @@ function WithTooltip(props: {
     className:
       props.children.props.className +
       ` ${props.classes ?? "" /** control position */} relative before:w-48 before:z-10 before:content-[attr(data-before-content)] hover:before:block before:hidden before:absolute  
-      before:text-xs before:bg-gray-l6 before:dark:bg-blue-d6 before:text-gray-d1 before:dark:text-gray before:border before:border-gray-l4 before:p-2 before:rounded`,
+      before:text-xs before:bg-gray-l6 before:dark:bg-blue-d6 before:text-navy-l1 before:dark:text-gray before:border before:border-gray-l4 before:p-2 before:rounded`,
   });
 }

--- a/src/pages/Registration/Steps/Reference.tsx
+++ b/src/pages/Registration/Steps/Reference.tsx
@@ -11,7 +11,7 @@ export default function Reference({ id, classes = "" }: Props) {
 
   return (
     <div
-      className={`${classes} w-full py-4 px-6 text-sm text-left md:text-center bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white md:text-navy-l1 md:dark:text-navy-l2 md:border-t border-gray-l4 rounded-b-lg`}
+      className={`${classes} w-full py-4 px-6 text-sm text-left md:text-center bg-gray-l6 dark:bg-blue-d5 text-navy-d4 dark:text-white md:text-navy-l1 md:dark:text-navy-l2 md:border-t border-gray-l4 rounded-b-lg`}
     >
       <div className="relative">
         <span className="font-semibold mr-2">Your registration number:</span>

--- a/src/pages/Registration/Steps/index.tsx
+++ b/src/pages/Registration/Steps/index.tsx
@@ -56,7 +56,7 @@ export default function Steps({ classes = "" }: { classes?: string }) {
 
   return (
     <div
-      className={`w-full md:w-[90%] max-w-[62.5rem] pt-8 grid md:grid-cols-[auto_1fr] md:border border-prim rounded-none md:rounded-lg bg-white dark:bg-blue-d6 ${classes}`}
+      className={`w-full md:w-[90%] max-w-[62.5rem] pt-8 grid md:grid-cols-[auto_1fr] md:border border-gray-l4 rounded-none md:rounded-lg bg-white dark:bg-blue-d6 ${classes}`}
     >
       <ProgressIndicator
         step={regState.step}

--- a/src/pages/Registration/Welcome.tsx
+++ b/src/pages/Registration/Welcome.tsx
@@ -26,7 +26,7 @@ export default function Welcome({ classes = "" }: { classes?: string }) {
       <h1 className="text-[2rem] mt-10 text-center">
         Thank you for joining {APP_NAME}!
       </h1>
-      <p className="text-center text-gray-d1 dark:text-white/75 w-full text-lg max-w-lg mt-4 mb-8">
+      <p className="text-center text-navy-l1 dark:text-white/75 w-full text-lg max-w-lg mt-4 mb-8">
         Your fundraising profile & account are just few steps away 😇
       </p>
 
@@ -51,7 +51,7 @@ export default function Welcome({ classes = "" }: { classes?: string }) {
           {GENERIC_ERROR_MESSAGE}
         </span>
       )}
-      <p className="text-sm italic text-gray-d1 dark:text-gray mt-8 text-center">
+      <p className="text-sm italic text-navy-l1 dark:text-gray mt-8 text-center">
         Note: Registration is quick, but we've sent an email link if you need to
         pause and resume at any point.
       </p>

--- a/src/pages/Registration/Welcome.tsx
+++ b/src/pages/Registration/Welcome.tsx
@@ -51,7 +51,7 @@ export default function Welcome({ classes = "" }: { classes?: string }) {
           {GENERIC_ERROR_MESSAGE}
         </span>
       )}
-      <p className="text-sm italic text-navy-l1 dark:text-gray mt-8 text-center">
+      <p className="text-sm italic text-navy-l1 dark:text-navy-l2 mt-8 text-center">
         Note: Registration is quick, but we've sent an email link if you need to
         pause and resume at any point.
       </p>

--- a/src/pages/Widget/Configurer/Form.tsx
+++ b/src/pages/Widget/Configurer/Form.tsx
@@ -30,7 +30,7 @@ export default function Form({
       <CheckField<FV>
         name="isAdvancedOptionsExpanded"
         disabled={isAdvancedOptionsHidden}
-        classes={{ label: "peer-disabled:text-gray" }}
+        classes={{ label: "peer-disabled:text-navy-l2" }}
       >
         Unfold "advanced options" by default
       </CheckField>

--- a/src/pages/Widget/Preview/DonateMethods/DonaterSample.tsx
+++ b/src/pages/Widget/Preview/DonateMethods/DonaterSample.tsx
@@ -14,7 +14,7 @@ export default function DonaterSample({
       </div>
 
       <div className="flex items-center gap-2 py-3 px-4 border border-gray-l2 rounded mb-1">
-        <span className="text-gray-d1 dark:text-gray">0.00000</span>
+        <span className="text-navy-l1 dark:text-gray">0.00000</span>
         <span className="text-sm ml-auto">TOKEN</span>
       </div>
       <p className="text-xs mt-1">Minimal amount: Token 0.0000</p>

--- a/src/pages/Widget/Preview/DonateMethods/DonaterSample.tsx
+++ b/src/pages/Widget/Preview/DonateMethods/DonaterSample.tsx
@@ -14,7 +14,7 @@ export default function DonaterSample({
       </div>
 
       <div className="flex items-center gap-2 py-3 px-4 border border-gray-l2 rounded mb-1">
-        <span className="text-navy-l1 dark:text-gray">0.00000</span>
+        <span className="text-navy-l1 dark:text-navy-l2">0.00000</span>
         <span className="text-sm ml-auto">TOKEN</span>
       </div>
       <p className="text-xs mt-1">Minimal amount: Token 0.0000</p>

--- a/src/pages/Widget/Preview/DonateMethods/StocksSample.tsx
+++ b/src/pages/Widget/Preview/DonateMethods/StocksSample.tsx
@@ -67,7 +67,7 @@ export default function StocksSample({ name, id }: WidgetConfig["endowment"]) {
         contributions when you transfer securities through Better.Giving:
       </p>
       <div className="grid rounded bg-gray-l5 dark:bg-navy-d3 p-2">
-        <span className="text-sm text-gray">
+        <span className="text-sm text-navy-l2">
           NOTE: This is not financial advice! Please speak to your tax advisor
           or broker about your specific situation and country's tax laws.
         </span>

--- a/src/pages/Widget/Preview/DonateMethods/StripeSample.tsx
+++ b/src/pages/Widget/Preview/DonateMethods/StripeSample.tsx
@@ -14,7 +14,7 @@ export default function StripeSample({
           expanded={display === "expanded"}
         />
       )}
-      <p className="text-sm text-gray-d2 dark:text-navy-l2 mt-4">
+      <p className="text-sm text-navy-d4 dark:text-navy-l2 mt-4">
         Please click the button below and follow the instructions provided to
         complete your donation
       </p>
@@ -24,7 +24,7 @@ export default function StripeSample({
           Pay with card
         </button>
       </div>
-      <p className="text-sm italic text-gray-d2 dark:text-navy-l2 mt-4">
+      <p className="text-sm italic text-navy-d4 dark:text-navy-l2 mt-4">
         By making a donation, you agree to our{" "}
         <span className="underline text-orange hover:text-orange-l2">
           Terms & Conditions

--- a/src/pages/Widget/Preview/DonateMethods/StripeSample.tsx
+++ b/src/pages/Widget/Preview/DonateMethods/StripeSample.tsx
@@ -14,7 +14,7 @@ export default function StripeSample({
           expanded={display === "expanded"}
         />
       )}
-      <p className="text-sm text-gray-d2 dark:text-gray mt-4">
+      <p className="text-sm text-gray-d2 dark:text-navy-l2 mt-4">
         Please click the button below and follow the instructions provided to
         complete your donation
       </p>
@@ -24,7 +24,7 @@ export default function StripeSample({
           Pay with card
         </button>
       </div>
-      <p className="text-sm italic text-gray-d2 dark:text-gray mt-4">
+      <p className="text-sm italic text-gray-d2 dark:text-navy-l2 mt-4">
         By making a donation, you agree to our{" "}
         <span className="underline text-orange hover:text-orange-l2">
           Terms & Conditions

--- a/src/pages/Widget/Preview/Preview.tsx
+++ b/src/pages/Widget/Preview/Preview.tsx
@@ -11,7 +11,7 @@ export default function Preview({ classes = "" }) {
       <h2 className="text-lg @4xl/widget:text-2xl text-center @4xl/widget:text-left mb-3">
         That's what our widget looks like:
       </h2>
-      <div className="pt-6 flex flex-col @xl/preview:pt-10 h-full overflow-y-auto scroller w-full max-h-[800px] border border-gray-l2 rounded text-gray-d2 bg-white">
+      <div className="pt-6 flex flex-col @xl/preview:pt-10 h-full overflow-y-auto scroller w-full max-h-[800px] border border-gray-l2 rounded text-navy-d4 bg-white">
         <h1 className="mb-10 px-10 w-full text-xl">{endowName}</h1>
         {isDescriptionTextShown && (
           <p className="px-6 @xl/preview:px-10 text-sm mb-10 text-center @xl/preview:text-left">

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -9,7 +9,7 @@
   }
 
   body {
-    @apply font-body bg-gray-l6 dark:bg-blue-d5 text-gray-d2 dark:text-white;
+    @apply font-body text-navy-d4;
   }
 
   a {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -36,7 +36,7 @@
     @apply absolute -bottom-5 right-0 text-xs text-right text-red dark:text-red-l2;
   }
   .field-input {
-    @apply w-full rounded text-sm px-4 py-3.5 bg-transparent placeholder:text-gray-d1 dark:placeholder:text-gray border border-gray-l3 dark:border-navy focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 disabled:bg-gray-l5 disabled:text-gray-d1 disabled:dark:text-gray disabled:dark:bg-navy-d3 aria-disabled:bg-gray-l5 aria-disabled:text-gray-d1 aria-disabled:dark:text-gray aria-disabled:dark:bg-navy-d3 aria-disabled:pointer-events-none;
+    @apply w-full rounded text-sm px-4 py-3.5 bg-transparent placeholder:text-navy-l1 dark:placeholder:text-gray border border-gray-l3 dark:border-navy focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 disabled:bg-gray-l5 disabled:text-navy-l1 disabled:dark:text-gray disabled:dark:bg-navy-d3 aria-disabled:bg-gray-l5 aria-disabled:text-navy-l1 aria-disabled:dark:text-gray aria-disabled:dark:bg-navy-d3 aria-disabled:pointer-events-none;
   }
 
   .field-input[aria-invalid="true"] {
@@ -92,7 +92,7 @@
   }
 
   .field-container {
-    @apply rounded border border-gray-l3 dark:border-navy focus-within:border-gray-d1 focus-within:dark:border-blue-l2 aria-disabled:bg-gray-l5 aria-disabled:dark:bg-navy-d3 aria-disabled:text-gray-d1 aria-disabled:dark:text-gray aria-disabled:pointer-events-none;
+    @apply rounded border border-gray-l3 dark:border-navy focus-within:border-gray-d1 focus-within:dark:border-blue-l2 aria-disabled:bg-gray-l5 aria-disabled:dark:bg-navy-d3 aria-disabled:text-navy-l1 aria-disabled:dark:text-gray aria-disabled:pointer-events-none;
   }
 
   .field-container[aria-invalid="true"] {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -36,7 +36,7 @@
     @apply absolute -bottom-5 right-0 text-xs text-right text-red dark:text-red-l2;
   }
   .field-input {
-    @apply w-full rounded text-sm px-4 py-3.5 bg-transparent placeholder:text-navy-l1 dark:placeholder:text-gray border border-gray-l3 dark:border-navy focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 disabled:bg-gray-l5 disabled:text-navy-l1 disabled:dark:text-gray disabled:dark:bg-navy-d3 aria-disabled:bg-gray-l5 aria-disabled:text-navy-l1 aria-disabled:dark:text-gray aria-disabled:dark:bg-navy-d3 aria-disabled:pointer-events-none;
+    @apply w-full rounded text-sm px-4 py-3.5 bg-transparent placeholder:text-navy-l1 dark:placeholder:text-navy-l2 border border-gray-l3 dark:border-navy focus:outline-none focus:border-gray-d1 focus:dark:border-blue-l2 disabled:bg-gray-l5 disabled:text-navy-l1 disabled:dark:text-navy-l2 disabled:dark:bg-navy-d3 aria-disabled:bg-gray-l5 aria-disabled:text-navy-l1 aria-disabled:dark:text-navy-l2 aria-disabled:dark:bg-navy-d3 aria-disabled:pointer-events-none;
   }
 
   .field-input[aria-invalid="true"] {
@@ -92,7 +92,7 @@
   }
 
   .field-container {
-    @apply rounded border border-gray-l3 dark:border-navy focus-within:border-gray-d1 focus-within:dark:border-blue-l2 aria-disabled:bg-gray-l5 aria-disabled:dark:bg-navy-d3 aria-disabled:text-navy-l1 aria-disabled:dark:text-gray aria-disabled:pointer-events-none;
+    @apply rounded border border-gray-l3 dark:border-navy focus-within:border-gray-d1 focus-within:dark:border-blue-l2 aria-disabled:bg-gray-l5 aria-disabled:dark:bg-navy-d3 aria-disabled:text-navy-l1 aria-disabled:dark:text-navy-l2 aria-disabled:pointer-events-none;
   }
 
   .field-container[aria-invalid="true"] {

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -6,10 +6,6 @@
     @apply absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2;
   }
 
-  .border-prim {
-    @apply border-gray-l3 dark:border-navy;
-  }
-
   .divide-prim {
     @apply divide-gray-l3 dark:divide-navy;
   }


### PR DESCRIPTION
## Explanation of the solution

* map `border-prim (border-gray-l3)` to `border-gray-l4` (default stroke colors in new design) 
* map `text-gray-*` to `text-navy-*` counterpart
```
text-gray-d2 (prev design primary) -> text-navy-d4 (new design primary)
text-gray-d1 (prev design secondary) -> text-navy-l1 (new design secondary)
```
and adjust other shades accordingly
e.g.
```
text-gray -> text-navy-l2 //since `gray-d1` is mapped to `navy-l1`
```




## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
all text should now align to the new brand color  navy-1000(design)/navy-d4(tailwind-config) `#183244`.

SAMPLES:

partly ( separate meticulous colors correction be done on the whole donation flow UIs ) aligned donate page
<img width="1469" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/4b5c88b1-7dc4-4566-9a7d-c01b24e73d70">

other text color  hierarchy preserved
<img width="1374" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/39d58fe8-e7da-4382-a26b-8aff4f63b3da">

<img width="1324" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/4199696b-6e6a-4b75-8c48-df22c2b05e1c">

<img width="1331" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/f62a6389-d4f8-4977-ab9c-74ce36ca7755">





When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
