### PR TITLE
Closes BG-1254: ACH routing number invalid

### DIFF
--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/useRecipientDetailsForm/createFieldSchema.ts
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/useRecipientDetailsForm/createFieldSchema.ts
@@ -3,6 +3,10 @@ import { Group } from "types/aws";
 import { OptionType } from "types/components";
 import { logger } from "helpers";
 import { requiredString } from "schemas/string";
+import { IS_TEST } from "constants/env";
+import { APIs } from "constants/urls";
+
+const wiseProxy = `${APIs.aws}/${IS_TEST ? "staging" : "v1"}/wise-proxy`;
 
 export function createStringSchema(
   requirements: Group
@@ -29,13 +33,15 @@ export function createStringSchema(
   }
   if (requirements.validationAsync) {
     const { url, params } = requirements.validationAsync;
+    const path = new URL(url).pathname;
+    const proxiedURL = wiseProxy + path;
     schema = schema.test(
       "Field's remote validation",
       `Must be a valid ${requirements.name}`,
       (val) =>
         // Still waiting on some response from Wise Support on how to handle
         // cases when params.length > 1, as it's currently not clear how do this.
-        fetch(`${url}?${params[0].key}=${val}`)
+        fetch(`${proxiedURL}?${params[0].key}=${val}`)
           .then((res) => res.ok)
           .catch((err) => {
             logger.error("Error fetching accounts requirements");


### PR DESCRIPTION
when web-app request account requirements, a validation URL is coupled to some fields so that wise can check what we input.
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/3b8d200f-fd07-4e5d-9657-4d008aff789f)

However, we are accessing this validation URL from origin `app.better.giving` (cross origin)

## Explanation of the solution
* proxy the validation URL instead, validation now works without CORS
![Screenshot 2024-04-08 at 14 04 55](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/a6aab416-8558-43a2-9752-a52aea0a8325)

NOTE: found that wise validation of ACH doesn't work on their sandbox environment 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
