### PR TITLE
BG-1256 Environ adaptable WP API URLs

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,9 +1,11 @@
-import { BASE_URL, ENVIRONMENT } from "./env";
+import { BASE_URL, ENVIRONMENT, IS_TEST } from "./env";
 
 export const APIs = {
   aws: "https://kpnxz5rzo2.execute-api.us-east-1.amazonaws.com",
   apes: `https://fctqkloitc.execute-api.us-east-1.amazonaws.com/${ENVIRONMENT}`,
-  wordpress: "https://angelgiving-dev.10web.site/wp-json/wp/v2",
+  wordpress: IS_TEST
+    ? "https://angelgiving-dev.10web.site/wp-json/wp/v2"
+    : "34.29.12.245",
 };
 
 export const LITEPAPER = `${BASE_URL}/docs/litepaper-introduction/`;


### PR DESCRIPTION
## Explanation of the solution
Adds logic to handle switching the WP API URL used when server is in dev vs. prod setup (using the env constant `IS_TEST` var).

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
N/A