### PR TITLE
BG-1179: Adjust page paddings affected by header positioning

### DIFF
--- a/src/pages/Application/Application.tsx
+++ b/src/pages/Application/Application.tsx
@@ -11,7 +11,7 @@ function Application() {
   const queryState = useApplicationQuery(id, { skip: !id });
 
   return (
-    <div className="grid content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container pt-8 lg:pt-20 pb-8">
+    <div className="grid content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container py-20">
       <h1 className="text-center text-3xl col-span-full max-lg:mb-4">
         Applications Review - Details
       </h1>

--- a/src/pages/Applications/Applications.tsx
+++ b/src/pages/Applications/Applications.tsx
@@ -22,7 +22,7 @@ function Applications() {
   const isLoadingOrError = isLoading || isLoadingNextPage || isError;
 
   return (
-    <div className="grid grid-cols-[1fr_auto] content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container pt-28 pb-8">
+    <div className="grid grid-cols-[1fr_auto] content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container py-20">
       <h1 className="text-center text-3xl col-span-full max-lg:mb-4">
         Applications Review - Dashboard
       </h1>

--- a/src/pages/BankingApplication/BankingApplication.tsx
+++ b/src/pages/BankingApplication/BankingApplication.tsx
@@ -17,7 +17,7 @@ function BankingApplication() {
   );
 
   return (
-    <div className="grid content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container pt-8 lg:pt-20 pb-8">
+    <div className="grid content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container py-20">
       <QueryLoader
         queryState={queryState}
         messages={{

--- a/src/pages/BankingApplications/BankingApplications.tsx
+++ b/src/pages/BankingApplications/BankingApplications.tsx
@@ -19,7 +19,7 @@ function BankingApplications() {
   const isLoadingOrError = isLoading || isLoadingNextPage || isError;
 
   return (
-    <div className="grid content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container pt-8 lg:pt-20 pb-8">
+    <div className="grid content-start gap-y-4 lg:gap-y-8 lg:gap-x-3 relative padded-container py-20 lg:pt-10">
       <h1 className="text-center text-3xl col-span-full max-lg:mb-4">
         Banking Applications
       </h1>

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -10,7 +10,7 @@ export default withAuth(function Donations({ user }) {
   const completeDonations = usePaginatedDonationRecords({ email: user.email });
 
   return (
-    <div className="grid gap-40 py-8 lg:pt-20">
+    <div className="grid gap-40 pt-8 lg:pt-20 pb-20">
       <DonationsSection {...onHoldDonations} title="Pending Donations" />
       <DonationsSection {...completeDonations} title="Finalized Donations" />
     </div>

--- a/src/pages/Leaderboard/index.tsx
+++ b/src/pages/Leaderboard/index.tsx
@@ -9,7 +9,7 @@ export default function Leaderboard() {
   const queryState = useLeaderboardsQuery(null);
 
   return (
-    <section className="padded-container grid content-start mt-28 sm:mt-40 pb-16">
+    <section className="padded-container grid content-start pt-8 sm:pt-20 pb-20">
       <Seo title={`Leaderboad - ${APP_NAME}`} url={`${DAPP_URL}/leaderboard`} />
       <DonationMetrics />
       <h3 className="mt-6 uppercase text-3xl">Impact board</h3>

--- a/src/pages/Registration/index.tsx
+++ b/src/pages/Registration/index.tsx
@@ -14,7 +14,7 @@ const Success = lazy(() => import("./Success"));
 
 function Registration() {
   return (
-    <div className="flex justify-center items-center mt-20">
+    <div className="flex justify-center items-center my-20">
       <Suspense fallback="Loading page...">
         <Seo
           title={`Registration Portal - ${APP_NAME}`}
@@ -23,24 +23,16 @@ function Registration() {
         <Routes>
           <Route
             path={regRoutes.welcome}
-            element={<Welcome classes="my-10 md:my-32 mx-6" />}
+            element={<Welcome classes="mx-6" />}
           />
           <Route
             path={regRoutes.steps + "/*"}
-            element={<Steps classes="md:my-20" />}
+            element={<Steps classes="max-sm:-my-20" />}
           />
-          <Route path={regRoutes.resume} element={<Resume classes="my-20" />} />
-          <Route
-            path={regRoutes.success}
-            element={<Success classes="mt-10 sm:mt-[5.5rem] mb-6 sm:mb-20" />}
-          />
-          <Route
-            path={regRoutes.sign_result}
-            element={
-              <SignResult classes="mt-10 sm:mt-[5.5rem] mb-6 sm:mb-20" />
-            }
-          />
-          <Route index element={<Signup classes="my-20" />} />
+          <Route path={regRoutes.resume} element={<Resume />} />
+          <Route path={regRoutes.success} element={<Success />} />
+          <Route path={regRoutes.sign_result} element={<SignResult />} />
+          <Route index element={<Signup />} />
           <Route path="*" element={<Navigate to={regRoutes.index} />} />
         </Routes>
       </Suspense>

--- a/src/pages/Registration/index.tsx
+++ b/src/pages/Registration/index.tsx
@@ -27,7 +27,7 @@ function Registration() {
           />
           <Route
             path={regRoutes.steps + "/*"}
-            element={<Steps classes="max-sm:-my-20" />}
+            element={<Steps classes="max-md:-my-20" />}
           />
           <Route path={regRoutes.resume} element={<Resume />} />
           <Route path={regRoutes.success} element={<Success />} />

--- a/src/pages/StripePaymentStatus.tsx
+++ b/src/pages/StripePaymentStatus.tsx
@@ -81,7 +81,7 @@ function Processing({ onMount = () => {} }) {
 function Unsuccessful() {
   const state = useGetter((state) => state.donation);
   return (
-    <div className="justify-self-center display-block m-auto max-w-[35rem] py-8 sm:py-20 scroll-mt-6">
+    <div className="justify-self-center display-block m-auto max-w-[35rem] pt-8 sm:pt-20 pb-20 scroll-mt-6">
       <Icon type="CloseCircle" size={96} className="text-green mb-4 mx-auto" />
       <h3 className="text-2xl sm:text-3xl mb-8 sm:mb-12 text-center">
         Donation unsuccessful
@@ -102,7 +102,7 @@ function Unsuccessful() {
 function SomethingWentWrong() {
   const state = useGetter((state) => state.donation);
   return (
-    <div className="justify-self-center display-block m-auto max-w-[35rem] py-8 sm:py-20 scroll-mt-6">
+    <div className="justify-self-center display-block m-auto max-w-[35rem] pt-8 sm:pt-20 pb-20 scroll-mt-6">
       <Icon type="CloseCircle" size={96} className="text-green mb-4 mx-auto" />
       <h3 className="text-2xl sm:text-3xl mb-8 sm:mb-12 text-center">
         Something went wrong


### PR DESCRIPTION
## Explanation of the solution
Added `pb-20` where appropriate, as it makes distance from the bottom of the page to the top of the footer look a bit more pronounced. 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- **verify all pages' top padding is aligned with the new header**