### PR TITLE
temp hide landing page btns

### DIFF
--- a/src/pages/Home/sections/Home/Path.tsx
+++ b/src/pages/Home/sections/Home/Path.tsx
@@ -8,7 +8,7 @@ import icon6 from "../../../../assets/landing/Icon6_wb.webp";
 import icon7 from "../../../../assets/landing/Icon7_wb.webp";
 import icon8 from "../../../../assets/landing/Icon8_wb.webp";
 import BenefitsCarousel from "../../../../components/landing/BenefitsCarousel";
-import Button from "../../../../components/landing/Button";
+// import Button from "../../../../components/landing/Button";
 import Carousel from "../../../../components/landing/Carousel";
 const Path = () => {
   const [path, setPath] = useState("non-profits");
@@ -108,7 +108,8 @@ const Path = () => {
       </div>
       <BenefitsCarousel slides={path === "non-profits" ? nonProfits : donors} />
       <Carousel slides={path === "non-profits" ? nonProfits : donors} />
-      <Button text="Learn More" />
+      {/* TODO: enable once we have the static pages ready */}
+      {/*<Button text="Learn More" />*/}
     </section>
   );
 };

--- a/src/pages/Home/sections/Home/Video.tsx
+++ b/src/pages/Home/sections/Home/Video.tsx
@@ -6,7 +6,7 @@ import s2 from "../../../../assets/landing/half1.png";
 import heart from "../../../../assets/landing/heartOfText.png";
 import heartText from "../../../../assets/landing/heartText.svg";
 import videobanner from "../../../../assets/landing/video_bannerUpdate.png";
-import Button from "../../../../components/landing/Button";
+// import Button from "../../../../components/landing/Button";
 
 const triggerId = "__video";
 
@@ -96,7 +96,8 @@ const Video = () => {
           ways to contribute, grow, and track your generosity, all while
           celebrating our collective impact.
         </p>
-        <Button text="Join the Movement" />
+        {/* TODO: enable once we have the static pages ready */}
+        {/*<Button text="Join the Movement" />*/}
       </div>
 
       <svg


### PR DESCRIPTION
## Explanation of the solution
Temp comment out two of the landing page buttons to hide them until we have the pages ready that they will point to. 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
