### PR TITLE
Dynamically set payment frequency for Stripe subscriptions

### DIFF
--- a/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
@@ -24,7 +24,7 @@ export default function StripeCheckout(props: StripeCheckoutStep) {
     isError,
     error,
   } = useStripePaymentIntentQuery({
-    type: "one-time",
+    type: details.frequency === "once" ? "one-time" : "subscription",
     amount: +details.amount,
     tipAmount: tip,
     usdRate: details.currency.rate,


### PR DESCRIPTION
## Explanation of the solution
When a donor selects "give monthly", the webapp should process that as a subscription. However it still creates a single donation record. To fix this, nstead of hard coding `"one-time"` which forces the creation of a single donation record, we have to change it to a ternary operator to set `payload.type` dynamically.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Create a donation with "monthly" frequency
- Verify that the payload sent to AWS is `type === "subscription"`
- Verify that donation and subs records are saved in AWS tables `on_hold_donations` and `subscriptions`, respectively

## UI changes for review
No major UI changes.