### PR TITLE
Include tip amount to crypto donation

### DIFF
--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
@@ -20,15 +20,15 @@ export default function TxSubmit({ wallet, donation, classes = "" }: Props) {
   const dispatch = useSetter();
   const [estimate, setEstimate] = useState<EstimateStatus>();
 
-  const { details } = donation;
+  const { details, tip } = donation;
   const sender = wallet?.address;
   useEffect(() => {
     if (!sender) return setEstimate(undefined);
     setEstimate("loading");
-    estimateDonation(details.token, details.chainId.value, sender).then(
+    estimateDonation(details.token, details.chainId.value, sender, tip).then(
       (estimate) => setEstimate(estimate)
     );
-  }, [sender, details]);
+  }, [sender, details, tip]);
 
   return (
     <div className={classes + " grid w-full gap-y-2"}>

--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/estimateDonation.ts
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/estimateDonation.ts
@@ -14,7 +14,8 @@ import { tokenBalance } from "./tokenBalance";
 export async function estimateDonation(
   token: TokenWithAmount,
   chainID: ChainID,
-  sender: string
+  sender: string,
+  tipAmount = 0
 ): Promise<Exclude<EstimateStatus, "loading">> {
   try {
     const balance = await tokenBalance(token, chainID, sender);
@@ -22,13 +23,15 @@ export async function estimateDonation(
       return { error: "Not enough balance" };
     }
 
+    const grossAmount = +token.amount + tipAmount;
+
     let toEstimate: EstimateInput;
     // ///////////// GET TX CONTENT ///////////////
 
     switch (chainID) {
       case "juno-1":
       case "uni-6": {
-        const scaledAmount = scaleToStr(token.amount, token.decimals);
+        const scaledAmount = scaleToStr(grossAmount, token.decimals);
         const to = apWallets.junoDeposit;
         const msg =
           token.type === "juno-native" || token.type === "ibc"
@@ -49,7 +52,7 @@ export async function estimateDonation(
 
       case "pisco-1":
       case "phoenix-1": {
-        const scaledAmount = scaleToStr(token.amount, token.decimals);
+        const scaledAmount = scaleToStr(grossAmount, token.decimals);
         const msg =
           token.type === "terra-native" || token.type === "ibc"
             ? new MsgSend(sender, apWallets.terra, [
@@ -67,7 +70,7 @@ export async function estimateDonation(
       //evm chains
       default: {
         const tx: SimulSendNativeTx | SimulContractTx = (() => {
-          const scaledAmount = scale(token.amount, token.decimals).toHex();
+          const scaledAmount = scale(grossAmount, token.decimals).toHex();
 
           switch (token.type) {
             case "evm-native":


### PR DESCRIPTION
Resolves BG-1291

## Explanation of the solution
When donating crypto and a tip is included, the actual transfer transaction's amount does not include the tip amount. However, the DB record does include the tip amount. This might introduce some "not enough tokens error" later on if left unchecked.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- try to donate with tip included and verify that the gross amount for the transfer includes the tip

## UI changes for review
No major UI changes.