### PR TITLE
BG-1188: registration progress indicator must revert to desktop position

### DIFF
--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -32,6 +32,7 @@ export default function ProgressIndicator({ step, classes = "" }: Props) {
 
       if (ref.isDesktop !== isOnDesktop) {
         setDesktop(isOnDesktop);
+        ref.isDesktop = isOnDesktop;
       }
     },
     {

--- a/src/pages/Registration/Steps/ProgressIndicator.tsx
+++ b/src/pages/Registration/Steps/ProgressIndicator.tsx
@@ -25,7 +25,7 @@ export default function ProgressIndicator({ step, classes = "" }: Props) {
   useHandleScreenResize(
     (screen, ref) => {
       const isOnDesktop = screen >= SCREEN_BREAKPOINTS.md;
-      if ((isOnDesktop && !ref.isOpen) || (!isOnDesktop && ref.isOpen)) {
+      if (isOnDesktop !== ref.isOpen) {
         setIsOtherStepsShown(isOnDesktop);
         ref.isOpen = isOnDesktop;
       }


### PR DESCRIPTION
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- perform repro steps (see ticket)
- **verify the issue no longer appears**