### PR TITLE
Default currency

### DIFF
--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -2,8 +2,6 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import CurrencySelector from "components/CurrencySelector";
 import QueryLoader from "components/QueryLoader";
 import { Field, Form as FormContainer } from "components/form";
-import ErrorBoundary from "errors/ErrorBoundary";
-import ErrorTrigger from "errors/ErrorTrigger";
 import { useController, useForm } from "react-hook-form";
 import { schema, stringNumber } from "schemas/shape";
 import { requiredString } from "schemas/string";
@@ -20,17 +18,15 @@ const USD_CODE = "usd";
 export default function Loader(props: Props) {
   const query = useFiatCurrenciesQuery();
   return (
-    <ErrorBoundary>
-      <QueryLoader
-        queryState={query}
-        messages={{
-          loading: "loading donate form",
-          error: <ErrorTrigger error={query.error} />,
-        }}
-      >
-        {(data) => <Form {...props} {...data} />}
-      </QueryLoader>
-    </ErrorBoundary>
+    <QueryLoader
+      queryState={query}
+      messages={{
+        loading: "loading donate form",
+        error: "failed to load donate form",
+      }}
+    >
+      {(data) => <Form {...props} {...data} />}
+    </QueryLoader>
   );
 }
 

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -54,7 +54,7 @@ export const apes = createApi({
       { currencies: DetailedCurrency[]; defaultCurr?: DetailedCurrency },
       void
     >({
-      query: () => "fiat-currencies",
+      query: () => ({ url: "fiat-currencies", credentials: "include" }),
       transformResponse: (res: FiatCurrencyData) => {
         const toDetailed = (
           input: FiatCurrencyData["currencies"][number]

--- a/src/types/aws/apes/donation.ts
+++ b/src/types/aws/apes/donation.ts
@@ -37,13 +37,15 @@ export type CryptoDonation = {
   donor: Donor;
 };
 
+type Currency = {
+  /** ISO 3166-1 alpha-3 code */
+  currency_code: string;
+  minimum_amount: number;
+  /** unit/usd */
+  rate: number;
+};
+
 export type FiatCurrencyData = {
-  currencies: {
-    /** ISO 3166-1 alpha-3 code */
-    currency_code: string;
-    minimum_amount: number;
-    /** unit/usd */
-    rate: number;
-    timestamp: string;
-  }[];
+  default?: Currency;
+  currencies: Currency[];
 };


### PR DESCRIPTION
Towards BG-1283
## Explanation of the solution
* reflect https://github.com/AngelProtocolFinance/devops/pull/555

### workings
- when loading the page from `better.giving`, cookie `bg_pref_currency` is `NOT` yet set (nor is being set while requesting the page)
- when user goes to `better.giving/donate/x`, cookie `bg_pref_currency` is also not set as going to this route is essentially client side (via `react-router`, and no request to the server is made )
- after `better.giving/donate/x` is rendered, it's the only time it requests for `GET apes/fiat-currencies` which `Response` header `Set-Cookie` has value `bg_pref_currency=PHP`(example) - and is now written to cookies
<img width="647" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/b56fd96f-7e01-4f6c-97b5-e6d00627d12d">

- when user reloads the page, `cookie.bg_pref_currency` is already present (if not deleted), and is included when quering `GET apes/fiat-currencies` via `credentials: "include"` header.  This means server don't need to get user's preference by getting ip address
<img width="519" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/5f07219e-d9bb-40cf-9b98-61c320e628e2">







## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
