### PR TITLE
Incorrect card sizes

### DIFF
--- a/src/pages/Blog/Post.tsx
+++ b/src/pages/Blog/Post.tsx
@@ -7,7 +7,7 @@ import { usePostQuery, useUserQuery } from "services/wordpress";
 import { Wordpress } from "types/wordpress";
 import Media from "./Media";
 
-const containerStyle = "padded-container max-w-4xl mx-auto pb-4";
+const containerStyle = "w-full padded-container max-w-4xl mx-auto pb-4";
 
 export default function Post() {
   const { slug = "" } = useParams<{ slug: string }>();

--- a/src/pages/Blog/Posts.tsx
+++ b/src/pages/Blog/Posts.tsx
@@ -75,7 +75,7 @@ const Cards = (props: { posts: Wordpress.Post[] }) =>
       <Media
         sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, 33vw"
         id={post.featured_media}
-        classes="h-32 sm:h-60 w-full object-cover"
+        classes="w-full"
       />
       <div className="flex flex-col p-4 gap-3">
         <h2

--- a/src/pages/Blog/Posts.tsx
+++ b/src/pages/Blog/Posts.tsx
@@ -75,7 +75,7 @@ const Cards = (props: { posts: Wordpress.Post[] }) =>
       <Media
         sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, 33vw"
         id={post.featured_media}
-        classes="w-full"
+        classes="w-full md:h-44 md:object-fill"
       />
       <div className="flex flex-col p-4 gap-3">
         <h2


### PR DESCRIPTION
## Explanation of the solution
* for smaller card sizes (multiple cards per row, where card  title alignment matters ) just fill the standard (uniform height) card image area
<img width="491" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/0a4d01b9-84d4-444d-bb73-72385ce76c1d">

<img width="603" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/858f21ba-1111-499a-b72b-20005aa6602f">


* for wide card sizes (single card per rwo), just let the browser pick from srcset and sizes provided and use the rendered size
<img width="386" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/5e440c60-acdc-491e-992a-70363f9aa61a">



## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
