### PR TITLE
Donate: currencies loaded as part of dropdown should include those supported by both PayPal and Stripe

### DIFF
--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -4,7 +4,7 @@ import { Field, Form as FormContainer } from "components/form";
 import { useController, useForm } from "react-hook-form";
 import { schema, stringNumber } from "schemas/shape";
 import { requiredString } from "schemas/string";
-import { useStripeCurrenciesQuery } from "services/apes";
+import { usePaypalCurrenciesQuery } from "services/apes";
 import { setDetails } from "slices/donation";
 import { useSetter } from "store/accessors";
 import { Currency } from "types/components";
@@ -17,7 +17,7 @@ const USD_CODE = "usd";
 export default function Form({ widgetConfig, details }: Props) {
   const dispatch = useSetter();
 
-  const currencies = useStripeCurrenciesQuery(null);
+  const currencies = usePaypalCurrenciesQuery(null);
 
   const initial: FV = {
     source: widgetConfig ? "bg-widget" : "bg-marketplace",

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -17,7 +17,7 @@ const USD_CODE = "usd";
 export default function Form({ widgetConfig, details }: Props) {
   const dispatch = useSetter();
 
-  const currencies = useFiatCurrenciesQuery(null);
+  const currencies = useFiatCurrenciesQuery();
 
   const initial: FV = {
     source: widgetConfig ? "bg-widget" : "bg-marketplace",

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -4,7 +4,7 @@ import { Field, Form as FormContainer } from "components/form";
 import { useController, useForm } from "react-hook-form";
 import { schema, stringNumber } from "schemas/shape";
 import { requiredString } from "schemas/string";
-import { usePaypalCurrenciesQuery } from "services/apes";
+import { useCurrenciesQuery } from "services/apes";
 import { setDetails } from "slices/donation";
 import { useSetter } from "store/accessors";
 import { Currency } from "types/components";
@@ -17,7 +17,7 @@ const USD_CODE = "usd";
 export default function Form({ widgetConfig, details }: Props) {
   const dispatch = useSetter();
 
-  const currencies = usePaypalCurrenciesQuery(null);
+  const currencies = useCurrenciesQuery(null);
 
   const initial: FV = {
     source: widgetConfig ? "bg-widget" : "bg-marketplace",

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -4,7 +4,7 @@ import { Field, Form as FormContainer } from "components/form";
 import { useController, useForm } from "react-hook-form";
 import { schema, stringNumber } from "schemas/shape";
 import { requiredString } from "schemas/string";
-import { useCurrenciesQuery } from "services/apes";
+import { useFiatCurrenciesQuery } from "services/apes";
 import { setDetails } from "slices/donation";
 import { useSetter } from "store/accessors";
 import { Currency } from "types/components";
@@ -17,7 +17,7 @@ const USD_CODE = "usd";
 export default function Form({ widgetConfig, details }: Props) {
   const dispatch = useSetter();
 
-  const currencies = useCurrenciesQuery(null);
+  const currencies = useFiatCurrenciesQuery(null);
 
   const initial: FV = {
     source: widgetConfig ? "bg-widget" : "bg-marketplace",

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -79,7 +79,7 @@ export const apes = createApi({
     }),
     currencies: builder.query<DetailedCurrency[], null>({
       query: () => ({
-        url: `v1/fiat/paypal/currencies`,
+        url: `v1/fiat/currencies`,
       }),
       transformResponse: (res: FiatCurrencyData) =>
         res.currencies.map((c) => ({

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -77,7 +77,7 @@ export const apes = createApi({
       }),
       transformResponse: (res: { grantId: string }) => res.grantId,
     }),
-    fiatCurrencies: builder.query<DetailedCurrency[], null>({
+    fiatCurrencies: builder.query<DetailedCurrency[], void>({
       query: () => ({
         url: `v1/fiat/currencies`,
       }),

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -77,7 +77,7 @@ export const apes = createApi({
       }),
       transformResponse: (res: { grantId: string }) => res.grantId,
     }),
-    currencies: builder.query<DetailedCurrency[], null>({
+    fiatCurrencies: builder.query<DetailedCurrency[], null>({
       query: () => ({
         url: `v1/fiat/currencies`,
       }),
@@ -125,7 +125,7 @@ export const apes = createApi({
 export const {
   useCapturePayPalOrderMutation,
   useChariotGrantIntentMutation,
-  useCurrenciesQuery,
+  useFiatCurrenciesQuery,
   useStripePaymentIntentQuery,
   usePaypalOrderQuery,
   useEndowBalanceQuery,

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -116,34 +116,6 @@ export const apes = createApi({
           rate: c.rate,
         })),
     }),
-    stripeCurrencies: builder.query<DetailedCurrency[], null>({
-      async queryFn(_args, _api, _extraOptions, baseQuery) {
-        return await fetch("https://ipapi.co/json/")
-          .then<{
-            country_code: string; // ISO 3166-1 alpha-2 code
-          }>((response) => response.json())
-          .then(({ country_code }) =>
-            baseQuery({
-              url: `v2/fiat/stripe-proxy/${apiEnv}/currencies/${country_code}`,
-            })
-          )
-          .then((response) => {
-            if (response.error) {
-              return response;
-            }
-
-            const data = response.data as FiatCurrencyData;
-
-            return {
-              data: data.currencies.map((c) => ({
-                code: c.currency_code,
-                min: c.minimum_amount,
-                rate: c.rate,
-              })),
-            };
-          });
-      },
-    }),
     tokens: builder.query<Token[], ChainID>({
       query: (chainID) => `v1/tokens/${chainID}`,
     }),
@@ -158,7 +130,6 @@ export const {
   useEndowBalanceQuery,
   useGetStripePaymentStatusQuery,
   usePaypalCurrenciesQuery,
-  useStripeCurrenciesQuery,
   useTokensQuery,
   util: {
     invalidateTags: invalidateApesTags,

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -77,6 +77,17 @@ export const apes = createApi({
       }),
       transformResponse: (res: { grantId: string }) => res.grantId,
     }),
+    currencies: builder.query<DetailedCurrency[], null>({
+      query: () => ({
+        url: `v1/fiat/paypal/currencies`,
+      }),
+      transformResponse: (res: FiatCurrencyData) =>
+        res.currencies.map((c) => ({
+          code: c.currency_code,
+          min: c.minimum_amount,
+          rate: c.rate,
+        })),
+    }),
     paypalOrder: builder.query<string, CreatePayPalOrderParams>({
       query: (params) => ({
         url: `v1/fiat/paypal/${apiEnv}/orders`,
@@ -105,17 +116,6 @@ export const apes = createApi({
         url: `v2/fiat/stripe-proxy/${apiEnv}?payment_intent=${paymentIntentId}`,
       }),
     }),
-    paypalCurrencies: builder.query<DetailedCurrency[], null>({
-      query: () => ({
-        url: `v1/fiat/paypal/currencies`,
-      }),
-      transformResponse: (res: FiatCurrencyData) =>
-        res.currencies.map((c) => ({
-          code: c.currency_code,
-          min: c.minimum_amount,
-          rate: c.rate,
-        })),
-    }),
     tokens: builder.query<Token[], ChainID>({
       query: (chainID) => `v1/tokens/${chainID}`,
     }),
@@ -125,11 +125,11 @@ export const apes = createApi({
 export const {
   useCapturePayPalOrderMutation,
   useChariotGrantIntentMutation,
+  useCurrenciesQuery,
   useStripePaymentIntentQuery,
   usePaypalOrderQuery,
   useEndowBalanceQuery,
   useGetStripePaymentStatusQuery,
-  usePaypalCurrenciesQuery,
   useTokensQuery,
   util: {
     invalidateTags: invalidateApesTags,


### PR DESCRIPTION
## Explanation of the solution
Towards BG-1181

Related PR https://github.com/AngelProtocolFinance/devops/pull/511

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to http://localhost:4200/donate/53
- **verify currencies get loaded correctly**
