### PR TITLE
Prefer package.json formatting to biome formatting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -53,7 +53,7 @@
     }
   },
   "formatter": {
-    "indentStyle": "space",
+    "indentStyle": "space"
   },
   "javascript": {
     "formatter": {

--- a/biome.json
+++ b/biome.json
@@ -3,6 +3,9 @@
   "organizeImports": {
     "enabled": true
   },
+  "files":{
+    "ignore":["./package.json"]
+  },
   "linter": {
     "enabled": true,
     "rules": {
@@ -50,7 +53,7 @@
     }
   },
   "formatter": {
-    "indentStyle": "space"
+    "indentStyle": "space",
   },
   "javascript": {
     "formatter": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "preview": "rsbuild preview"
   },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",


### PR DESCRIPTION
When running `yarn install`, package.json is auto formatted, (sorts dependencies), biome should just let this be
## Explanation of the solution

* added `package.json` in biome ignores

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
