### PR TITLE
Follow up fix to reimplemented donations query

### DIFF
--- a/src/services/aws/usePaginatedDonations.ts
+++ b/src/services/aws/usePaginatedDonations.ts
@@ -27,6 +27,7 @@ export default function usePaginatedDonationRecords(args: Args) {
 
   const [params, setParams] = useState<DonationsQueryParams>({
     asker: id,
+    status: "final",
   });
 
   const queryState = useDonationsQuery(params, {


### PR DESCRIPTION
BUG report
* https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/2853#discussion_r1557216346

* init donations where loaded under cache key `{asker}`
* but when switching tabs, donations are loaded with cache key `{asker, status}` - a mistmatch from the key of initially loaded data

## Explanation of the solution
* init query with args `{asker,status: "final"}` 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
