### PR TITLE
Cherry pick wise validation via proxy

### DIFF
--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -3,6 +3,7 @@ import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { NativeSelect } from "components/Selector";
 import { Label } from "components/form";
 import { GENERIC_ERROR_MESSAGE } from "constants/common";
+import { APIs } from "constants/urls";
 import { useErrorContext } from "contexts/ErrorContext";
 import { isEmpty, logger } from "helpers";
 import { Controller, get, useForm } from "react-hook-form";
@@ -247,8 +248,10 @@ export default function RecipientDetailsForm({
                     ? async (v: string) => {
                         try {
                           const { params, url } = f.validationAsync!;
+                          const path = new URL(url).pathname;
+                          const proxy = `${APIs.aws}/v1/wise-proxy/${path}`;
                           const res = await fetch(
-                            `${url}?${params[0].key}=${v}`
+                            `${proxy}?${params[0].key}=${v}`
                           );
                           return res.ok || "invalid";
                         } catch (err) {


### PR DESCRIPTION
## Explanation of the solution
cherry picked and resolved conflicts (so conflict would not arise in `v1.92 -> master` merge)
* #2848 

* staging validation now also uses prod proxy `aws/v1/wise-proxy` for consistent behavior prod/staging behavior

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
