### PR TITLE
Dynamically set PayPal button's currency

### DIFF
--- a/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Paypal.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Paypal.tsx
@@ -43,7 +43,7 @@ export default function Paypal(props: StripeCheckoutStep) {
       options={{
         clientId: PAYPAL_CLIENT_ID,
         commit: true,
-        currency: "USD",
+        currency: details.currency.code.toUpperCase(),
         enableFunding: "paylater",
         disableFunding: "card,venmo",
       }}


### PR DESCRIPTION
## Explanation of the solution
Replaced the hard coded `"USD"` when initializing the PayPal button with `details.currency.code.toUpperCase()` so that both the initial order creation and button initialization processes use the same currency.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Create a single fiat donation for USD & a non-USD currency
- Verify that PayPal Express checkout button does not throw an error and opens the pop-up window for checkout

## UI changes for review
No major UI changes.