### PR TITLE
Avoid layout shift 

### DIFF
--- a/src/App/Header/index.tsx
+++ b/src/App/Header/index.tsx
@@ -6,26 +6,24 @@ import NavDropdown from "./NavDropdown";
 import UserMenu from "./UserMenu";
 import useHeaderClassNames from "./useHeaderClassNames";
 
-type Props = { links: Link[] };
+type Props = { links: Link[]; classes?: string };
 
-export default function Header({ links }: Props) {
+export default function Header({ links, classes }: Props) {
   const location = useLocation();
-  const headerClassNames = useHeaderClassNames();
+  const headerClassNames = useHeaderClassNames(classes);
 
   return (
     <header className={headerClassNames}>
-      <div className="px-0 md:py-2 h-full w-full bg-white">
-        <div className="grid grid-cols-2 gap-4 padded-container">
-          <DappLogo classes="w-48 h-12" />
-          <div className="flex gap-2 md:gap-4 justify-self-end items-center">
-            {!(
-              location.pathname === appRoutes.signin ||
-              location.pathname === appRoutes.signup ||
-              location.pathname === appRoutes.reset_password ||
-              location.pathname === appRoutes.auth_redirector
-            ) && <UserMenu />}
-            <NavDropdown links={links} />
-          </div>
+      <div className="grid items-center grid-cols-2 gap-4 padded-container">
+        <DappLogo classes="w-48 h-12" />
+        <div className="flex gap-2 md:gap-4 justify-self-end items-center">
+          {!(
+            location.pathname === appRoutes.signin ||
+            location.pathname === appRoutes.signup ||
+            location.pathname === appRoutes.reset_password ||
+            location.pathname === appRoutes.auth_redirector
+          ) && <UserMenu />}
+          <NavDropdown links={links} />
         </div>
       </div>
     </header>

--- a/src/App/Header/useHeaderClassNames.ts
+++ b/src/App/Header/useHeaderClassNames.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-export default function useHeaderClassNames() {
+export default function useHeaderClassNames(classes = "") {
   // The ref is used to compare the current and previous bool value
   // instead of the state (for the previous value); the reason is that
   // this makes it unnecessary to add the state value to the below useEffect's
@@ -22,7 +22,7 @@ export default function useHeaderClassNames() {
     };
   }, []);
 
-  return `sticky top-0 transition ease-in-out duration-100 z-20 w-full ${
+  return `${classes} grid bg-white transition ease-in-out duration-100 w-full ${
     isScrolled ? "shadow-lg" : ""
   }`;
 }

--- a/src/App/Layout.tsx
+++ b/src/App/Layout.tsx
@@ -12,7 +12,7 @@ const { GROUPS_DATA, SOCIAL_MEDIA_LINKS } = CHARITY_LINKS;
 export default function Layout() {
   const headerLinks = useHeaderLinks();
   return (
-    <div className="grid grid-rows-[auto_1fr_auto]">
+    <div className="grid grid-rows-[4rem_minmax(calc(100vh-4rem),1fr)_auto]">
       <Seo /> {/* Load all defaults for SEO meta tags */}
       <Header links={headerLinks} /> {/* sticky component, not part of grid */}
       <Suspense fallback={<LoaderComponent />}>

--- a/src/App/Layout.tsx
+++ b/src/App/Layout.tsx
@@ -12,7 +12,7 @@ const { GROUPS_DATA, SOCIAL_MEDIA_LINKS } = CHARITY_LINKS;
 export default function Layout() {
   const headerLinks = useHeaderLinks();
   return (
-    <div className="grid grid-rows-[4rem_minmax(calc(100vh-4rem),1fr)_auto]">
+    <div className="grid grid-rows-[4rem_minmax(calc(100dvh-4rem),1fr)_auto]">
       <Seo /> {/* Load all defaults for SEO meta tags */}
       <Header links={headerLinks} classes="sticky top-0 z-20" />
       <Suspense fallback={<LoaderComponent />}>

--- a/src/App/Layout.tsx
+++ b/src/App/Layout.tsx
@@ -14,7 +14,7 @@ export default function Layout() {
   return (
     <div className="grid grid-rows-[4rem_minmax(calc(100vh-4rem),1fr)_auto]">
       <Seo /> {/* Load all defaults for SEO meta tags */}
-      <Header links={headerLinks} /> {/* sticky component, not part of grid */}
+      <Header links={headerLinks} classes="sticky top-0 z-20" />
       <Suspense fallback={<LoaderComponent />}>
         <Outlet />
       </Suspense>

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400&family=Quicksand:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>
-  <body class="grid min-h-screen">
+  <body class="grid min-h-dvh">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root" class="grid min-h-screen"></div>
     <script src="/scripts/intercom.js"></script>

--- a/src/pages/Donate/index.tsx
+++ b/src/pages/Donate/index.tsx
@@ -22,6 +22,8 @@ export default function Donate() {
     "hide_bg_tip",
   ]);
 
+  queryState.isLoading = true;
+
   return (
     <QueryLoader
       queryState={queryState}
@@ -29,7 +31,7 @@ export default function Donate() {
         loading: "Getting nonprofit info..",
         error: "Failed to get nonprofit info",
       }}
-      classes={{ container: "justify-self-center text-center mt-8" }}
+      classes={{ container: "place-self-center text-center mt-8" }}
     >
       {(profile) => (
         <>

--- a/src/pages/Donate/index.tsx
+++ b/src/pages/Donate/index.tsx
@@ -22,8 +22,6 @@ export default function Donate() {
     "hide_bg_tip",
   ]);
 
-  queryState.isLoading = true;
-
   return (
     <QueryLoader
       queryState={queryState}


### PR DESCRIPTION
## Explanation of the solution
* set initial content height to a minimum of `100dvh - headerHeight`
```
-----------|-- screen start
header     |
-----------|
           |
content    |
           |
-----------|-- screen end
footer     |


```

footer would always be the next thing the user see when first scrolling (unless content is longer than what is initially set)
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/115fdbbe-d2d3-48fb-ac2c-7f78dd33aaae)


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
