### PR TITLE
Closes BG-1194: Incorrect dollar values shown in summary

### DIFF
--- a/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
@@ -54,12 +54,15 @@ export default function StripeCheckout(props: StripeCheckoutStep) {
           : undefined
       }
     >
-      <div className="has-[#paypal-failure-fallback]:hidden peer">
-        <p className="mb-2 font-medium">Express checkout</p>
-        <div className="flex items-center">
-          <Paypal {...props} />
+      {details.frequency === "once" && (
+        // we don't have subscriptions for paypal for now
+        <div className="has-[#paypal-failure-fallback]:hidden peer">
+          <p className="mb-2 font-medium">Express checkout</p>
+          <div className="flex items-center">
+            <Paypal {...props} />
+          </div>
         </div>
-      </div>
+      )}
       <div className="relative border border-gray-l4 h-px w-full mb-8 mt-6 grid place-items-center peer-has-[.hidden]:hidden">
         <span className="absolute bg-white px-4 text-navy-l2 text-xs">OR</span>
       </div>

--- a/src/components/donation/Steps/Summary/Summary.tsx
+++ b/src/components/donation/Steps/Summary/Summary.tsx
@@ -33,6 +33,7 @@ export default function Summary({
 
   return (
     <SummaryContainer
+      frequency={details.method === "stripe" ? details.frequency : "once"}
       classes="grid content-start p-4 @md:p-8"
       Amount={Amount}
       amount={amount}

--- a/src/components/donation/Steps/common/Currency.tsx
+++ b/src/components/donation/Steps/common/Currency.tsx
@@ -10,7 +10,10 @@ export function currency({ rate, code }: TCurrency) {
         {CODE === "USD"
           ? `$${humanize(amount, 2)}`
           : rate
-            ? `${CODE} ${humanize(amount, 2)} ($${humanize(+amount * rate, 2)})`
+            ? `${CODE} ${humanize(amount, 2)} ($${humanize(
+                +amount * (1 / rate),
+                2
+              )})`
             : `${CODE} ${humanize(amount, 2)}`}
       </dd>
     );

--- a/src/types/aws/apes/donation.ts
+++ b/src/types/aws/apes/donation.ts
@@ -87,6 +87,7 @@ export type FiatCurrencyData = {
     /** ISO 3166-1 alpha-3 code */
     currency_code: string;
     minimum_amount: number;
+    /** unit/usd */
     rate: number;
     timestamp: string;
   }[];

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -25,12 +25,14 @@ type BaseCurrency = {
 };
 
 export type DetailedCurrency = BaseCurrency & {
+  /** unit/usd */
   rate: number;
   min: number;
 };
 
 export type Currency = BaseCurrency & {
   min?: number;
+  /** unit/usd */
   rate: number | null;
 };
 


### PR DESCRIPTION
rates (`unit/usd`) were incorrectly used as `usd/unit` 
## Explanation of the solution
* invert rate in computation (summary dollar is now correct)
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/99736018-2bec-4782-962d-b89b7f797e0a)

* add unit comment to rate attributes
* PLUS: unreported bugs fixed unrelated to the linear problem (noticed in demo yesterday)
  * word `monthly` not showing in summary page when user chose monthly
  * paypal showing as payment option when user chose monthly

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
