### PR TITLE
BG-1278 Fix WP URL

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -3,9 +3,9 @@ import { BASE_URL, ENVIRONMENT, IS_TEST } from "./env";
 export const APIs = {
   aws: "https://kpnxz5rzo2.execute-api.us-east-1.amazonaws.com",
   apes: `https://fctqkloitc.execute-api.us-east-1.amazonaws.com/${ENVIRONMENT}`,
-  wordpress: IS_TEST
-    ? "https://angelgiving-dev.10web.site/wp-json/wp/v2"
-    : "34.29.12.245",
+  wordpress: `https://${
+    IS_TEST ? "angelgiving-dev.10web.site" : "34.29.12.245"
+  }/wp-json/wp/v2`,
 };
 
 export const LITEPAPER = `${BASE_URL}/docs/litepaper-introduction/`;


### PR DESCRIPTION
## Problem at hand 
Blog related items were not being fetched in prod. 

## Explanation of the solution
Turned out the WP url was missing the needed suffix parts of the URL. :facepalm:

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp

## UI changes for review
None