### PR TITLE
Reflect donations endpoint changes

### DIFF
--- a/src/pages/Admin/Charity/Donations/DonationsTable.tsx
+++ b/src/pages/Admin/Charity/Donations/DonationsTable.tsx
@@ -99,7 +99,7 @@ const csvHeadersDonations: {
 ];
 
 /** fill undefined with "" */
-export function fill<T extends object>(
+function fill<T extends object>(
   obj: T
 ): { [K in keyof T]-?: NonNullable<T[K]> } {
   return new Proxy(obj, {

--- a/src/pages/Admin/Charity/Donations/DonationsTable.tsx
+++ b/src/pages/Admin/Charity/Donations/DonationsTable.tsx
@@ -1,8 +1,9 @@
 import CsvExporter from "components/CsvExporter";
 import Icon from "components/Icon";
 import QueryLoader from "components/QueryLoader";
-import { usePaginatedDonationRecords } from "services/apes";
-import { DonationReceivedByEndow, KYCData } from "types/aws";
+import usePaginatedDonationRecords from "services/aws/usePaginatedDonations";
+import { DonationRecord, KYCData } from "types/aws";
+import { Ensure } from "types/utils";
 import { useAdminContext } from "../../Context";
 import Table from "./Table";
 
@@ -53,8 +54,17 @@ export default function DonationsTable({ classes = "" }) {
                 classes="border border-blue text-blue-d1 hover:border-blue-l2 hover:text-blue rounded px-4 py-2 text-sm"
                 headers={csvHeadersReceipts}
                 data={donations
-                  .filter((x) => !!x.kycData)
-                  .map((x) => x.kycData!)}
+                  .filter(
+                    (d): d is Ensure<DonationRecord, "donorDetails"> =>
+                      !!d.donorDetails
+                  )
+                  .map<KYCData>(({ donorDetails: d }) =>
+                    fill({
+                      ...d.address,
+                      fullName: d.fullName,
+                      kycEmail: d.kycEmail,
+                    })
+                  )}
                 filename="receipts.csv"
               >
                 <Icon type="FileCSV" size={17} className="text-2xl" />
@@ -79,19 +89,31 @@ export default function DonationsTable({ classes = "" }) {
 }
 
 const csvHeadersDonations: {
-  key: keyof DonationReceivedByEndow;
+  key: keyof DonationRecord;
   label: string;
 }[] = [
-  { key: "amount", label: "Amount" },
+  { key: "initAmount", label: "Amount" },
   { key: "symbol", label: "Currency" },
   { key: "date", label: "Date" },
-  { key: "hash", label: "Transaction Hash" },
+  { key: "id", label: "Transaction Hash" },
 ];
+
+/** fill undefined with "" */
+export function fill<T extends object>(
+  obj: T
+): { [K in keyof T]-?: NonNullable<T[K]> } {
+  return new Proxy(obj, {
+    get(target: any, key) {
+      return target[key] ?? "";
+    },
+  });
+}
 
 const csvHeadersReceipts: { key: keyof KYCData; label: string }[] = [
   { key: "fullName", label: "Full Name" },
   { key: "kycEmail", label: "Email" },
-  { key: "streetAddress", label: "Street Address" },
+  { key: "line1", label: "Address line 1" },
+  { key: "line2", label: "Address line 2" },
   { key: "city", label: "City" },
   { key: "zipCode", label: "Zip Code" },
   { key: "state", label: "State" },

--- a/src/pages/Admin/Charity/Donations/Table.tsx
+++ b/src/pages/Admin/Charity/Donations/Table.tsx
@@ -4,10 +4,10 @@ import Icon from "components/Icon";
 import TableSection, { Cells } from "components/TableSection";
 import { getTxUrl, humanize, maskAddress } from "helpers";
 import useSort from "hooks/useSort";
-import { DonationReceivedByEndow } from "types/aws";
+import { DonationRecord } from "types/aws";
 
 type Props = {
-  donations: DonationReceivedByEndow[];
+  donations: DonationRecord[];
   classes?: string;
   onLoadMore(): void;
   hasMore: boolean;
@@ -54,7 +54,7 @@ export default function Table({
             Currency
           </HeaderButton>
           <HeaderButton
-            onClick={handleHeaderClick("amount")}
+            onClick={handleHeaderClick("initAmount")}
             _activeSortKey={sortKey}
             _sortKey="amount"
             _sortDirection={sortDirection}
@@ -75,16 +75,16 @@ export default function Table({
         {sorted
           .map(
             ({
-              hash,
-              amount,
+              id,
+              initAmount,
               symbol,
-              chainId,
+              viaId,
               date,
-              kycData,
-              splitLiq = "50",
+              donorDetails,
+              splitLiqPct = "50",
             }) => (
               <Cells
-                key={hash}
+                key={id}
                 type="td"
                 cellClass={`p-3 border-t border-gray-l4 max-w-[256px] truncate ${
                   hasMore ? "" : "first:rounded-bl last:rounded-br"
@@ -94,24 +94,24 @@ export default function Table({
                   {new Date(date).toLocaleDateString()}
                 </span>
                 <span className="text-sm">{symbol}</span>
-                <>{humanize(amount, 3)}</>
-                <>{humanize(amount * (+splitLiq / 100), 3)}</>
-                <>{humanize(amount * ((100 - +splitLiq) / 100), 3)}</>
+                <>{humanize(initAmount, 3)}</>
+                <>{humanize(initAmount * (+splitLiqPct / 100), 3)}</>
+                <>{humanize(initAmount * ((100 - +splitLiqPct) / 100), 3)}</>
 
-                {chainId === "staging" || chainId === "fiat" ? (
+                {viaId === "staging" || viaId === "fiat" ? (
                   <>- - -</>
                 ) : (
                   <ExtLink
                     //default to ethereum for staging
-                    href={getTxUrl(chainId, hash)}
+                    href={getTxUrl(viaId, id)}
                     className="text-center text-blue-d1 hover:text-navy uppercase text-sm"
                   >
-                    {maskAddress(hash)}
+                    {maskAddress(id)}
                   </ExtLink>
                 )}
 
                 <td className="relative">
-                  {!kycData ? (
+                  {!donorDetails ? (
                     <Icon
                       type="Close"
                       //prevent icon size from affecting row height

--- a/src/pages/Donations/Filter/NetworkDropdown.tsx
+++ b/src/pages/Donations/Filter/NetworkDropdown.tsx
@@ -11,7 +11,7 @@ export default function NetworkDropdown({ classes = "" }) {
         classes={{ button: "dark:bg-blue-d6", options: "text-sm" }}
         options={Object.entries(chains).map(([, chain]) => ({
           label: chain.name,
-          value: chain.name,
+          value: chain.id,
         }))}
       />
     </div>

--- a/src/pages/Donations/Filter/index.tsx
+++ b/src/pages/Donations/Filter/index.tsx
@@ -14,10 +14,16 @@ import { FormValues as FV } from "./types";
 type Props = {
   classes?: string;
   setParams: React.Dispatch<React.SetStateAction<DonationsQueryParams>>;
+  asker: string;
   isDisabled: boolean;
 };
 
-export default function Filter({ setParams, classes = "", isDisabled }: Props) {
+export default function Filter({
+  setParams,
+  classes = "",
+  isDisabled,
+  asker,
+}: Props) {
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 
   const methods = useForm<FV>({
@@ -37,14 +43,13 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
 
   async function submit(data: FV) {
     setParams((prev) => ({
-      id: prev.id,
-      chain_id: prev.chain_id,
+      asker,
       status: prev.status,
       ...cleanObject({
-        afterDate: data.startDate ? new Date(data.startDate).toISOString() : "",
-        beforeDate: data.endDate ? new Date(data.endDate).toISOString() : "",
-        chainName: data.network.value,
-        denomination: data.currency.value,
+        startDate: data.startDate ? new Date(data.startDate).toISOString() : "",
+        endDate: data.endDate ? new Date(data.endDate).toISOString() : "",
+        viaId: data.network.value,
+        symbol: data.currency.value,
       }),
     }));
     buttonRef.current?.click();
@@ -53,8 +58,7 @@ export default function Filter({ setParams, classes = "", isDisabled }: Props) {
   const onReset: FormEventHandler<HTMLFormElement> = () => {
     reset();
     setParams((prev) => ({
-      id: prev.id,
-      chain_id: prev.chain_id,
+      asker,
       status: prev.status,
     }));
     buttonRef.current?.click();

--- a/src/pages/Donations/MobileTable.tsx
+++ b/src/pages/Donations/MobileTable.tsx
@@ -54,23 +54,27 @@ export default function MobileTable({
                   isOpen={open}
                 />
                 <p className="text-sm p-4 text-left h-full truncate">
-                  {row.charityName}
+                  {row.recipientName}
                 </p>
                 <div className="p-4 text-center text-sm w-28">
                   {new Date(row.date).toLocaleDateString()}
                 </div>
               </Disclosure.Button>
               <Disclosure.Panel className="w-full divide-y divide-blue-l2">
-                <Row title="Network">{row.chainName}</Row>
+                <Row title="Network">{row.viaName}</Row>
                 <Row title="Currency">{row.symbol}</Row>
-                <Row title="Amount">{humanize(row.amount, 3)}</Row>
-                <Row title="USD Value">{`$${humanize(row.usdValue, 2)}`}</Row>
-                <Row title="TX Hash">{row.hash}</Row>
-                {status === "RECEIVED" && (
+                <Row title="Amount">{humanize(row.initAmount, 3)}</Row>
+                <Row title="USD Value">
+                  {row.initAmountUsd
+                    ? `$${humanize(row.initAmountUsd, 2)}`
+                    : "--"}
+                </Row>
+                <Row title="TX Hash">{row.id}</Row>
+                {status === "final" && (
                   <Row title="Receipt" className="rounded-b">
                     <button
                       className="block"
-                      onClick={() => showKYCForm(row.hash)}
+                      onClick={() => showKYCForm(row.id)}
                     >
                       <Icon type="FatArrowDownload" className="text-2xl" />
                     </button>

--- a/src/pages/Donations/NoDonations.tsx
+++ b/src/pages/Donations/NoDonations.tsx
@@ -18,7 +18,7 @@ export default function NoDonations({ classes, status }: Props) {
       />
       <h3 className="text-lg self-end">No donations found.</h3>
       <p className="self-start text-navy-l1 dark:text-navy-l2">
-        {status === "PENDING"
+        {status === "pending"
           ? "You have no donations pending"
           : "You've not made any donations yet"}
         . Take a look at our marketplace to choose from hundreds of nonprofits

--- a/src/pages/Donations/StatusTabs.tsx
+++ b/src/pages/Donations/StatusTabs.tsx
@@ -9,35 +9,35 @@ export default function StatusTabs(props: Props) {
   return (
     <div className="flex">
       <button
-        onClick={() => props.changeStatus("RECEIVED")}
+        onClick={() => props.changeStatus("final")}
         className={`relative group w-full sm:w-40 rounded-t-lg py-2.5 text-sm font-bold leading-5
         focus:outline-none border-t border-x border-gray-l4 ${
-          props.status === "RECEIVED"
+          props.status === "final"
             ? "bg-blue-l4 z-10"
             : "bg-blue-l5 hover:bg-blue-l3 -mr-4"
         }`}
       >
         <span
-          className="group-focus-visible:outline-none group-focus-visible:rounded-sm 
+          className="uppercase group-focus-visible:outline-none group-focus-visible:rounded-sm 
         group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-blue-d1"
         >
-          {"RECEIVED" satisfies DonationsQueryParams["status"]}
+          Received
         </span>
       </button>
       <button
-        onClick={() => props.changeStatus("PENDING")}
+        onClick={() => props.changeStatus("pending")}
         className={`relative group w-full sm:w-40 rounded-t-lg py-2.5 text-sm font-bold leading-5
         focus:outline-none border-t border-x border-gray-l4 ${
-          props.status === "PENDING"
+          props.status === "pending"
             ? "bg-blue-l4 z-10"
             : "bg-blue-l5 hover:bg-blue-l3 -ml-4"
         }`}
       >
         <span
-          className="group-focus-visible:outline-none group-focus-visible:rounded-sm 
+          className="uppercase group-focus-visible:outline-none group-focus-visible:rounded-sm 
         group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-blue-d1"
         >
-          {"PENDING" satisfies DonationsQueryParams["status"]}
+          Pending
         </span>
       </button>
     </div>

--- a/src/pages/Donations/Table.tsx
+++ b/src/pages/Donations/Table.tsx
@@ -102,7 +102,7 @@ export default function Table({
                   appRoutes[
                     row.viaId === chainIds.juno ? "profile" : "marketplace"
                   ]
-                }/${row.id}`}
+                }/${row.recipientId}`}
                 className="flex items-center justify-between gap-1 cursor-pointer text-sm hover:underline"
               >
                 <span className="truncate max-w-[12rem]">

--- a/src/pages/Donations/Table.tsx
+++ b/src/pages/Donations/Table.tsx
@@ -37,9 +37,9 @@ export default function Table({
           cellClass="px-3 py-4 text-xs uppercase font-semibold text-left first:rounded-tl last:rounded-tr"
         >
           <HeaderButton
-            onClick={handleHeaderClick("charityName")}
+            onClick={handleHeaderClick("recipientName")}
             _activeSortKey={sortKey}
-            _sortKey="charityName"
+            _sortKey="recipientName"
             _sortDirection={sortDirection}
           >
             Recipient
@@ -53,7 +53,7 @@ export default function Table({
             Date
           </HeaderButton>
           <HeaderButton
-            onClick={handleHeaderClick("chainName")}
+            onClick={handleHeaderClick("viaName")}
             _activeSortKey={sortKey}
             _sortKey="chainName"
             _sortDirection={sortDirection}
@@ -62,15 +62,15 @@ export default function Table({
           </HeaderButton>
           <>Currency</>
           <HeaderButton
-            onClick={handleHeaderClick("amount")}
+            onClick={handleHeaderClick("initAmount")}
             _activeSortKey={sortKey}
-            _sortKey="amount"
+            _sortKey="initAmount"
             _sortDirection={sortDirection}
           >
             Amount
           </HeaderButton>
           <HeaderButton
-            onClick={handleHeaderClick("usdValue")}
+            onClick={handleHeaderClick("initAmountUsd")}
             _activeSortKey={sortKey}
             _sortKey="usdValue"
             _sortDirection={sortDirection}
@@ -78,7 +78,7 @@ export default function Table({
             USD Value
           </HeaderButton>
           <>TX Hash</>
-          {status === "RECEIVED" && (
+          {status === "final" && (
             <span className="flex justify-center">Receipt</span>
           )}
         </Cells>
@@ -91,7 +91,7 @@ export default function Table({
         {sorted
           .map((row) => (
             <Cells
-              key={row.hash}
+              key={row.id}
               type="td"
               cellClass={`p-3 border-t border-blue-l2 max-w-[256px] truncate ${
                 hasMore ? "" : "first:rounded-bl last:rounded-br"
@@ -100,35 +100,39 @@ export default function Table({
               <Link
                 to={`${
                   appRoutes[
-                    row.chainId === chainIds.juno ? "profile" : "marketplace"
+                    row.viaId === chainIds.juno ? "profile" : "marketplace"
                   ]
                 }/${row.id}`}
                 className="flex items-center justify-between gap-1 cursor-pointer text-sm hover:underline"
               >
                 <span className="truncate max-w-[12rem]">
-                  {row.charityName}
+                  {row.recipientName}
                 </span>
                 <Icon type="ExternalLink" className="w-5 h-5" />
               </Link>
               <>{new Date(row.date).toLocaleDateString()}</>
-              <>{row.chainName}</>
+              <>{row.viaName}</>
               <span className="text-sm">{row.symbol}</span>
-              <>{humanize(row.amount, 3)}</>
-              <>{`$${humanize(row.usdValue, 2)}`}</>
-              {row.chainId === "fiat" || row.chainId === "staging" ? (
+              <>{humanize(row.initAmount, 3)}</>
+              <>
+                {row.initAmountUsd
+                  ? `$${humanize(row.initAmountUsd, 2)}`
+                  : "--"}
+              </>
+              {row.viaId === "fiat" || row.viaId === "staging" ? (
                 <>- - -</>
               ) : (
                 <ExtLink
-                  href={getTxUrl(row.chainId, row.hash)}
+                  href={getTxUrl(row.viaId, row.id)}
                   className="text-center text-blue-d1 hover:text-navy-d1 uppercase text-sm"
                 >
-                  {row.hash}
+                  {row.id}
                 </ExtLink>
               )}
-              {status === "RECEIVED" && (
+              {status === "final" && (
                 <button
                   className="w-full flex justify-center"
-                  onClick={() => showKYCForm(row.hash)}
+                  onClick={() => showKYCForm(row.id)}
                 >
                   <Icon type="FatArrowDownload" className="text-2xl" />
                 </button>

--- a/src/pages/Donations/index.tsx
+++ b/src/pages/Donations/index.tsx
@@ -3,9 +3,8 @@ import Icon from "components/Icon";
 import QueryLoader from "components/QueryLoader";
 import withAuth from "contexts/Auth";
 import { isEmpty } from "helpers";
-import { useState } from "react";
-import { usePaginatedDonationRecords } from "services/apes";
-import { DonationMadeByDonor, DonationsQueryParams } from "types/aws";
+import usePaginatedDonationRecords from "services/aws/usePaginatedDonations";
+import { DonationRecord } from "types/aws";
 import Filter from "./Filter";
 import MobileTable from "./MobileTable";
 import NoDonations from "./NoDonations";
@@ -13,12 +12,8 @@ import StatusTabs from "./StatusTabs";
 import Table from "./Table";
 
 export default withAuth(function Donations({ user }) {
-  const [status, setStatus] =
-    useState<DonationsQueryParams["status"]>("RECEIVED");
-
   const queryState = usePaginatedDonationRecords({
     email: user.email,
-    status,
   });
 
   const {
@@ -33,6 +28,8 @@ export default withAuth(function Donations({ user }) {
     loadNextPage,
     onQueryChange,
     setParams,
+    status,
+    setStatus,
   } = queryState;
 
   const isLoadingOrError =
@@ -49,7 +46,7 @@ export default withAuth(function Donations({ user }) {
         headers={csvHeaders}
         data={data?.Items || []}
         filename={
-          status === "RECEIVED" ? "donations.csv" : "pending-donations.csv"
+          status === "final" ? "donations.csv" : "pending-donations.csv"
         }
       >
         Export to CSV
@@ -72,6 +69,7 @@ export default withAuth(function Donations({ user }) {
       <Filter
         isDisabled={isLoading || isLoadingNextPage}
         setParams={setParams}
+        asker={user.email}
         classes="max-lg:col-span-full max-lg:w-full"
       />
       <div className="grid col-span-full">
@@ -127,10 +125,10 @@ export default withAuth(function Donations({ user }) {
   );
 });
 
-const csvHeaders: { key: keyof DonationMadeByDonor; label: string }[] = [
-  { key: "amount", label: "Amount" },
-  { key: "usdValue", label: "USD Value" },
+const csvHeaders: { key: keyof DonationRecord; label: string }[] = [
+  { key: "initAmount", label: "Amount" },
+  { key: "initAmountUsd", label: "USD Value" },
   { key: "symbol", label: "Currency" },
   { key: "date", label: "Date" },
-  { key: "hash", label: "Transaction Hash" },
+  { key: "id", label: "Transaction Hash" },
 ];

--- a/src/pages/Donations/types.ts
+++ b/src/pages/Donations/types.ts
@@ -1,7 +1,7 @@
-import { DonationMadeByDonor, DonationsQueryParams } from "types/aws";
+import { DonationRecord, DonationsQueryParams } from "types/aws";
 
 export type TableProps = {
-  donations: DonationMadeByDonor[];
+  donations: DonationRecord[];
   classes?: string;
   onLoadMore(): void;
   hasMore: boolean;

--- a/src/services/apes/donations/donations.ts
+++ b/src/services/apes/donations/donations.ts
@@ -1,12 +1,5 @@
 import { IS_TEST } from "constants/env";
-import {
-  DonationRecord,
-  DonationsQueryParams,
-  PaginatedAWSQueryRes,
-  ReceiptPayload,
-  Token,
-} from "types/aws";
-import { version as v } from "../../helpers";
+import { ReceiptPayload, Token } from "types/aws";
 import { apes } from "../apes";
 
 export const donations_api = apes.injectEndpoints({
@@ -19,21 +12,6 @@ export const donations_api = apes.injectEndpoints({
           url: `crypto-donation/${transactionId}`,
           method: "PUT",
           body: restOfPayload,
-        };
-      },
-    }),
-    donations: builder.query<
-      PaginatedAWSQueryRes<DonationRecord[]>,
-      DonationsQueryParams
-    >({
-      providesTags: ["donations"],
-      query: ({ id, chain_id, status, ...rest }) => {
-        return {
-          url:
-            status === "PENDING"
-              ? `v1/donations/on-hold/${id}`
-              : `${v(3)}/donation/${chain_id}/${id}`,
-          params: rest,
         };
       },
     }),

--- a/src/services/apes/donations/index.ts
+++ b/src/services/apes/donations/index.ts
@@ -1,13 +1,3 @@
 import { donations_api } from "./donations";
 
-export const {
-  useRequestReceiptMutation,
-  useDonationsQuery,
-  useCurrenciesQuery,
-  endpoints: {
-    donations: { useLazyQuery: useLazyDonationsQuery },
-  },
-  util: { updateQueryData: updateDonationsQueryData },
-} = donations_api;
-
-export { default as usePaginatedDonationRecords } from "./usePaginatedDonations";
+export const { useRequestReceiptMutation, useCurrenciesQuery } = donations_api;

--- a/src/services/apes/tags.ts
+++ b/src/services/apes/tags.ts
@@ -1,1 +1,1 @@
-export const tags = ["chain", "donations", "tokens"] as const;
+export const tags = ["chain", "tokens"] as const;

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -210,7 +210,7 @@ export const aws = createApi({
       query: (params) => {
         return {
           url: `${v(1)}/donations`,
-          params: params,
+          params,
           headers: { authorization: TEMP_JWT },
         };
       },

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -211,6 +211,7 @@ export const aws = createApi({
         return {
           url: `${v(1)}/donations`,
           params: params,
+          headers: { authorization: TEMP_JWT },
         };
       },
     }),

--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -9,6 +9,8 @@ import {
   ApplicationDetails,
   ApplicationVerdict,
   ApplicationsQueryParams,
+  DonationRecord,
+  DonationsQueryParams,
   EndowListPaginatedAWSQueryRes,
   Endowment,
   EndowmentCard,
@@ -64,6 +66,7 @@ export const aws = createApi({
     "banking-application",
     "registration",
     "users",
+    "donations",
   ],
   reducerPath: "aws",
   baseQuery: awsBaseQuery,
@@ -199,6 +202,18 @@ export const aws = createApi({
         };
       },
     }),
+    donations: builder.query<
+      { Items: DonationRecord[]; nextPage?: number },
+      DonationsQueryParams
+    >({
+      providesTags: ["donations"],
+      query: (params) => {
+        return {
+          url: `${v(1)}/donations`,
+          params: params,
+        };
+      },
+    }),
   }),
 });
 
@@ -214,6 +229,8 @@ export const {
   useApplicationsQuery,
   useApplicationQuery,
   useReviewApplicationMutation,
+  useDonationsQuery,
+  useLazyDonationsQuery,
   useLazyEndowWithEinQuery,
   endpoints: {
     endowmentCards: { useLazyQuery: useLazyEndowmentCardsQuery },

--- a/src/services/aws/usePaginatedDonations.ts
+++ b/src/services/aws/usePaginatedDonations.ts
@@ -95,8 +95,7 @@ export default function usePaginatedDonationRecords(args: Args) {
     onQueryChange: setQuery,
     status: originalArgs?.status || "final",
     setStatus: (status: DonationsQueryParams["status"]) =>
-      //reset page when switching status (changes table source)
-      setParams((prev) => ({ ...prev, status, page: 1 })),
+      setParams((prev) => ({ ...prev, status })),
     setParams,
   };
 }

--- a/src/slices/donation/sendDonation/index.ts
+++ b/src/slices/donation/sendDonation/index.ts
@@ -5,6 +5,7 @@ import { LogDonationFail } from "errors/errors";
 import { logger } from "helpers";
 import { sendTx } from "helpers/tx";
 import { invalidateApesTags } from "services/apes";
+import { invalidateAwsTags } from "services/aws/aws";
 import { CryptoDonation, GuestDonor } from "types/aws";
 import { isTxResultError } from "types/tx";
 import donation, { setTxStatus } from "../donation";
@@ -66,7 +67,8 @@ export const sendDonation = createAsyncThunk<void, DonateArgs>(
 
       updateTx({ hash, guestDonor });
       //invalidate cache entries
-      dispatch(invalidateApesTags(["tokens", "donations"]));
+      dispatch(invalidateApesTags(["tokens"]));
+      dispatch(invalidateAwsTags(["donations"]));
     } catch (err) {
       logger.error(err);
       updateTx("error");

--- a/src/types/aws/ap/donations.ts
+++ b/src/types/aws/ap/donations.ts
@@ -1,0 +1,61 @@
+import { ChainID } from "types/chain";
+
+type DonorAddress = {
+  line1: string;
+  line2?: string;
+  city?: string;
+  state?: string;
+  zipCode?: string;
+  country: string;
+};
+
+type DonorDetails = {
+  fullName: string;
+  kycEmail?: string;
+  address?: DonorAddress;
+};
+
+export type KYCData = Required<Omit<DonorDetails, "address"> & DonorAddress>;
+
+export type DonationRecord = {
+  id: string;
+
+  //from
+  /** email */
+  donorId: string;
+  donorDetails?: DonorDetails;
+
+  //to
+  /** endow id  */
+  recipientId: number;
+  recipientName: string;
+
+  //details
+  /** ISODate string */
+  date: string;
+  symbol: string;
+  initAmount: number;
+  initAmountUsd?: number;
+  finalAmountUsd?: number;
+  splitLiqPct: number;
+
+  //medium
+  viaId: ChainID | "staging" | "fiat";
+  viaName: string;
+};
+
+export type DonationsQueryParams = {
+  page?: number;
+  /** number of items per page */
+  limit?: number;
+  /** ISOstring */
+  startDate?: string;
+  /** ISOstring */
+  endDate?: string;
+  recipientName?: string;
+  /** id of medium: i.e. chainId for crypto */
+  viaId?: string;
+  symbol?: string;
+  asker: number | string;
+  status?: "final" | "pending";
+};

--- a/src/types/aws/apes/donation.ts
+++ b/src/types/aws/apes/donation.ts
@@ -1,5 +1,4 @@
 import { DonationSource } from "types/lists";
-import { ChainID } from "../../chain";
 
 export type Donor = {
   email: string;
@@ -12,7 +11,7 @@ export type GuestDonor = {
   fullName: string;
 };
 
-export type KYCData = {
+export type ReceiptPayload = {
   fullName: string; // "John Doe"
   kycEmail: string; // "john@doe.email.com"
   streetAddress: string;
@@ -20,50 +19,7 @@ export type KYCData = {
   state: string;
   zipCode: string; //2000
   country: string;
-};
-
-type DonationRecordBase = {
-  amount: number;
-  chainId: ChainID | "staging" | "fiat";
-  date: string;
-  hash: string;
-  symbol: string;
-  kycData?: KYCData;
-};
-
-type DonorAddress = string;
-type RecipientEndowId = string;
-
-export type DonationReceivedByEndow = DonationRecordBase & {
-  id: DonorAddress;
-  //only relevant for now in admin
-  //some record doesn't have this attribute
-  //percent string
-  splitLiq?: string;
-};
-
-export type DonationMadeByDonor = DonationRecordBase & {
-  id: RecipientEndowId;
-  chainName: string;
-  charityName: string;
-  usdValue: number;
-};
-
-export type DonationRecord = DonationReceivedByEndow | DonationMadeByDonor;
-
-export type ReceiptPayload = KYCData & {
   transactionId: string; // tx hash
-};
-export type DonationsQueryParams = {
-  id: string;
-  chain_id: string;
-  afterDate?: string;
-  beforeDate?: string;
-  chainName?: string;
-  denomination?: string;
-  status?: "PENDING" | "RECEIVED";
-  start?: number; //to load next page, set start to ItemCutOff + 1
-  limit?: number; // Number of items to be returned per request
 };
 
 export type CryptoDonation = {

--- a/src/types/aws/index.ts
+++ b/src/types/aws/index.ts
@@ -3,5 +3,6 @@ export * from "./ap";
 export * from "./ap/registration";
 export * from "./ap/applications";
 export * from "./ap/bankDetails";
+export * from "./ap/donations";
 export * from "./apes";
 export * from "./apes/donation";


### PR DESCRIPTION
Closes BG-1249

NOTE: changes for use of `finalAmountUsd` would be on another PR to easily distinguish the changes made to reflect the new donations endpoint

## Explanation of the solution
* reflect changes in 
  * #546
* devops: authorizers are now applied to `GET (v1 | staging) / donations` 
* kindly see change comments for details

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
