### PR TITLE
Donate page: Create PayPal order (donation intent) only on button click

### DIFF
--- a/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Checkout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Checkout.tsx
@@ -79,8 +79,8 @@ export default function Checkout(props: StripeCheckoutStep) {
               }
             }
           }}
-          createOrder={async () => {
-            const orderId = await createOrder({
+          createOrder={async () =>
+            await createOrder({
               amount: +details.amount,
               tipAmount: tip,
               usdRate: details.currency.rate,
@@ -89,9 +89,8 @@ export default function Checkout(props: StripeCheckoutStep) {
               splitLiq: liquidSplitPct,
               donor,
               source: details.source,
-            }).unwrap();
-            return orderId;
-          }}
+            }).unwrap()
+          }
         />
       )}
     </>

--- a/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Checkout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Checkout.tsx
@@ -7,19 +7,17 @@ import { isEmpty } from "helpers";
 import { DonateFiatThanksState } from "pages/DonateFiatThanks";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useCapturePayPalOrderMutation } from "services/apes";
-import { DonationRecipient } from "slices/donation";
-import { DonationSource } from "types/lists";
-
-type Props = {
-  orderId: string;
-  recipient: DonationRecipient;
-  source: DonationSource;
-};
+import {
+  useCapturePayPalOrderMutation,
+  usePaypalOrderMutation,
+} from "services/apes";
+import { StripeCheckoutStep } from "slices/donation";
 
 // Code inspired by React Stripe.js docs, see:
 // https://stripe.com/docs/stripe-js/react#useelements-hook
