### PR TITLE
BG-1298: fix img editor issues

### DIFF
--- a/src/components/ImgEditor/ImgCropper.tsx
+++ b/src/components/ImgEditor/ImgCropper.tsx
@@ -6,18 +6,12 @@ import Cropper from "cropperjs";
 import { useCallback, useRef } from "react";
 
 type Props = {
-  preview: string;
-  type: string; // original file type, will be the same for blob in `onSave(blob: Blob)`
+  file: File;
   aspect: [number, number];
-  onSave(blob: Blob | null): void; // blob.type is the same as Props.type
+  onSave(file: File): void; // blob.type is the same as Props.type
 };
 
-export default function ImgCropper({
-  preview,
-  type,
-  aspect: [x, y],
-  onSave,
-}: Props) {
+export default function ImgCropper({ file, aspect: [x, y], onSave }: Props) {
   const { closeModal } = useModalContext();
 
   const cropperRef = useRef<Cropper>();
@@ -37,12 +31,13 @@ export default function ImgCropper({
   );
 
   function handleSave() {
-    if (cropperRef.current) {
-      cropperRef.current.getCroppedCanvas().toBlob((blob) => {
-        onSave(blob);
-        closeModal();
-      }, type);
-    }
+    if (!cropperRef.current) return onSave(file);
+    cropperRef.current.getCroppedCanvas().toBlob((blob) => {
+      //nothing is cropped
+      if (!blob) return onSave(file);
+      onSave(new File([blob], file.name));
+      closeModal();
+    }, file.type);
   }
 
   return (
@@ -56,7 +51,12 @@ export default function ImgCropper({
           <Icon type="Save" size={24} />
         </button>
       </div>
-      <Image ref={imgRef} alt="banner" src={preview} className="w-full" />
+      <Image
+        ref={imgRef}
+        alt="banner"
+        src={URL.createObjectURL(file)}
+        className="w-full"
+      />
     </Modal>
   );
 }

--- a/src/components/ImgEditor/ImgCropper.tsx
+++ b/src/components/ImgEditor/ImgCropper.tsx
@@ -35,7 +35,7 @@ export default function ImgCropper({ file, aspect: [x, y], onSave }: Props) {
     cropperRef.current.getCroppedCanvas().toBlob((blob) => {
       //nothing is cropped
       if (!blob) return onSave(file);
-      onSave(new File([blob], file.name));
+      onSave(new File([blob], file.name, { type: file.type }));
       closeModal();
     }, file.type);
   }

--- a/src/components/ImgEditor/ImgCropper.tsx
+++ b/src/components/ImgEditor/ImgCropper.tsx
@@ -8,7 +8,7 @@ import { useCallback, useRef } from "react";
 type Props = {
   file: File;
   aspect: [number, number];
-  onSave(file: File): void; // blob.type is the same as Props.type
+  onSave(cropped: File): void;
 };
 
 export default function ImgCropper({ file, aspect: [x, y], onSave }: Props) {

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -117,7 +117,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
         </span>{" "}
         <ErrorMessage
           errors={errors}
-          name={filePath as any}
+          name={filePath}
           as="span"
           className="text-red dark:text-red-l2 text-xs before:content-['('] before:mr-0.5 after:content-[')'] after:ml-0.5 empty:before:hidden empty:after:hidden"
         />

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -4,19 +4,15 @@ import { humanize } from "helpers";
 import React from "react";
 import { useDropzone } from "react-dropzone";
 import { FieldValues, Path, get, useFormContext } from "react-hook-form";
-import { ImgLink, Props } from "./types";
+import { Props } from "./types";
 import useImgEditor from "./useImgEditor";
 
 const BYTES_IN_MB = 1e6;
-
-type Key = keyof ImgLink;
-const precropFileKey: Key = "precropFile";
 
 export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
   props: Props<T, K>
 ) {
   const { name, classes, maxSize, accept } = props;
-  const precropFilePath: any = `${String(name)}.${precropFileKey}`;
 
   const {
     formState: { errors, isSubmitting },
@@ -25,7 +21,8 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
   const {
     handleOpenCropper,
     handleReset,
-    imgSize,
+    file,
+    filePath,
     isInitial,
     noneUploaded,
     onDrop,
@@ -110,8 +107,8 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
             <>
               Image should be less than {maxSize / BYTES_IN_MB}MB in size.
               <br />
-              {imgSize
-                ? `Current image size: ${humanize(imgSize / BYTES_IN_MB)}MB.`
+              {file.size
+                ? `Current image size: ${humanize(file.size / BYTES_IN_MB)}MB.`
                 : ""}
             </>
           ) : (
@@ -120,7 +117,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
         </span>{" "}
         <ErrorMessage
           errors={errors}
-          name={precropFilePath as any}
+          name={filePath as any}
           as="span"
           className="text-red dark:text-red-l2 text-xs before:content-['('] before:mr-0.5 after:content-[')'] after:ml-0.5 empty:before:hidden empty:after:hidden"
         />

--- a/src/components/ImgEditor/types.ts
+++ b/src/components/ImgEditor/types.ts
@@ -5,7 +5,6 @@ import { ImageMIMEType } from "types/lists";
 export type ImgLink = FileObject & {
   file?: File;
   preview: string;
-  precropFile?: File;
 };
 
 type Classes = { container?: string; dropzone?: string };

--- a/src/components/ImgEditor/useImgEditor.ts
+++ b/src/components/ImgEditor/useImgEditor.ts
@@ -68,6 +68,7 @@ export default function useImgEditor<T extends Base, K extends Path<T>>({
   function handleCropResult(cropped: File) {
     setValue(path("preview"), URL.createObjectURL(cropped) as any);
     onFileChange(cropped);
+    trigger(name);
   }
 
   const handleReset: MouseEventHandler<HTMLButtonElement> = (e) => {
@@ -85,7 +86,7 @@ export default function useImgEditor<T extends Base, K extends Path<T>>({
     handleReset,
     preview,
     file: currFile,
-    filePath: path("file"),
+    filePath: path("file") as any,
     ref,
   };
 }

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -53,7 +53,7 @@ export default function ModalContext(
   const closeModal = useCallback(() => {
     setState((prev) => {
       if (!prev) throw new Error("there's no modal to close");
-      if (!prev.isDismissible) return;
+      if (!prev.isDismissible) return prev;
       prev.onClose(); //side effect with no access to state
       return undefined;
     });

--- a/src/pages/Admin/Charity/EditProfile/schema.ts
+++ b/src/pages/Admin/Charity/EditProfile/schema.ts
@@ -18,10 +18,8 @@ export const VALID_MIME_TYPES: ImageMIMEType[] = [
 export const MAX_SIZE_IN_BYTES = 1e6;
 export const MAX_CHARS = 4000;
 
-// we only need to validate the pre-crop image and if we confirm it is valid
-// we can be sure that the cropped image is valid too
 const fileObj = object<any, SchemaShape<ImgLink>>({
-  precropFile: genFileSchema(MAX_SIZE_IN_BYTES, VALID_MIME_TYPES),
+  file: genFileSchema(MAX_SIZE_IN_BYTES, VALID_MIME_TYPES),
 });
 
 //construct strict shape to avoid hardcoding shape keys

--- a/src/pages/Admin/Charity/ProgramEditor/schema.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/schema.ts
@@ -17,10 +17,8 @@ export const VALID_MIME_TYPES: ImageMIMEType[] = [
 export const MAX_SIZE_IN_BYTES = 1e6;
 export const MAX_CHARS = 500;
 
-// we only need to validate the pre-crop image and if we confirm it is valid
-// we can be sure that the cropped image is valid too
 const fileObj = object().shape<SchemaShape<ImgLink>>({
-  precropFile: genFileSchema(MAX_SIZE_IN_BYTES, VALID_MIME_TYPES),
+  file: genFileSchema(MAX_SIZE_IN_BYTES, VALID_MIME_TYPES),
 });
 
 const milesStoneSchema = object<any, SchemaShape<FormMilestone>>({


### PR DESCRIPTION
## Explanation of the solution

* Img editor now only works on single `file`
* pre crop preview is shown until user decides to crop it 
* validation always apply to latest cropped version of the file


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
