### PR TITLE
BG-1218 Donation splits slider: swap display ordering

### DIFF
--- a/src/components/donation/Steps/Splits/Splits.tsx
+++ b/src/components/donation/Steps/Splits/Splits.tsx
@@ -50,12 +50,12 @@ export default function Split({
 
       {/** percentages */}
       <div className="flex justify-between mt-6 mb-3">
-        <div className="grid gap-1 grid-cols-[1fr_auto] items-center">
+        <div className="grid gap-1 grid-cols-[auto_1fr] items-center">
           <p className="text-xl text-right">{liqSplitPct}%</p>
           <Image src={sendMoney} className="ml-1" />
           <p className="uppercase text-xs col-span-full">Instantly Available</p>
         </div>
-        <div className="grid gap-1 grid-cols-[auto_1fr] items-center">
+        <div className="grid gap-1 grid-cols-[1fr_auto] items-center">
           <Image src={leaf} className="mr-1" />
           <p className="text-xl">{lockedSplitPct}%</p>
           <p className="uppercase text-xs col-span-full">Sustainable fund</p>

--- a/src/components/donation/Steps/Splits/Splits.tsx
+++ b/src/components/donation/Steps/Splits/Splits.tsx
@@ -50,15 +50,15 @@ export default function Split({
 
       {/** percentages */}
       <div className="flex justify-between mt-6 mb-3">
-        <div className="grid gap-1 grid-cols-[auto_1fr] items-center">
-          <Image src={leaf} className="mr-1" />
-          <p className="text-xl">{lockedSplitPct}%</p>
-          <p className="uppercase text-xs col-span-full">Sustainable fund</p>
-        </div>
         <div className="grid gap-1 grid-cols-[1fr_auto] items-center">
           <p className="text-xl text-right">{liqSplitPct}%</p>
           <Image src={sendMoney} className="ml-1" />
           <p className="uppercase text-xs col-span-full">Instantly Available</p>
+        </div>
+        <div className="grid gap-1 grid-cols-[auto_1fr] items-center">
+          <Image src={leaf} className="mr-1" />
+          <p className="text-xl">{lockedSplitPct}%</p>
+          <p className="uppercase text-xs col-span-full">Sustainable fund</p>
         </div>
       </div>
 
@@ -81,21 +81,21 @@ export default function Split({
       {/** amount breakdown */}
       <div className="flex justify-between mt-1">
         <dl>
-          <dt className="text-navy-l1 text-xs">Compounded Forever</dt>
-          <dd>
-            <span className="text-xs font-medium mr-1">
-              {symbol.toUpperCase()}
-            </span>
-            <span>{humanize(locked, DECIMALS)}</span>
-          </dd>
-        </dl>
-        <dl>
           <dt className="text-navy-l1 text-xs">Instantly Available</dt>
           <dd className="text-right">
             <span className="text-xs font-medium mr-1">
               {symbol.toUpperCase()}
             </span>
             <span>{humanize(liq, DECIMALS)}</span>
+          </dd>
+        </dl>
+        <dl>
+          <dt className="text-navy-l1 text-xs">Compounded Forever</dt>
+          <dd>
+            <span className="text-xs font-medium mr-1">
+              {symbol.toUpperCase()}
+            </span>
+            <span>{humanize(locked, DECIMALS)}</span>
           </dd>
         </dl>
       </div>

--- a/src/components/donation/Steps/Splits/Splits.tsx
+++ b/src/components/donation/Steps/Splits/Splits.tsx
@@ -50,12 +50,12 @@ export default function Split({
 
       {/** percentages */}
       <div className="flex justify-between mt-6 mb-3">
-        <div className="grid gap-1 grid-cols-[auto_1fr] items-center">
+        <div className="grid gap-1 grid-cols-[1fr_auto] items-center">
           <p className="text-xl text-right">{liqSplitPct}%</p>
           <Image src={sendMoney} className="ml-1" />
           <p className="uppercase text-xs col-span-full">Instantly Available</p>
         </div>
-        <div className="grid gap-1 grid-cols-[1fr_auto] items-center">
+        <div className="grid gap-1 grid-cols-[auto_1fr] items-center">
           <Image src={leaf} className="mr-1" />
           <p className="text-xl">{lockedSplitPct}%</p>
           <p className="uppercase text-xs col-span-full">Sustainable fund</p>


### PR DESCRIPTION
## Explanation of the solution
Display needed to be swapped for split component ordering to avoid confusion over colors and %s. 
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/ec61437e-d738-494c-985e-c1c260c8cc83)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Go to any nonprofit donation page
- Verify the splits work as desired still. Only the display order has changed

## UI changes for review
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/0de56ec1-8a49-4ec7-942b-2d762ac643aa)