### PR TITLE
Get/set cookie in client

### DIFF
--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -2,6 +2,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import CurrencySelector from "components/CurrencySelector";
 import QueryLoader from "components/QueryLoader";
 import { Field, Form as FormContainer } from "components/form";
+import { bgCookies, getCookie, setCookie } from "helpers/cookie";
 import { useController, useForm } from "react-hook-form";
 import { schema, stringNumber } from "schemas/shape";
 import { requiredString } from "schemas/string";
@@ -17,7 +18,8 @@ import { FormValues as FV, Props } from "./types";
 const USD_CODE = "usd";
 
 export default function Loader(props: Props) {
-  const query = useFiatCurrenciesQuery();
+  const prefCode = getCookie(bgCookies.prefCode);
+  const query = useFiatCurrenciesQuery(prefCode);
   return (
     <QueryLoader
       queryState={query}
@@ -95,8 +97,8 @@ function Form({
         currencies={currencies}
         label="Currency"
         onChange={(c) => {
-          document.cookie = `bg_pref_currency=${c.code.toUpperCase()}`;
           onCurrencyChange(c);
+          setCookie(bgCookies.prefCode, c.code.toUpperCase());
         }}
         value={currency}
         classes={{

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -2,7 +2,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import CurrencySelector from "components/CurrencySelector";
 import QueryLoader from "components/QueryLoader";
 import { Field, Form as FormContainer } from "components/form";
-import { bgCookies, getCookie, setCookie } from "helpers/cookie";
+import { bgCookies, setCookie } from "helpers/cookie";
 import { useController, useForm } from "react-hook-form";
 import { schema, stringNumber } from "schemas/shape";
 import { requiredString } from "schemas/string";
@@ -18,8 +18,7 @@ import { FormValues as FV, Props } from "./types";
 const USD_CODE = "usd";
 
 export default function Loader(props: Props) {
-  const prefCode = getCookie(bgCookies.prefCode);
-  const query = useFiatCurrenciesQuery(prefCode);
+  const query = useFiatCurrenciesQuery();
   return (
     <QueryLoader
       queryState={query}

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -96,8 +96,8 @@ function Form({
         currencies={currencies}
         label="Currency"
         onChange={(c) => {
-          onCurrencyChange(c);
           setCookie(bgCookies.prefCode, c.code.toUpperCase());
+          onCurrencyChange(c);
         }}
         value={currency}
         classes={{

--- a/src/helpers/cookie.ts
+++ b/src/helpers/cookie.ts
@@ -1,0 +1,19 @@
+export const bgCookies = {
+  prefCode: "bg_pref_currency",
+};
+
+export const getCookie = (key: string): string | undefined => {
+  const cookies = document.cookie.split(";").reduce(
+    (prev, kvStr) => {
+      const [k, v] = kvStr.trim().split("=");
+      return { ...prev, [k]: v };
+    },
+    {} as Record<string, string>
+  );
+  return cookies[key];
+};
+
+export const setCookie = (key: string, value: string, path = "/"): void => {
+  //this won't override the cookie, but append to the list instead
+  document.cookie = `${key}=${value}; Secure; SameSite=None; Path=${path}`; //Domain = window.origin
+};

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -2,7 +2,7 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { PaymentIntent } from "@stripe/stripe-js";
 import { TEMP_JWT } from "constants/auth";
 import { APIs } from "constants/urls";
-import { bgCookies, setCookie } from "helpers/cookie";
+import { bgCookies, getCookie, setCookie } from "helpers/cookie";
 import {
   Donor,
   EndowmentBalances,
@@ -53,9 +53,12 @@ export const apes = createApi({
     }),
     fiatCurrencies: builder.query<
       { currencies: DetailedCurrency[]; defaultCurr?: DetailedCurrency },
-      string | undefined
+      void
     >({
-      query: (prefCode) => ({ url: "fiat-currencies", params: { prefCode } }),
+      query: () => ({
+        url: "fiat-currencies",
+        params: { prefCode: getCookie(bgCookies.prefCode) },
+      }),
       transformResponse: (res: FiatCurrencyData) => {
         const toDetailed = (
           input: FiatCurrencyData["currencies"][number]


### PR DESCRIPTION
Towards BG-1283
server set cookie value e.g.
```
...value ; domain: apes-api.better.giving; path="/dev"
```
can't be modified (contrary to the initial expectation) in the client running on domain `staging.better.giving`. 
Instead a distinct cookie is created
```
...value ; domain: apes-api.better.giving; path="/dev"
...value ; domain: staging.better.giving; path="/donate"
```
in which case, cookie `...value ; domain: staging.better.giving; path="/donate"` is never included in succeeding calls with `{credentials:include}` and therefore value is not used. 


## Explanation of the solution
* on first visit (no pref yet), save to cookie `prefCode` based on IP
* on succeeding visit, use saved `prefCode` as search param (as cookie with domain `staging.better.giving` is not included when requesting `apes-api.better.giving` ) so ip query need not be run

## Instructions on making this work
- [x] verify that selected currency is persisted on page reload for both `/donate` and `widget (embedded on standalone html document)

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
