### PR TITLE
Fix: handle doc reset when registrant already accomplishes banking details

### DIFF
--- a/src/App/__tests__/App.test.tsx
+++ b/src/App/__tests__/App.test.tsx
@@ -9,7 +9,7 @@ import App from "../App";
 const mockMetrics: DonationsMetricList = {
   donations_daily_count: 0,
   donations_daily_amount: 0,
-  donations_total_amount: 0,
+  donations_total_amount_v2: 0,
 };
 
 jest.mock("services/aws/business_metrics", () => ({

--- a/src/pages/Registration/Steps/getRegistrationState.ts
+++ b/src/pages/Registration/Steps/getRegistrationState.ts
@@ -1,9 +1,9 @@
 import { InitReg, RegistrationState } from "../types";
 import {
   BankingDetails,
+  DidDocs,
+  DidFSAInquiry,
   DoneBanking,
-  DoneDocs,
-  DoneFSAInquiry,
   DoneOrgDetails,
   FSAInquiry,
   InitContact,
@@ -161,7 +161,7 @@ function orgDetails(reg: DoneOrgDetails["Registration"]): OrgDetails {
 
 const US = "United States";
 type Docs = NonNullable<TDocumentation["Documentation"]>;
-function docs(reg: DoneDocs["Registration"]): Docs {
+function docs(reg: DidDocs["Registration"]): Docs {
   const fallback: Docs =
     reg.AuthorizedToReceiveTaxDeductibleDonations ?? reg.HqCountry === US
       ? {
@@ -205,7 +205,7 @@ function bankDetails(reg: DoneBanking["Registration"]): BankingDetails {
   };
 }
 
-function fsaInquiry(reg: DoneFSAInquiry["Registration"]): FSAInquiry {
+function fsaInquiry(reg: DidFSAInquiry["Registration"]): FSAInquiry {
   return {
     AuthorizedToReceiveTaxDeductibleDonations:
       reg.AuthorizedToReceiveTaxDeductibleDonations ?? reg.HqCountry === US,

--- a/src/pages/Registration/Steps/getRegistrationState.ts
+++ b/src/pages/Registration/Steps/getRegistrationState.ts
@@ -159,8 +159,29 @@ function orgDetails(reg: DoneOrgDetails["Registration"]): OrgDetails {
   };
 }
 
-function docs(reg: DoneDocs["Registration"]): TDocumentation["Documentation"] {
+const US = "United States";
+type Docs = NonNullable<TDocumentation["Documentation"]>;
+function docs(reg: DoneDocs["Registration"]): Docs {
+  const fallback: Docs =
+    reg.AuthorizedToReceiveTaxDeductibleDonations ?? reg.HqCountry === US
+      ? {
+          DocType: "Non-FSA",
+          EIN: "",
+        }
+      : {
+          DocType: "FSA",
+          ProofOfIdentity: { name: "", publicUrl: "" },
+          RegistrationNumber: "",
+          ProofOfRegistration: { name: "", publicUrl: "" },
+          LegalEntityType: "",
+          ProjectDescription: "",
+          FiscalSponsorshipAgreementSigningURL: "",
+          SignedFiscalSponsorshipAgreement: "",
+        };
+
   const doc = reg.Documentation;
+  if (!doc) return fallback;
+
   if (doc.DocType === "Non-FSA") {
     return { EIN: doc.EIN, DocType: doc.DocType };
   }
@@ -187,6 +208,6 @@ function bankDetails(reg: DoneBanking["Registration"]): BankingDetails {
 function fsaInquiry(reg: DoneFSAInquiry["Registration"]): FSAInquiry {
   return {
     AuthorizedToReceiveTaxDeductibleDonations:
-      reg.AuthorizedToReceiveTaxDeductibleDonations,
+      reg.AuthorizedToReceiveTaxDeductibleDonations ?? reg.HqCountry === US,
   };
 }

--- a/src/pages/Registration/Steps/getRegistrationState.ts
+++ b/src/pages/Registration/Steps/getRegistrationState.ts
@@ -12,10 +12,10 @@ import {
   TDocumentation,
   isDoneBanking,
   isDoneContact,
-  isDoneDocs,
   isDoneFSAInquiry,
   isDoneOrgDetails,
   isSubmitted,
+  isWithDocs,
 } from "types/aws";
 import { steps } from "../routes";
 
@@ -61,7 +61,7 @@ export function getRegistrationState(reg: SavedRegistration): {
     };
   }
 
-  if (isDoneDocs(reg)) {
+  if (isWithDocs(reg)) {
     const { ContactPerson: c, Registration: r } = reg;
     const isSignedFSA =
       r.Documentation.DocType === "FSA"

--- a/src/types/aws/ap/registration.ts
+++ b/src/types/aws/ap/registration.ts
@@ -150,7 +150,7 @@ export type SavedRegistration =
   | DoneBanking
   | InReview;
 
-export type DoneDocs<T extends DoneBanking | DidDocs | InReview> = Omit<
+export type WithDocs<T extends DoneBanking | DidDocs | InReview> = Omit<
   T,
   "Registration"
 > & { Registration: SetNonNullable<T["Registration"]> };
@@ -210,7 +210,7 @@ type WiseRecipient = {
   bankName: string;
 };
 
-export type ApplicationDetails = DoneDocs<InReview> & {
+export type ApplicationDetails = WithDocs<InReview> & {
   WiseRecipient?: WiseRecipient;
 };
 
@@ -238,7 +238,7 @@ export function isDoneFSAInquiry(
   return reg.AuthorizedToReceiveTaxDeductibleDonations != null;
 }
 
-export function isDoneDocs(data: SavedRegistration): data is DoneDocs<DidDocs> {
+export function isWithDocs(data: SavedRegistration): data is WithDocs<DidDocs> {
   const { Registration: reg } = data as DidDocs;
   return (
     !!reg.Documentation && reg.AuthorizedToReceiveTaxDeductibleDonations != null


### PR DESCRIPTION
when registrant finishes banking details, it was assumed that previous step is complete. However, docs can be reset in scenarios:
1. user changes country from US to Non-US
2. user changes answer in FSA inquiry
3. user changes some contact details (those included in FSA doc), invalidating previously signed FSA agreement

Currently, these cases are only handled up until documentation step. 

## Explanation of the solution
* reflect to types these scenarios and handle accordingly

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
