### PR TITLE
Remove `usdRate` from fiat donation payload and update PayPal proxy endpoint

### DIFF
--- a/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Checkout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/Paypal/Checkout.tsx
@@ -79,7 +79,6 @@ export default function Checkout(props: StripeCheckoutStep) {
         await createOrder({
           amount: +details.amount,
           tipAmount: tip,
-          usdRate: details.currency.rate,
           currency: details.currency.code,
           endowmentId: recipient.id,
           splitLiq: liquidSplitPct,

--- a/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
@@ -28,7 +28,6 @@ export default function StripeCheckout(props: StripeCheckoutStep) {
     type: details.frequency === "once" ? "one-time" : "subscription",
     amount: +details.amount,
     tipAmount: tip,
-    usdRate: details.currency.rate,
     currency: details.currency.code,
     endowmentId: recipient.id,
     splitLiq: liquidSplitPct,

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -45,7 +45,7 @@ export const apes = createApi({
   endpoints: (builder) => ({
     capturePayPalOrder: builder.mutation<PayPalOrder, { orderId: string }>({
       query: (params) => ({
-        url: `v1/fiat/paypal/${apiEnv}/orders/${params.orderId}/capture`,
+        url: `fiat-donation/paypal/orders/${params.orderId}/capture`,
         method: "POST",
         headers: { authorization: TEMP_JWT },
       }),
@@ -63,7 +63,7 @@ export const apes = createApi({
     }),
     paypalOrder: builder.mutation<string, CreatePayPalOrderParams>({
       query: (params) => ({
-        url: `v1/fiat/paypal/${apiEnv}/orders`,
+        url: "fiat-donation/paypal/orders",
         method: "POST",
         headers: { authorization: TEMP_JWT },
         body: JSON.stringify(params),

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -21,7 +21,6 @@ type FiatDonation = {
   /** Denominated in USD. */
   amount: number;
   tipAmount: number;
-  usdRate: number;
   /**ISO 3166-1 alpha-3 code. */
   currency: string;
   endowmentId: number;


### PR DESCRIPTION
Related to BG-1261

## Explanation of the solution
Due to AWS proxy Lambdas usage of `getUsdRate()` helper, the web app does not need to send `usdRate` into the payload anymore. Another update is to use stage variables for the PayPal proxy endpoint.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- test fiat donations and check if payment intents/orders are created

## UI changes for review
No major UI change.