### PR TITLE
hide paypal & OR separator if the env var is the empty default

### DIFF
--- a/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Paypal.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Paypal.tsx
@@ -36,7 +36,7 @@ export default function Paypal(props: StripeCheckoutStep) {
 
   return isLoading ? (
     <ContentLoader className="rounded h-10 w-40" />
-  ) : isError || !orderId ? (
+  ) : isError || !orderId || PAYPAL_CLIENT_ID === "" ? (
     <div id="paypal-failure-fallback" className="hidden" />
   ) : (
     <PayPalScriptProvider


### PR DESCRIPTION
## Explanation of the solution
If PayPal env var is empty string fallback, hide the paypal area & it's separator. 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
None