### PR TITLE
BG-1243: create crypto intents on Checkout page load + confirm crypto intents on success

### DIFF
--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
@@ -85,7 +85,7 @@ export default function TxSubmit({ wallet, donation, classes = "" }: Props) {
   ]);
 
   return (
-    <div className={classes + " grid w-full gap-y-2"}>
+    <div className={`${classes} grid w-full gap-y-2`}>
       {/** estimate tooltip */}
       {estimate &&
         (estimate === "loading" ? (

--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
@@ -1,10 +1,17 @@
 import Icon from "components/Icon/Icon";
 import { ErrorStatus, LoadingStatus } from "components/Status";
+import { chains } from "constants/chains";
+import { useErrorContext } from "contexts/ErrorContext";
 import { humanize } from "helpers";
 import { useEffect, useState } from "react";
+import {
+  useConfirmCryptoIntentMutation,
+  useCreateCryptoIntentMutation,
+} from "services/apes";
 import { CryptoSubmitStep } from "slices/donation";
 import { sendDonation } from "slices/donation/sendDonation";
 import { useSetter } from "store/accessors";
+import { CryptoDonation } from "types/aws";
 import { ConnectedWallet } from "types/wallet";
 import ContinueBtn from "../../../common/ContinueBtn";
 import { EstimateStatus, isSuccess } from "../types";
@@ -19,8 +26,12 @@ type Props = {
 export default function TxSubmit({ wallet, donation, classes = "" }: Props) {
   const dispatch = useSetter();
   const [estimate, setEstimate] = useState<EstimateStatus>();
+  const [transactionId, setTransactionId] = useState<string>();
 
-  const { details } = donation;
+  const { handleError } = useErrorContext();
+
+  const { details, recipient, liquidSplitPct, tip = 0, donor } = donation;
+  const chain = chains[details.chainId.value];
   const sender = wallet?.address;
   useEffect(() => {
     if (!sender) return setEstimate(undefined);
@@ -29,6 +40,49 @@ export default function TxSubmit({ wallet, donation, classes = "" }: Props) {
       (estimate) => setEstimate(estimate)
     );
   }, [sender, details]);
+
+  const [createCryptoIntent] = useCreateCryptoIntentMutation();
+  const [confirmCryptoIntent] = useConfirmCryptoIntentMutation();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (!wallet?.address) {
+          return;
+        }
+
+        const payload: CryptoDonation = {
+          amount: +details.token.amount,
+          tipAmount: tip,
+          chainId: chain.id,
+          chainName: chain.name,
+          denomination: details.token.symbol,
+          splitLiq: liquidSplitPct,
+          walletAddress: wallet.address,
+          endowmentId: recipient.id,
+          source: details.source,
+          donor,
+        };
+        const id = await createCryptoIntent(payload).unwrap();
+        setTransactionId(id);
+      } catch (err) {
+        handleError(err);
+      }
+    })();
+  }, [
+    details.token.amount,
+    details.token.symbol,
+    details.source,
+    recipient.id,
+    liquidSplitPct,
+    chain.id,
+    chain.name,
+    tip,
+    donor,
+    wallet?.address,
+    createCryptoIntent,
+    handleError,
+  ]);
 
   return (
     <div className={classes + " grid w-full gap-y-2"}>
@@ -52,17 +106,23 @@ export default function TxSubmit({ wallet, donation, classes = "" }: Props) {
       <ContinueBtn
         type="button"
         onClick={
-          wallet && estimate && isSuccess(estimate)
+          wallet && transactionId && estimate && isSuccess(estimate)
             ? () => {
                 const action = sendDonation({
-                  donation,
+                  onSuccess: (txHash) =>
+                    confirmCryptoIntent({
+                      txHash,
+                      txId: transactionId,
+                    }).unwrap(),
                   ...txPackage(estimate, wallet),
                 });
                 dispatch(action);
               }
             : undefined
         }
-        disabled={!wallet || !estimate || !isSuccess(estimate)}
+        disabled={
+          !transactionId || !wallet || !estimate || !isSuccess(estimate)
+        }
       />
     </div>
   );

--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
@@ -1,22 +1,17 @@
 import Icon from "components/Icon/Icon";
 import { ErrorStatus, LoadingStatus } from "components/Status";
-import { chains } from "constants/chains";
-import { useErrorContext } from "contexts/ErrorContext";
 import { humanize } from "helpers";
 import { useEffect, useState } from "react";
-import {
-  useConfirmCryptoIntentMutation,
-  useCreateCryptoIntentMutation,
-} from "services/apes";
+import { useConfirmCryptoIntentMutation } from "services/apes";
 import { CryptoSubmitStep } from "slices/donation";
 import { sendDonation } from "slices/donation/sendDonation";
 import { useSetter } from "store/accessors";
-import { CryptoDonation } from "types/aws";
 import { ConnectedWallet } from "types/wallet";
 import ContinueBtn from "../../../common/ContinueBtn";
 import { EstimateStatus, isSuccess } from "../types";
 import { estimateDonation } from "./estimateDonation";
 import { txPackage } from "./txPackage";
+import useCreateCryptoIntent from "./useCreateCryptoIntent";
 
 type Props = {
   classes?: string;
@@ -26,12 +21,8 @@ type Props = {
 export default function TxSubmit({ wallet, donation, classes = "" }: Props) {
   const dispatch = useSetter();
   const [estimate, setEstimate] = useState<EstimateStatus>();
-  const [transactionId, setTransactionId] = useState<string>();
 
-  const { handleError } = useErrorContext();
-
-  const { details, recipient, liquidSplitPct, tip = 0, donor } = donation;
-  const chain = chains[details.chainId.value];
+  const { details } = donation;
   const sender = wallet?.address;
   useEffect(() => {
     if (!sender) return setEstimate(undefined);
@@ -41,48 +32,9 @@ export default function TxSubmit({ wallet, donation, classes = "" }: Props) {
     );
   }, [sender, details]);
 
-  const [createCryptoIntent] = useCreateCryptoIntentMutation();
   const [confirmCryptoIntent] = useConfirmCryptoIntentMutation();
 
-  useEffect(() => {
-    (async () => {
-      try {
-        if (!wallet?.address) {
-          return;
-        }
-
-        const payload: CryptoDonation = {
-          amount: +details.token.amount,
-          tipAmount: tip,
-          chainId: chain.id,
-          chainName: chain.name,
-          denomination: details.token.symbol,
-          splitLiq: liquidSplitPct,
-          walletAddress: wallet.address,
-          endowmentId: recipient.id,
-          source: details.source,
-          donor,
-        };
-        const id = await createCryptoIntent(payload).unwrap();
-        setTransactionId(id);
-      } catch (err) {
-        handleError(err);
-      }
-    })();
-  }, [
-    details.token.amount,
-    details.token.symbol,
-    details.source,
-    recipient.id,
-    liquidSplitPct,
-    chain.id,
-    chain.name,
-    tip,
-    donor,
-    wallet?.address,
-    createCryptoIntent,
-    handleError,
-  ]);
+  const transactionId = useCreateCryptoIntent(donation, wallet);
 
   return (
     <div className={`${classes} grid w-full gap-y-2`}>

--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/useCreateCryptoIntent.ts
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/useCreateCryptoIntent.ts
@@ -1,0 +1,63 @@
+import { chains } from "constants/chains";
+import { useErrorContext } from "contexts/ErrorContext";
+import { useEffect, useState } from "react";
+import { useCreateCryptoIntentMutation } from "services/apes";
+import { CryptoSubmitStep } from "slices/donation";
+import { CryptoDonation } from "types/aws";
+import { ConnectedWallet } from "types/wallet";
+
+export default function useCreateCryptoIntent(
+  donation: CryptoSubmitStep,
+  wallet?: ConnectedWallet
+) {
+  const [transactionId, setTransactionId] = useState<string>();
+
+  const [createCryptoIntent] = useCreateCryptoIntentMutation();
+  const { handleError } = useErrorContext();
+
+  const { details, recipient, liquidSplitPct, tip = 0, donor } = donation;
+
+  const chain = chains[details.chainId.value];
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (!wallet?.address) {
+          return;
+        }
+
+        const payload: CryptoDonation = {
+          amount: +details.token.amount,
+          tipAmount: tip,
+          chainId: chain.id,
+          chainName: chain.name,
+          denomination: details.token.symbol,
+          splitLiq: liquidSplitPct,
+          walletAddress: wallet.address,
+          endowmentId: recipient.id,
+          source: details.source,
+          donor,
+        };
+        const id = await createCryptoIntent(payload).unwrap();
+        setTransactionId(id);
+      } catch (err) {
+        handleError(err);
+      }
+    })();
+  }, [
+    details.token.amount,
+    details.token.symbol,
+    details.source,
+    recipient.id,
+    liquidSplitPct,
+    chain.id,
+    chain.name,
+    tip,
+    donor,
+    wallet?.address,
+    createCryptoIntent,
+    handleError,
+  ]);
+
+  return transactionId;
+}

--- a/src/contexts/ErrorContext/ErrorContext.tsx
+++ b/src/contexts/ErrorContext/ErrorContext.tsx
@@ -1,7 +1,7 @@
 import Prompt from "components/Prompt";
 import { EMAIL_SUPPORT } from "constants/env";
 import { logger } from "helpers";
-import { ReactNode } from "react";
+import { ReactNode, useCallback } from "react";
 import { useModalContext } from "../ModalContext";
 
 function parseError(error: unknown): string | undefined {
@@ -42,19 +42,22 @@ export function useErrorContext() {
    * @param error - unknown error occured
    * @param display - error info shown to user
    */
-  function handleError(error: unknown, display?: DisplayType) {
-    const disp = display || {};
-    showModal(Prompt, {
-      type: "error",
-      children:
-        disp === "parsed"
-          ? parseError(error)
-          : "custom" in disp
-            ? disp.custom
-            : genericMsg(disp.context),
-    });
-    logger.error(error);
-  }
+  const handleError = useCallback(
+    (error: unknown, display?: DisplayType) => {
+      const disp = display || {};
+      showModal(Prompt, {
+        type: "error",
+        children:
+          disp === "parsed"
+            ? parseError(error)
+            : "custom" in disp
+              ? disp.custom
+              : genericMsg(disp.context),
+      });
+      logger.error(error);
+    },
+    [showModal]
+  );
 
   return { handleError, displayError };
 }

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -3,6 +3,7 @@ import { PaymentIntent } from "@stripe/stripe-js";
 import { TEMP_JWT } from "constants/auth";
 import { APIs } from "constants/urls";
 import {
+  CryptoDonation,
   Donor,
   EndowmentBalances,
   FiatCurrencyData,
@@ -49,6 +50,27 @@ export const apes = createApi({
         method: "POST",
         headers: { authorization: TEMP_JWT },
       }),
+    }),
+    createCryptoIntent: builder.mutation<string, CryptoDonation>({
+      query: (params) => ({
+        url: `crypto-donation/v2`,
+        method: "POST",
+        headers: { authorization: TEMP_JWT },
+        body: JSON.stringify(params),
+      }),
+      transformResponse: (res: { id: string }) => res.id,
+    }),
+    confirmCryptoIntent: builder.mutation<
+      { guestDonor: GuestDonor },
+      { txId: string; txHash: string }
+    >({
+      query: ({ txHash, txId }) => ({
+        url: `crypto-donation/${txId}/confirm`,
+        method: "POST",
+        headers: { authorization: TEMP_JWT },
+        body: JSON.stringify({ txHash }),
+      }),
+      transformResponse: (res: { guestDonor: GuestDonor }) => res,
     }),
     fiatCurrencies: builder.query<
       { currencies: DetailedCurrency[]; defaultCurr?: DetailedCurrency },
@@ -108,6 +130,8 @@ export const apes = createApi({
 
 export const {
   useCapturePayPalOrderMutation,
+  useCreateCryptoIntentMutation,
+  useConfirmCryptoIntentMutation,
   useFiatCurrenciesQuery,
   useStripePaymentIntentQuery,
   usePaypalOrderMutation,

--- a/src/slices/donation/types.ts
+++ b/src/slices/donation/types.ts
@@ -112,6 +112,8 @@ export type DonationState =
   | SubmitStep
   | CryptoResultStep;
 
-export type DonateArgs = { donation: CryptoSubmitStep } & TxPackage;
+export type DonateArgs = {
+  onSuccess: (txHash: string) => Promise<{ guestDonor: GuestDonor }>;
+} & TxPackage;
 
 export type DonationStep = DonationState["step"];

--- a/src/types/aws/apes/donation.ts
+++ b/src/types/aws/apes/donation.ts
@@ -28,7 +28,6 @@ export type CryptoDonation = {
   denomination: string;
   endowmentId: number;
   chainId: string;
-  transactionId: string;
   walletAddress: string;
   /** 1 - 100 */
   splitLiq: number;


### PR DESCRIPTION
## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to http://localhost:4200/donate/53
- start crypto donation flow
- **