### PR TITLE
Closes BG-1195: Image size tooltip

### DIFF
--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -102,7 +102,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
       <p className="text-xs text-navy-l1 dark:text-navy-l2 mt-2">
         <span>
           Valid types are:{" "}
-          {accept.map((m)·=>·m.split("/")[1].toUpperCase()).join(",·")}.{"·"}
+          {accept.map((m) => m.split("/")[1].toUpperCase()).join(", ")}.{" "}
           {maxSize ? (
             <>
               Image should be less than {maxSize / BYTES_IN_MB}MB in size.

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -102,10 +102,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
       <p className="text-xs text-navy-l1 dark:text-navy-l2 mt-2">
         <span>
           Valid types are:{" "}
-          {accept
-            .map((m) => m.split("/")[1].toUpperCase())
-            .join(", ")}
-          .{" "}
+          {accept.map((m)·=>·m.split("/")[1].toUpperCase()).join(",·")}.{"·"}
           {maxSize ? (
             <>
               Image should be less than {maxSize / BYTES_IN_MB}MB in size.

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -103,7 +103,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
         <span>
           Valid types are:{" "}
           {accept
-            .map((m) => m.split("/")[1].toUpperCase().replace(/\+xml/gi, ""))
+            .map((m) => m.split("/")[1].toUpperCase())
             .join(", ")}
           .{" "}
           {maxSize ? (

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -102,7 +102,10 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
       <p className="text-xs text-navy-l1 dark:text-navy-l2 mt-2">
         <span>
           Valid types are:{" "}
-          {accept.map((m) => m.split("/")[1].toUpperCase()).join(", ")}.{" "}
+          {accept
+            .map((m) => m.split("/")[1].toUpperCase().replace(/\+xml/gi, ""))
+            .join(", ")}
+          .{" "}
           {maxSize ? (
             <>
               Image should be less than {maxSize / BYTES_IN_MB}MB in size.

--- a/src/pages/Admin/Charity/EditProfile/Form.tsx
+++ b/src/pages/Admin/Charity/EditProfile/Form.tsx
@@ -80,6 +80,7 @@ export default function Form() {
           accept={VALID_MIME_TYPES}
           aspect={[4, 1]}
           classes={{ container: "mb-4", dropzone: "w-full aspect-[4/1]" }}
+          maxSize={MAX_SIZE_IN_BYTES}
         />
         <Label className="-mb-4">Logo of your organization</Label>
         <ImgEditor<FV, "logo">
@@ -103,6 +104,7 @@ export default function Form() {
             container: "mb-4",
             dropzone: "w-full aspect-[2/1]",
           }}
+          maxSize={MAX_SIZE_IN_BYTES}
         />
         <Label className="-mb-4">Description of your organization</Label>
         <RichTextEditor<FV>

--- a/src/pages/Admin/Charity/ProgramEditor/Form.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Form.tsx
@@ -5,7 +5,7 @@ import { Field, Label } from "components/form";
 import { adminRoutes } from "constants/routes";
 import { Link } from "react-router-dom";
 import Milestones from "./Milestones";
-import { MAX_CHARS, VALID_MIME_TYPES } from "./schema";
+import { MAX_CHARS, MAX_SIZE_IN_BYTES, VALID_MIME_TYPES } from "./schema";
 import { FV } from "./types";
 import useSubmit from "./useSubmit";
 
@@ -33,6 +33,7 @@ export default function Form() {
           accept={VALID_MIME_TYPES}
           aspect={[4, 1]}
           classes={{ container: "mb-4", dropzone: "w-full aspect-[4/1]" }}
+          maxSize={MAX_SIZE_IN_BYTES}
         />
 
         <Label className="-mb-4" required>

--- a/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestone.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/Milestones/Milestone.tsx
@@ -4,7 +4,7 @@ import ImgEditor from "components/ImgEditor/ImgEditor";
 import { RichTextEditor } from "components/RichText";
 import { Field, Label } from "components/form";
 import { Path, useFormContext } from "react-hook-form";
-import { MAX_CHARS, VALID_MIME_TYPES } from "../schema";
+import { MAX_CHARS, MAX_SIZE_IN_BYTES, VALID_MIME_TYPES } from "../schema";
 import { FV, FormMilestone } from "../types";
 
 export default function Milestone({
@@ -55,6 +55,7 @@ export default function Milestone({
             container: "mb-4",
             dropzone: "w-full @md:aspect-[4/1] h-36 @md:h-auto",
           }}
+          maxSize={MAX_SIZE_IN_BYTES}
         />
         <Field<FV, "date">
           type="date"

--- a/src/pages/Admin/Charity/ProgramEditor/schema.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/schema.ts
@@ -14,7 +14,7 @@ export const VALID_MIME_TYPES: ImageMIMEType[] = [
   "image/svg+xml",
 ];
 
-const MAX_SIZE_IN_BYTES = 1e6;
+export const MAX_SIZE_IN_BYTES = 1e6;
 export const MAX_CHARS = 500;
 
 // we only need to validate the pre-crop image and if we confirm it is valid


### PR DESCRIPTION
## Explanation of the solution
* search for `<ImgEditor..` renders
* ensure maxSize prop is passed

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
