### PR TITLE
Bump endpoint version for S3 file uploader to use `v2`

### DIFF
--- a/src/helpers/uploadFiles.test.ts
+++ b/src/helpers/uploadFiles.test.ts
@@ -33,7 +33,7 @@ describe("uploadFiles tests", () => {
     await uploadFiles([file], bucket);
     expect(global.fetch).toHaveBeenCalledTimes(1);
 
-    expect(global.fetch).toHaveBeenCalledWith(APIs.aws + "/v1/file-upload", {
+    expect(global.fetch).toHaveBeenCalledWith(APIs.aws + "/v2/file-upload", {
       method: "POST",
       body: JSON.stringify({
         bucket: bucket,

--- a/src/helpers/uploadFiles.ts
+++ b/src/helpers/uploadFiles.ts
@@ -19,7 +19,7 @@ export async function uploadFiles(
 
   await Promise.all(
     files.map((f, idx) =>
-      fetch(APIs.aws + "/v1/file-upload", {
+      fetch(APIs.aws + "/v2/file-upload", {
         method: "POST",
         body: JSON.stringify({
           bucket,


### PR DESCRIPTION
Related to BG-1229

## Explanation of the solution
Updated the version of the endpoint used for S3 file uploading from `v1` to `v2`.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Register an NPO and verify that file uploading works as intended

## UI changes for review
No major UI changes.