### PR TITLE
BG-1213: URI validation bug: should encode all URIs before submitting to AWS to be RFC-compliant

### DIFF
--- a/src/helpers/uploadFiles.ts
+++ b/src/helpers/uploadFiles.ts
@@ -6,6 +6,7 @@ export type Bucket = "endow-profiles" | "endow-reg";
 export const bucketURL = "s3.amazonaws.com";
 
 const SPACES = /\s+/g;
+
 export async function uploadFiles(
   files: File[],
   bucket: Bucket
@@ -36,7 +37,7 @@ export async function uploadFiles(
 }
 
 export function getFullURL(baseURL: string, fileName: string) {
-  return `${baseURL}-${fileName.replace(SPACES, "_")}`;
+  return encodeURI(`${baseURL}-${fileName.replace(SPACES, "_")}`);
 }
 
 function toDataURL(file: File): Promise<string> {


### PR DESCRIPTION
## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- **verify issue no longer appears**