-export default function Checkout({ orderId, recipient, source }: Props) {
+export default function Checkout(props: StripeCheckoutStep) {
+  const { details, recipient, liquidSplitPct, tip = 0, donor } = props;
+
   const navigate = useNavigate();
 
   const [isSubmitting, setSubmitting] = useState(false);
@@ -27,6 +25,8 @@ export default function Checkout({ orderId, recipient, source }: Props) {
   const [{ isPending }] = usePayPalScriptReducer();
   const [captureOrder] = useCapturePayPalOrderMutation();
   const { handleError } = useErrorContext();
+
+  const [createOrder, { isLoading }] = usePaypalOrderMutation();
 
   return (
     <>
@@ -41,54 +41,58 @@ export default function Checkout({ orderId, recipient, source }: Props) {
             height: 40,
           }}
           className="w-40 flex gap-2"
-          disabled={isSubmitting}
+          disabled={isSubmitting || isLoading}
           onCancel={() => setSubmitting(false)}
           onError={(error) => {
             setSubmitting(false);
-            handleError(error);
+            handleError(error, GENERIC_ERROR_MESSAGE);
           }}
           onApprove={async (data, actions) => {
-            try {
-              const order = await captureOrder({
-                orderId: data.orderID,
-              }).unwrap();
+            const order = await captureOrder({
+              orderId: data.orderID,
+            }).unwrap();
 
-              if ("details" in order) {
-                if (order.details[0]?.issue === "INSTRUMENT_DECLINED") {
-                  // (1) Recoverable INSTRUMENT_DECLINED -> call actions.restart()
-                  // recoverable state, per https://developer.paypal.com/docs/checkout/standard/customize/handle-funding-failures/
-                  return actions.restart();
-                } else if ("debug_id" in order) {
-                  // (2) Other non-recoverable errors -> Show a failure message
-                  throw new Error(
-                    `${order.details[0]?.description} (${order.debug_id})`
-                  );
-                }
-              } else if (isEmpty(order.purchase_units ?? [])) {
-                throw new Error(JSON.stringify(order));
-              } else {
-                //accessed by redirect page
-                const state: DonateFiatThanksState = {
-                  guestDonor: order.guestDonor,
-                  recipientName: recipient.name,
-                };
-                if (source === "bg-widget") {
-                  navigate(
-                    `${appRoutes.donate_widget}/${donateWidgetRoutes.donate_fiat_thanks}`,
-                    { state }
-                  );
-                } else {
-                  navigate(appRoutes.donate_fiat_thanks, { state });
-                }
+            if ("details" in order) {
+              if (order.details[0]?.issue === "INSTRUMENT_DECLINED") {
+                // (1) Recoverable INSTRUMENT_DECLINED -> call actions.restart()
+                // recoverable state, per https://developer.paypal.com/docs/checkout/standard/customize/handle-funding-failures/
+                return actions.restart();
+              } else if ("debug_id" in order) {
+                // (2) Other non-recoverable errors -> Show a failure message
+                throw new Error(
+                  `${order.details[0]?.description} (${order.debug_id})`
+                );
               }
-            } catch (error) {
-              handleError(error, GENERIC_ERROR_MESSAGE);
-            } finally {
-              setSubmitting(false);
+            } else if (isEmpty(order.purchase_units ?? [])) {
+              throw new Error(JSON.stringify(order));
+            } else {
+              //accessed by redirect page
+              const state: DonateFiatThanksState = {
+                guestDonor: order.guestDonor,
+                recipientName: recipient.name,
+              };
+              if (details.source === "bg-widget") {
+                navigate(
+                  `${appRoutes.donate_widget}/${donateWidgetRoutes.donate_fiat_thanks}`,
+                  { state }
+                );
+              } else {
+                navigate(appRoutes.donate_fiat_thanks, { state });
+              }
             }
           }}
           createOrder={async () => {
             setSubmitting(true);
+            const orderId = await createOrder({
+              amount: +details.amount,
+              tipAmount: tip,
+              usdRate: details.currency.rate,
+              currency: details.currency.code,
+              endowmentId: recipient.id,
+              splitLiq: liquidSplitPct,
+              donor,
+              source: details.source,
+            }).unwrap();
             return orderId;
           }}
         />

--- a/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Paypal.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Paypal.tsx
@@ -1,59 +1,24 @@
 import { PayPalScriptProvider } from "@paypal/react-paypal-js";
-import ContentLoader from "components/ContentLoader";
 import { PAYPAL_CLIENT_ID } from "constants/env";
-import { logger } from "helpers";
-import { useEffect } from "react";
-import { usePaypalOrderQuery } from "services/apes";
 import { StripeCheckoutStep } from "slices/donation";
 import Checkout from "./Checkout";
 
-// Followed Stripe's custom flow docs
-// https://stripe.com/docs/payments/quickstart
+// https://paypal.github.io/react-paypal-js/?path=/docs/example-paypalbuttons--default
 export default function Paypal(props: StripeCheckoutStep) {
-  const { details, recipient, liquidSplitPct, tip = 0, donor } = props;
-
-  const {
-    data: orderId,
-    isLoading,
-    isError,
-    error,
-  } = usePaypalOrderQuery({
-    amount: +details.amount,
-    tipAmount: tip,
-    usdRate: details.currency.rate,
-    currency: details.currency.code,
-    endowmentId: recipient.id,
-    splitLiq: liquidSplitPct,
-    donor,
-    source: details.source,
-  });
-
-  useEffect(() => {
-    if (error) {
-      logger.error(error);
-    }
-  }, [error]);
-
-  return isLoading ? (
-    <ContentLoader className="rounded h-10 w-40" />
-  ) : isError || !orderId || PAYPAL_CLIENT_ID === "" ? (
+  return PAYPAL_CLIENT_ID === "" ? (
     <div id="paypal-failure-fallback" className="hidden" />
   ) : (
     <PayPalScriptProvider
       options={{
         clientId: PAYPAL_CLIENT_ID,
         commit: true,
-        currency: details.currency.code.toUpperCase(),
+        currency: props.details.currency.code.toUpperCase(),
         enableFunding: "paylater",
         disableFunding: "card,venmo",
       }}
     >
       <div className="flex items-center gap-2">
-        <Checkout
-          orderId={orderId}
-          source={details.source}
-          recipient={recipient}
-        />
+        <Checkout {...props} />
       </div>
     </PayPalScriptProvider>
   );

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -62,7 +62,7 @@ export const apes = createApi({
           rate: c.rate,
         })),
     }),
-    paypalOrder: builder.query<string, CreatePayPalOrderParams>({
+    paypalOrder: builder.mutation<string, CreatePayPalOrderParams>({
       query: (params) => ({
         url: `v1/fiat/paypal/${apiEnv}/orders`,
         method: "POST",
@@ -103,7 +103,7 @@ export const {
   useCapturePayPalOrderMutation,
   useFiatCurrenciesQuery,
   useStripePaymentIntentQuery,
-  usePaypalOrderQuery,
+  usePaypalOrderMutation,
   useEndowBalanceQuery,
   useGetStripePaymentStatusQuery,
   useTokensQuery,

--- a/src/types/aws/ap/donations.ts
+++ b/src/types/aws/ap/donations.ts
@@ -57,5 +57,5 @@ export type DonationsQueryParams = {
   viaId?: string;
   symbol?: string;
   asker: number | string;
-  status?: "final" | "pending";
+  status?: "final" | "pending" | "intent";
 };

--- a/src/types/aws/ap/donations.ts
+++ b/src/types/aws/ap/donations.ts
@@ -57,5 +57,5 @@ export type DonationsQueryParams = {
   viaId?: string;
   symbol?: string;
   asker: number | string;
-  status?: "final" | "pending" | "intent";
+  status?: "final" | "pending";
 };


### PR DESCRIPTION
## Explanation of the solution
Towards BG-1243

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- sign in
- go to http://localhost:4200/donate/53
- open browser console
- get to fiat checkout page
- **verify in browser console no PayPal order is created on page load, only for Stripe**
- click on "PayPal" button
- **verify in browser console PayPal order is created at this point**
- donate with PayPal
- go to http://localhost:4200/donations
- **verify 2 donation intents were created - one for Stripe and one for PayPal**