### PR TITLE
redirect signins to marketplace, not to root

### DIFF
--- a/src/helpers/determineAuthRedirectPath.ts
+++ b/src/helpers/determineAuthRedirectPath.ts
@@ -22,6 +22,6 @@ export function determineAuthRedirectPath(
   const pathname =
     isSigningUp && signInRouteState?.from === appRoutes.register
       ? `${appRoutes.register}/${regRoutes.welcome}`
-      : signInRouteState?.from || "/";
+      : signInRouteState?.from || "/marketplace";
   return { redirectPath: { pathname, search }, data: signInRouteState?.data };
 }


### PR DESCRIPTION
## Explanation of the solution
Send signin users to marketplace not to root of domain. 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
