### PR TITLE
Fix: hide express checkout OrSeparator when subscription

### DIFF
--- a/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
@@ -58,17 +58,22 @@ export default function StripeCheckout(props: StripeCheckoutStep) {
       }
     >
       {details.frequency === "once" && (
-        // we don't have subscriptions for paypal for now
-        <div className="has-[#paypal-failure-fallback]:hidden peer">
-          <p className="mb-2 font-medium">Express checkout</p>
-          <div className="flex items-center">
-            <Paypal {...props} />
+        <>
+          // we don't have subscriptions for paypal for now
+          <div className="has-[#paypal-failure-fallback]:hidden peer">
+            <p className="mb-2 font-medium">Express checkout</p>
+            <div className="flex items-center">
+              <Paypal {...props} />
+            </div>
           </div>
-        </div>
+          <div className="relative border border-gray-l4 h-px w-full mb-8 mt-6 grid place-items-center peer-has-[.hidden]:hidden">
+            <span className="absolute bg-white px-4 text-navy-l2 text-xs">
+              OR
+            </span>
+          </div>
+        </>
       )}
-      <div className="relative border border-gray-l4 h-px w-full mb-8 mt-6 grid place-items-center peer-has-[.hidden]:hidden">
-        <span className="absolute bg-white px-4 text-navy-l2 text-xs">OR</span>
-      </div>
+
       {isLoading ? (
         <Loader msg="Loading payment form.." />
       ) : isError || !clientSecret ? (


### PR DESCRIPTION

![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/68e1e197-e9fe-49de-b8b9-b7d32c02469c)

## Explanation of the solution
* include OrSeparator in frequency check

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
