### PR TITLE
Static pages for legal

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -29,6 +29,9 @@ const Widget = lazy(() => import("pages/Widget"));
 const BlogPosts = lazy(() => import("pages/Blog/Posts"));
 const BlogPost = lazy(() => import("pages/Blog/Post"));
 const Home = lazy(() => import("pages/Home"));
+const PrivacyPolicy = lazy(() => import("pages/Legal/PrivacyPolicy"));
+const TermsDonors = lazy(() => import("pages/Legal/TermsDonors"));
+const TermsNonprofits = lazy(() => import("pages/Legal/TermsNonprofits"));
 
 export default function App() {
   const location = useLocation();
@@ -115,6 +118,12 @@ export default function App() {
             <Route path=":slug" element={<BlogPost />} />
             <Route index element={<BlogPosts />} />
           </Route>
+          <Route path={appRoutes.privacy_policy} element={<PrivacyPolicy />} />
+          <Route
+            path={appRoutes.terms_nonprofits}
+            element={<TermsNonprofits />}
+          />
+          <Route path={appRoutes.terms_donors} element={<TermsDonors />} />
         </Route>
         <Route path="*" element={<Navigate replace to={appRoutes.home} />} />
       </SentryRoutes>

--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -1,3 +1,5 @@
+import { appRoutes } from "constants/routes";
+import { Link } from "react-router-dom";
 import log from "../../assets/landing/logo.svg";
 
 const Footer = () => {
@@ -51,7 +53,7 @@ const Footer = () => {
                 <a href="https://intercom.help/better-giving/en">FAQs</a>
               </li>
               <li className="text-xs text-black mt-4 whitespace-nowrap font-normal opacity-90">
-                News
+                <Link to={appRoutes.blog}>News</Link>
               </li>
             </ul>
           </div>
@@ -61,13 +63,17 @@ const Footer = () => {
             </h6>
             <ul>
               <li className="text-xs text-black  whitespace-nowrap font-normal opacity-90">
-                Privacy Policy
+                <Link to={appRoutes.privacy_policy}>Privacy Policy</Link>
               </li>
               <li className="text-xs text-black mt-4  whitespace-nowrap font-normal opacity-90">
-                Terms of Use <br /> (Donors)
+                <Link to={appRoutes.terms_donors}>
+                  Terms of Use <br /> (Donors)
+                </Link>
               </li>
               <li className="text-xs text-black mt-4 whitespace-nowrap font-normal opacity-90">
-                Terms of Use <br /> (Non-Profits)
+                <Link to={appRoutes.terms_nonprofits}>
+                  Terms of Use <br /> (Non-Profits)
+                </Link>
               </li>
             </ul>
           </div>
@@ -82,7 +88,7 @@ const Footer = () => {
               By subscribing to this newsletter you confirm that you <br /> have
               read and agree with our{" "}
               <span className="underline font-medium text-[#000] opacity-[1]">
-                Privacy Policy.
+                <Link to={appRoutes.privacy_policy}>Privacy Policy</Link>.
               </span>
             </p>
           </span>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -19,6 +19,9 @@ export enum appRoutes {
   reset_password = "/signin/reset",
   widget_config = "/widget-config",
   blog = "/blog",
+  privacy_policy = "/privacy-policy",
+  terms_donors = "/terms-of-use",
+  terms_nonprofits = "/terms-of-use-npo",
 }
 
 export const adminRoutes = {

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -10,6 +10,5 @@ export const APIs = {
 
 export const LITEPAPER = `${BASE_URL}/docs/litepaper-introduction/`;
 export const PRIVACY_POLICY = `${BASE_URL}/privacy-policy/`;
-
 export const TERMS_OF_USE_NPO = `${BASE_URL}/terms-of-use-npo/`;
 export const TERMS_OF_USE_DONOR = `${BASE_URL}/terms-of-use/`;

--- a/src/pages/Legal/PrivacyPolicy.tsx
+++ b/src/pages/Legal/PrivacyPolicy.tsx
@@ -1,0 +1,595 @@
+import ExtLink from "components/ExtLink";
+import { appRoutes } from "constants/routes";
+import { Link } from "react-router-dom";
+
+export default function PrivacyPolicy() {
+  return (
+    <div className="padded-container min-h-screen pb-6">
+      <h1 className="font-bold uppercase col-span-full text-2xl lg:text-3xl break-words mt-6">
+        Privacy Policy
+      </h1>
+      <span className="text-gray text-sm">
+        Last modified: September 8, 2023
+      </span>
+      <section className="pt-8">
+        <h2 className="text-2xl">Introduction</h2>
+        <p className="pt-5">
+          Altruistic Partners Empowering Society, Inc. d/b/a Better Giving
+          ("Better Giving", "We" or "Our") respects your privacy and is
+          committed to protecting it through our compliance with this policy.
+        </p>
+        <p className="pt-5">
+          This policy applies to the website{" "}
+          <Link className="hover:text-blue-d1 text-blue" to={appRoutes.home}>
+            www.better.giving
+          </Link>
+          , as well as applications, products and services (collectively our
+          "Site") on or in which it is posted, linked or referenced. This policy
+          provides information about our practices for collecting, using,
+          maintaining, protecting, and disclosing your information.
+        </p>
+        <p className="pt-5">This policy applies to information we collect:</p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">On this Site.</li>
+          <li className="pt-2">
+            In email, text, and other electronic messages between you and this
+            Site.
+          </li>
+          <li className="pt-2">
+            Through mobile and desktop applications you download from this Site,
+            which provide dedicated non-browser-based interaction between you
+            and this Site.
+          </li>
+          <li className="pt-2">
+            When you interact with our advertising and applications on
+            third-party Sites and services, if those applications or advertising
+            include links to this policy.
+          </li>
+        </ul>
+        <p className="pt-5">It does not apply to information collected by:</p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">
+            Us offline or through any other means, including on any other Site
+            operated by Company or any third party; or
+          </li>
+          <li className="pt-2">
+            Any third party, including through any application or content
+            (including advertising) that may link to or be accessible from or on
+            the Site.
+          </li>
+        </ul>
+        <p className="pt-5">
+          Please read this policy carefully to understand our policies and
+          practices regarding your information and how we will treat it. If you
+          do not agree with our policies and practices, your choice is not to
+          use our Site. By accessing or using this Site, you agree to this
+          privacy policy. This policy may change from time to time. Your
+          continued use of our Site after we make changes is deemed to be
+          acceptance of those changes, so please check the policy periodically
+          for updates.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">Children Under the Age of 13</h2>
+        <p className="pt-5">
+          Our Site is not intended for children under 13 years of age. No one
+          under age 13 may provide any information to or on the Site. We do not
+          knowingly collect personal information from children under 13. If you
+          are under 13, do not use or provide any information on this Site or on
+          or through any of its features. If we learn we have collected or
+          received personal information from a child under 13 without
+          verification of parental consent, we will delete that information. If
+          you believe we might have any information from or about a child under
+          13, please contact us at: hi@better.giving.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">
+          Information We Collect About You and How We Collect It
+        </h2>
+        <p className="pt-5">
+          We collect several types of information from and about users of our
+          Site, including information:
+        </p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">
+            By which you may be personally identified, such as name, postal
+            address, e-mail address, telephone number, or any other identifier
+            by which you may be contacted online or offline ("personal
+            information");
+          </li>
+          <li className="pt-2">
+            That is about you but individually does not identify you; and/or
+          </li>
+          <li className="pt-2">
+            About your internet connection, the equipment you use to access our
+            Site, and usage details.
+          </li>
+        </ul>
+        <p className="pt-5">We collect this information:</p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">Directly from you when you provide it to us.</li>
+          <li className="pt-2">
+            Automatically as you navigate through the site. Information
+            collected automatically may include usage details, IP addresses, and
+            information collected through cookies, and web beacons.
+          </li>
+        </ul>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">Information You Provide to Us</h2>
+        <p className="pt-5">
+          The information we collect on or through our Site may include:
+        </p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">
+            Information that you provide by filling in forms on our Site. This
+            includes information provided at the time of registering to use our
+            Site, subscribing to our service, posting material, or requesting
+            further services. We may also ask you for information when you
+            report a problem with our Site.
+          </li>
+          <li className="pt-2">
+            Records and copies of correspondence between you and us (including
+            email addresses), if you contact us.
+          </li>
+          <li className="pt-2">
+            Your responses to surveys that we might ask you to complete for
+            research purposes.
+          </li>
+          <li className="pt-2">
+            Payment information and details of transactions you carry out
+            through our Site and of the fulfillment and processing of your
+            charitable contributions. This payment information may include but
+            is not limited to cryptocurrency type, cryptocurrency amounts,
+            billing address, and digital currency transaction identifiers.
+          </li>
+          <li className="pt-2">Your search queries on the Site.</li>
+        </ul>
+        <p className="pt-5">
+          You also may provide information to be published or displayed
+          (hereinafter, "posted") on public areas of the Site, or transmitted to
+          other users of the Site or third parties (collectively, "User
+          Contributions"). Your User Contributions are posted on and transmitted
+          to others at your own risk. Although we limit access to certain pages,
+          please be aware that no security measures are perfect or impenetrable.
+          Additionally, we cannot control the actions of other users of the Site
+          with whom you may choose to share your User Contributions. Therefore,
+          we cannot and do not guarantee that your User Contributions will not
+          be viewed by unauthorized persons.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">
+          Information We Collect Through Automatic Data Collection Technologies
+        </h2>
+        <p className="pt-5">
+          As you navigate through and interact with our Site, we may use
+          automatic data collection technologies to collect certain information
+          about your equipment, browsing actions, and patterns, including:
+        </p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">
+            Details of your visits to our Site, including traffic data, location
+            data, logs, and other communication data and the resources that you
+            access and use on the Site.
+          </li>
+          <li className="pt-2">
+            Information about your computer and internet connection, including
+            your IP address, operating system, and browser type.
+          </li>
+        </ul>
+        <p className="pt-5">
+          The information we collect automatically may include personal
+          information, or we may maintain it or associate it with personal
+          information we collect in other ways or receive from third parties. It
+          helps us to improve our Site and to deliver a better and more
+          personalized service, including by enabling us to:
+        </p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">
+            Estimate our audience size and usage patterns.
+          </li>
+          <li className="pt-2">
+            Store information about your preferences, allowing us to customize
+            our Site according to your individual interests.
+          </li>
+          <li className="pt-2">Speed up your searches.</li>
+          <li className="pt-2">Recognize you when you return to our Site.</li>
+        </ul>
+        <p className="pt-5">
+          The technologies we use for this automatic data collection may
+          include:
+        </p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">
+            <strong>Cookies (or browser cookies).</strong> A cookie is a small
+            file placed on the hard drive of your computer. You may refuse to
+            accept browser cookies by activating the appropriate setting on your
+            browser. However, if you select this setting you may be unable to
+            access certain parts of our Site. Unless you have adjusted your
+            browser setting so that it will refuse cookies, our system will
+            issue cookies when you direct your browser to our Site.
+          </li>
+          <li className="pt-2">
+            <strong>Flash Cookies.</strong> Certain features of our Site may use
+            local stored objects (or Flash cookies) to collect and store
+            information about your preferences and navigation to, from, and on
+            our Site. Flash cookies are not managed by the same browser settings
+            as are used for browser cookies. For information about managing your
+            privacy and security settings for Flash cookies, see{" "}
+            <ExtLink
+              className="hover:text-blue-d1 text-blue"
+              href="https://docs.google.com/document/d/1OMF45tdJW_IdiNxjL2juHwPhtUWbCtzE/edit#bookmark=id.1ksv4uv"
+            >
+              Choices About How We Use and Disclose Your Information
+            </ExtLink>
+            .
+          </li>
+          <li className="pt-2">
+            <strong>Web Beacons.</strong> Pages of our Site and our emails may
+            contain small electronic files known as web beacons (also referred
+            to as clear gifs, pixel tags, and single-pixel gifs) that permit the
+            Company, for example, to count users who have visited those pages or
+            opened an email and for other related Site statistics (for example,
+            recording the popularity of certain Site content and verifying
+            system and server integrity).
+          </li>
+        </ul>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">How We Use Your Information</h2>
+        <p className="pt-5">
+          We use information that we collect about you or that you provide to
+          us, including any personal information:
+        </p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">To present our Site and its contents to you.</li>
+          <li className="pt-2">
+            To provide you with information, products, or services that you
+            request from us.
+          </li>
+          <li className="pt-2">
+            To fulfill any other purpose for which you provide it.
+          </li>
+          <li className="pt-2">
+            To provide you with notices about your account, including expiration
+            and renewal notices.
+          </li>
+          <li className="pt-2">
+            To carry out our obligations and enforce our rights arising from any
+            contracts entered into between you and us, including for billing and
+            collection.
+          </li>
+          <li className="pt-2">
+            To notify you about changes to our Site or any products or services
+            we offer or provide through it.
+          </li>
+          <li className="pt-2">
+            To allow you to participate in interactive features on our Site.
+          </li>
+          <li className="pt-2">
+            In any other way we may describe when you provide the information.
+          </li>
+          <li className="pt-2">For any other purpose with your consent.</li>
+        </ul>
+        <p className="pt-5">
+          We may also use your information to contact you about our own and
+          third-parties’ goods and services that may be of interest to you. If
+          you do not want us to use your information in this way, please check
+          the relevant box located on the form on which we collect your data
+          (the registration form). For more information, see{" "}
+          <ExtLink
+            className="hover:text-blue-d1 text-blue"
+            href="https://docs.google.com/document/d/1OMF45tdJW_IdiNxjL2juHwPhtUWbCtzE/edit#bookmark=id.1ksv4uv"
+          >
+            Choices About How We Use and Disclose Your Information
+          </ExtLink>
+          .
+        </p>
+        <p className="pt-5">
+          We may use the information we have collected from you to enable us to
+          display advertisements to our advertisers’ target audiences. Even
+          though we do not disclose your personal information for these purposes
+          without your consent, if you click on or otherwise interact with an
+          advertisement, the advertiser may assume that you meet its target
+          criteria.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">Disclosure of Your Information</h2>
+        <p className="pt-5">
+          We may disclose aggregated information about our users without
+          restriction.
+        </p>
+        <p className="pt-5">
+          We may disclose personal information that we collect or you provide as
+          described in this privacy policy:
+        </p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">
+            To contractors, service providers, and other third parties we use to
+            support our business and who are bound by contractual obligations to
+            keep personal information confidential and use it only for the
+            purposes for which we disclose it to them.
+          </li>
+          <li className="pt-2">
+            To a buyer or other successor in the event of a merger, divestiture,
+            restructuring, reorganization, dissolution, or other sale or
+            transfer of some or all of the Company’s assets, whether as a going
+            concern or as part of bankruptcy, liquidation, or similar
+            proceeding, in which personal information held by the Company about
+            our Site users is among the assets transferred.
+          </li>
+          <li className="pt-2">
+            To third parties to market their products or services to you if you
+            have consented to these disclosures. We contractually require these
+            third parties to keep personal information confidential and use it
+            only for the purposes for which we disclose it to them. For more
+            information, see{" "}
+            <ExtLink
+              className="hover:text-blue-d1 text-blue"
+              href="https://docs.google.com/document/d/1OMF45tdJW_IdiNxjL2juHwPhtUWbCtzE/edit#bookmark=id.1ksv4uv"
+            >
+              Choices About How We Use and Disclose Your Information
+            </ExtLink>
+            .
+          </li>
+          <li className="pt-2">
+            To fulfill the purpose for which you provide it.
+          </li>
+          <li className="pt-2">
+            For any other purpose disclosed by us when you provide the
+            information.
+          </li>
+          <li className="pt-2">With your consent.</li>
+        </ul>
+        <p className="pt-5">We may also disclose your personal information:</p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">
+            To comply with any court order, law, or legal process (including KYC
+            and AML requirements), including to respond to any government or
+            regulatory request.
+          </li>
+          <li className="pt-2">
+            If we believe disclosure is necessary or appropriate to protect the
+            rights, property, or safety of the Company, our customers, or
+            others. This includes exchanging information with other companies
+            and organizations for the purposes of fraud protection and credit
+            risk reduction.
+          </li>
+        </ul>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">
+          Choices About How We Use and Disclose Your Information
+        </h2>
+        <p className="pt-5">
+          We strive to provide you with choices regarding the personal
+          information you provide to us. We have created mechanisms to provide
+          you with the following control over your information:
+        </p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">
+            <strong>Tracking Technologies and Advertising.</strong> You can set
+            your browser to refuse all or some browser cookies, or to alert you
+            when cookies are being sent. If you disable or refuse cookies,
+            please note that some parts of this site may then be inaccessible or
+            not function properly.
+          </li>
+          <li className="pt-2">
+            <strong>
+              Disclosure of Your Information for Third-Party Advertising.
+            </strong>{" "}
+            If you do not want us to share your personal information with
+            unaffiliated or non-agent third parties for promotional purposes,
+            you can opt out by checking the relevant box located on the form on
+            which we collect your data (the registration form). You can also
+            always opt out by checking or unchecking the relevant boxes or by
+            sending us an email stating your request to hi@better.giving.
+          </li>
+          <li className="pt-2">
+            <strong>Promotional Offers from the Company.</strong> If you do not
+            wish to have your contact information used by the Company to promote
+            our own or third parties’ products or services, you can opt out by
+            checking the relevant box located on the form on which we collect
+            your data (the registration form) or at any other time by sending us
+            an email stating your request to hi@better.giving. If we have sent
+            you a promotional email, you may send us a return email asking to be
+            omitted from future email distributions.
+          </li>
+        </ul>
+        <p className="pt-5">
+          We do not control third parties’ collection or use of your information
+          to serve interest-based advertising. However these third parties may
+          provide you with ways to choose not to have your information collected
+          or used in this way. You can opt out of receiving targeted ads from
+          members of the Network Advertising Initiative ("NAI") on the NAI’s
+          <ExtLink
+            className="hover:text-blue-d1 text-blue"
+            href="http://www.networkadvertising.org/managing/opt_out.asp"
+          >
+            Site
+          </ExtLink>
+          .
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">Lawful Basis for Processing</h2>
+        <p className="pt-5">
+          We only use your personal information as permitted by law. We are
+          required to inform you of the lawful bases of our processing of your
+          personal information, which are described below. If you have questions
+          about the legal bases under which we are processing your information,
+          please contact us at hi@better.giving. The legal bases under which We
+          may process your personal information include:
+        </p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">To provide our services to you.</li>
+          <li className="pt-2">
+            To comply with applicable laws and legal obligations, including
+            anti-money laundering laws (AML) and know-your-customer (KYC)
+            requirements.
+          </li>
+          <li className="pt-2">
+            To improve our existing services and products and to develop new
+            services and products.
+          </li>
+          <li className="pt-2">To optimize our platform.</li>
+          <li className="pt-2">
+            To notify you of new services, products and events that may be of
+            interest.
+          </li>
+          <li className="pt-2">
+            To protect the vital interests of the public.
+          </li>
+          <li className="pt-2">To personalize our services.</li>
+          <li className="pt-2">
+            For any other purpose with your explicit consent.
+          </li>
+        </ul>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">
+          Your Rights under the General Data Protection Regulation ("GDPR")
+        </h2>
+        <p className="pt-5">
+          Under the GDPR you have certain rights regarding your personal
+          information. You may email hi@better.giving to request the following
+          actions:
+        </p>
+        <ul className="pl-8 list-disc list-outside">
+          <li className="pt-2">
+            To access personal data about you that we possess. This includes
+            information on the ways in which we use your personal data,
+            categories of personal data concerned, recipients or categories of
+            recipients to whom your data has been or will be disclosed, the
+            right to lodge a complaint with a supervisory authority, the source
+            of your personal data, and our use of automated decision-making in
+            processing your data.
+          </li>
+          <li className="pt-2">To correct and update your personal data.</li>
+          <li className="pt-2">
+            To erase personal data, if that data is no longer necessary for the
+            purpose it was collected or otherwise processed, if you object to
+            the use of that data and a fundamental right is at stake, or if your
+            personal data has been unlawfully processed. Where your data was
+            made public, our responsibility to erase it is limited to deleting
+            data in our possession, and taking reasonable steps to inform other
+            data controllers of your request. In no event shall we have any
+            obligation to erase your data where doing so would prevent exercise
+            of the right of freedom of expression and information, would
+            interfere with a legal obligation, would interfere with the
+            processing of health data, would interfere with legitimate
+            archiving, or would impede the establishment, exercise, or defense
+            of legal claims.
+          </li>
+          <li className="pt-2">
+            To restrict processing of your personal data, except for storage and
+            other uses with your consent. We are not obligated to restrict
+            processing of your personal data unless you contest the accuracy of
+            that data for a period of time reasonably allowing us to verify
+            accuracy, the processing is unlawful and you request that processing
+            be restricted instead of erasing the data, your data is no longer
+            necessary for processing but you require it for the establishment,
+            exercise, or defense of a legal claim, or pending a determination
+            after you object to data processing.
+          </li>
+          <li className="pt-2">
+            To stop sending you direct marketing communications which you have
+            previously consented to receive. We may continue to send you
+            service-related and other non-marketing communications.
+          </li>
+          <li className="pt-2">
+            To object to any given form of data processing.
+          </li>
+        </ul>
+        <p className="pt-5">
+          We will notify you of any action taken regarding your request. You may
+          lodge a complaint with a supervisory authority for failure to provide
+          you with a response within a period of one month.
+        </p>
+        <p className="pt-5">
+          For requests that are manifestly unfounded or excessive, we may charge
+          a fee based on administrative costs or refuse to respond. If we refuse
+          to respond, you will be informed of the reason for refusal, and of
+          available recourse.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">Your Privacy Rights Under Californa Law</h2>
+        <p className="pt-5">
+          Under California Civil Code Section 1798.83, California users are
+          entitled to the following consumer rights notice: California residents
+          may reach the Complaint Assistance Unit of the Division of Consumer
+          Services of the California Department of Consumer Affairs by mail at
+          1625 North Market Blvd., Sacramento, CA 95834 or by phone
+          at946-445-1254 or 800-952-5210.
+        </p>
+        <p className="pt-5">
+          This section provides additional details about the personal
+          information we collect about California consumers and the rights
+          afforded to them under the California Consumer Privacy Act ("
+          <strong>CCPA</strong>").
+        </p>
+        <p className="pt-5">
+          Subject to certain limitations, the CCPA provides California consumers
+          the right to request to know more details about the categories of
+          personal information we collect (including how we use and disclose
+          this information), to delete their personal information, to opt out of
+          any "sales" that may be occurring, and to not be discriminated against
+          for exercising these rights.
+        </p>
+        <p className="pt-5">
+          California consumers may make a request pursuant to their rights under
+          the CCPA by contacting us at hi@better.giving.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">Data Security</h2>
+        <p className="pt-5">
+          We have implemented industry-standard security measures designed to
+          secure your personal information from accidental loss and from
+          unauthorized access, use, alteration, and disclosure.
+        </p>
+        <p className="pt-5">
+          The safety and security of your information also depends on you. Where
+          we have given you (or where you have chosen) a password for access to
+          certain parts of our Site, you are responsible for keeping this
+          password confidential. We ask you not to share your password with
+          anyone.
+        </p>
+        <p className="pt-5">
+          Unfortunately, the transmission of information via the internet is not
+          completely secure. Although we do our best to protect your personal
+          information, we cannot guarantee the security of your personal
+          information transmitted to our Site. Any transmission of personal
+          information is at your own risk. We are not responsible for
+          circumvention of any privacy settings or security measures contained
+          on the Site.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">Changes to Our Privacy Policy</h2>
+        <p className="pt-5">
+          It is our policy to post any changes we make to our privacy policy on
+          this page. If we make material changes to how we treat our users’
+          personal information, we will notify you. The date the privacy policy
+          was last revised is identified at the top of the page. You are
+          responsible for ensuring we have an up-to-date active and deliverable
+          email address for you, and for periodically visiting our Site and this
+          privacy policy to check for any changes. In all cases, your continued
+          use of the Site after the posting of any modified privacy policy
+          indicates your acceptance of the terms of the modified privacy policy.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">Contact Information</h2>
+        <p className="pt-5 pb-10">
+          To ask questions or comment about this privacy policy and our privacy
+          practices, contact us at hi@better.giving.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Legal/TermsDonors.tsx
+++ b/src/pages/Legal/TermsDonors.tsx
@@ -1,0 +1,261 @@
+import { appRoutes } from "constants/routes";
+import { Link } from "react-router-dom";
+
+export default function TermsDonors() {
+  return (
+    <div className="padded-container min-h-screen pb-6">
+      <h1 className="font-bold uppercase col-span-full text-2xl lg:text-3xl break-words mt-6">
+        Terms and Conditions: Donors
+      </h1>
+      <span className="text-gray text-sm">
+        Last modified: September 8, 2023
+      </span>
+      <section className="pt-8">
+        <h2 className="text-2xl">Introduction</h2>
+        <p className="pt-5">
+          Welcome to Better Giving! Thank you for your support of impactful
+          nonprofits, we’re grateful you’re here.
+        </p>
+        <p className="pt-5">
+          These Terms of Use (the "Terms") are a binding contract ("Agreement")
+          by and between you ("you." "your," or "Donors") and Altruistic
+          Partners Empowering Society, Inc., d/b/a Better Giving ("Better
+          Giving," "we," "us," or "our"). Better Giving is a public charity
+          recognized by the Internal Revenue Service (the "IRS") under Section
+          501(c)(3) of the Internal Revenue Code (Federal Tax ID # 87-3758939).
+        </p>
+        <p className="pt-5">
+          Better Giving provides and offers a charitable giving platform (the
+          "Platform") which enables Donors to make charitable contributions to
+          Better Giving and make grant recommendations to qualified nonprofit
+          organization(s) ("NPOs") on the Platform to advance their missions.
+          Better Giving accepts contributions of fiat currency, cryptocurrency
+          and securities from Donors on the Platform and makes charitable grants
+          to NPOs.
+        </p>
+        <p className="pt-5">
+          In furtherance of its charitable mission, Better Giving (1) maintains
+          a donor-advised fund (the "Fund") enabling Donors to donate assets to
+          Better Giving and make grant recommendations to NPOs; (2) provides
+          fiscal sponsorship services to qualifying NPOs, and accepting
+          donations and grants on their behalf; and (3) maintains and manages a
+          board designated endowment (or quasi-endowment) (hereinafter the
+          "Endowment") to accept unrestricted donations from Donors, to support
+          NPOs with sustainable grant funding, at Better Giving’s discretion.
+        </p>
+        <p className="pt-5">
+          By making donations to Better Giving, you acknowledge and represent
+          that you (i) agree that these Terms are supported by reasonable,
+          valuable and sufficient consideration, (ii) acknowledge the receipt of
+          such consideration, and (iii) state that you have read and understand,
+          and agree to be bound by these Terms.
+        </p>
+        <p className="pt-5">
+          We may revise and update these Terms from time to time at our sole
+          discretion. All changes are effective immediately when posted.
+        </p>
+        <p className="pt-5">
+          The headings and subheadings are for reference only and do not limit
+          the terms or application of the applicable section. Your trust is very
+          important to us. If you have questions about this Agreement, please
+          email support@better.giving.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">1. Terms and Conditions for Donations</h2>
+        <p className="pt-5">
+          <strong>a.</strong> Control of Funds. By making a donation, you
+          understand, acknowledge and agree that you are making a charitable
+          donation to Better Giving, a public charity recognized by the Internal
+          Revenue Service as a tax-exempt organization under Internal Revenue
+          Code 501(c)(3). You understand, acknowledge and agree that all
+          donations made to Better Giving are irrevocable, unrestricted and
+          non-refundable charitable contributions and that Better Giving has
+          full and exclusive legal control over any and all donated funds or
+          assets.
+        </p>
+        <p className="pt-5">
+          <strong>b.</strong> Authority. By making a donation to Better Giving,
+          you hereby represent and warrant that you have the legal authority to
+          make a donation and that any and all funds or assets donated to Better
+          Giving belong to you and are free and clear of any and all
+          encumbrances. Better Giving will provide you with a receipt for your
+          donation in accordance with applicable tax laws.
+        </p>
+        <p className="pt-5">
+          <strong>c.</strong> Donation Options: When you make a donation to
+          Better Giving, you may either (i) recommend a specific qualified NPO
+          to receive a one-time grant from Better Giving, or (ii) may direct
+          your contribution to the Better Giving Endowment and recommend an NPO
+          to be supported by the principal of your contribution in perpetuity.
+          Better Giving retains the ultimate authority and discretion to approve
+          and disburse any grants in accordance with this Agreement and any
+          applicable laws and regulations.
+        </p>
+        <p className="pt-5">
+          Donation for Immediate Grant. You may make a one-time donation to
+          Better Giving and recommend an NPO to receive a grant from Better
+          Giving, which will be disbursed to the NPO on a rolling basis.
+        </p>
+        <p className="pt-5">
+          Donation to Board Designated (or Quasi) Endowment. You may direct your
+          charitable contribution to the Better Giving Endowment, which is a
+          board designated endowment created and maintained by Better Giving to
+          support NPOs in perpetuity. When making contributions to the
+          Endowment, Donors may recommend NPOs to be supported by income
+          generated from the principal of their contribution(s) in perpetuity,
+          with grant disbursements issued to NPOs on a quarterly basis. All
+          contributions made by Donors to the Endowment are unrestricted
+          contributions and Donors understand that both principal and income are
+          available for expenditure by Better Giving at the discretion of its
+          board of directors. Although the Endowment allows for the withdrawal
+          of principal, the Better Giving board of directors views contributions
+          to the Endowment as long term investments with principal remaining
+          intact to support NPOs, as part of Better Giving’s charitable mission.
+        </p>
+        <p className="pt-5">
+          <strong>d.</strong> NPO Eligibility. On an ongoing basis, we will take
+          steps to confirm that each NPO you make grant recommendations to, is
+          registered as a public charity in good standing under Section
+          501(c)(3) of the Internal Revenue Code or in the case of non-US
+          organizations, recognized as the equivalent of a charitable
+          organization by the appropriate regulatory and/or governmental
+          agencies in the relevant jurisdiction. If circumstances make it
+          impossible or inappropriate to disburse funds to the recommended
+          charitable organization, we may, at our sole discretion, select an
+          alternate charitable organization to receive the grant. You
+          acknowledge that the ultimate discretion in fulfilling a grant
+          recommendation rests with Better Giving.
+        </p>
+        <p className="pt-5">
+          <strong>e.</strong> Donor Fees:
+        </p>
+        <p className="pt-5">
+          Donors are charged a base fee of 1.5% for all donations made on the
+          Platform, in addition to a 1.4% processing fee for non-fiat donations
+          (cryptocurrency, publicly traded securities, and Fund contributions).
+          Better Giving provides fiscal sponsorship services to certain
+          qualified NPOs and charitable projects. Donors making contributions to
+          Better Giving to support fiscally sponsored NPO’s are charged a 2.9%
+          fee.
+        </p>
+        <p className="pt-5">
+          <strong>f.</strong> Charitable Use. Donations made to Better Giving
+          may only be used for charitable purposes in accordance with any and
+          all applicable local, state, federal or national laws. Any grant
+          recommendations may not confer an impermissible private benefit.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">2. Privacy</h2>
+        <p className="pt-5">
+          Your personally identifiable information ("PII"), including your name,
+          email address and physical address will be handled in accordance with
+          our{" "}
+          <Link
+            to={appRoutes.privacy_policy}
+            className="hover:text-blue-d1 text-blue"
+          >
+            Privacy Policy
+          </Link>
+          , and unless you have elected to donate anonymously, may be shared
+          with the NPO(s). We use commercially reasonable safeguards to preserve
+          the integrity and security of your PII. However, we cannot guarantee
+          that unauthorized third parties will never be able to obtain or use
+          your PII or aggregate data for improper purposes. You acknowledge that
+          you provide your PII and aggregate data at your own risk.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">3. Indemnity, Warranties and Disclaimers</h2>
+        <p className="pt-5">
+          <strong>a.</strong> You agree to indemnify, hold harmless, and, defend
+          Better Giving and its affiliates and each of its and their officers,
+          directors, employees, licensees, agents and vendors from and against
+          all claims, costs, losses, damages, expenses (including attorneys’
+          fees and court costs) and liabilities arising from (i) your use of our
+          services, or activities in connection with making donations in
+          accordance with these Terms; or (ii) your violations of these Terms.
+          Better Giving reserves the right to assume the exclusive defense and
+          control of any matter otherwise subject to indemnification by you and,
+          in such case, you agree to cooperate with Better Giving’ defense of
+          such claim.
+        </p>
+        <p className="pt-5">
+          <strong>b.</strong> YOU ACKNOWLEDGE THAT OUR PERFORMANCE HEREUNDER IS
+          PROVIDED ON AN "AS IS" BASIS, AND WE DISCLAIM ALL REPRESENTATIONS AND
+          WARRANTIES UNDER THIS AGREEMENT, WHETHER EXPRESS, IMPLIED OR
+          STATUTORY. YOU ACKNOWLEDGE THAT BETTER GIVING DOES NOT OPERATE THE
+          PLATFORM AND CONSEQUENTLY WE MAKE NO REPRESENTATIONS OR WARRANTIES
+          REGARDING THE PLATFORM, INCLUDING THE PERFORMANCE, EFFICIENCY OR
+          AVAILABILITY THEREOF. WE MAKE NO REPRESENTATIONS OR WARRANTIES
+          REGARDING ANY LEGAL REQUIREMENTS TO WHICH YOU MAY BE SUBJECT; NOR DO
+          WE MAKE ANY REPRESENTATIONS OR WARRANTIES REGARDING THE APPLICABILITY
+          OF TAX LAWS TO ANY DONOR, SUCH AS, BY WAY OF EXAMPLE, ANY DONOR’S
+          ABILITY TO OBTAIN TAX DEDUCTIONS OR OTHER TAX BENEFITS IN CONNECTION
+          WITH DONATIONS MADE TO BETTER GIVING.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">4. No Professional Advice</h2>
+        <p className="pt-5">
+          Before you make any financial, legal, or other decisions regarding any
+          donations made to Better Giving and any tax deductions you may be
+          eligible for, you should seek independent professional advice from an
+          individual who is licensed and qualified in the area for which such
+          advice would be appropriate. We do not offer any tax or legal advice.
+          Please consider working with a tax professional, account and/or
+          attorney to address any questions you may have concerning the impact
+          of using the Platform to make donations. You agree and acknowledge
+          that it is your responsibility to consult with any tax professionals
+          regarding the deductibility and tax consequences of any donation(s)
+          made to Better Giving.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">5. Miscellaneous Terms and Conditions</h2>
+        <p className="pt-5">
+          <strong>a.</strong> Should any provision of this Agreement be held by
+          a court or other tribunal of competent jurisdiction to be void,
+          illegal, invalid, inoperative, or unenforceable, the remaining
+          provisions of this Agreement shall not be affected and shall continue
+          in effect, and the invalid provision shall be deemed modified to the
+          least degree necessary to remedy such invalidity.
+        </p>
+        <p className="pt-5">
+          <strong>b.</strong> Our failure to partially or fully exercise any
+          right will not be considered a waiver of that right unless we so state
+          in writing to you. The waiver of any breach, shall not prevent a
+          subsequent exercise of such right or be deemed a waiver of any
+          subsequent breach of the same or any other term of this Agreement. Any
+          remedies made available to us by the terms of this Agreement are
+          cumulative and are without prejudice to any other remedies that may be
+          available to us in law or equity.
+        </p>
+        <p className="pt-5">
+          <strong>c.</strong> Dispute Resolution. Any dispute between you and
+          Better Giving which cannot be resolved by negotiation shall be
+          submitted to mediation, and if mediation fails, arbitration, under the
+          rules of any entity that you and we may subsequently agree upon in
+          writing. Any arbitration award issued by the arbitrator shall be
+          final, binding, and enforceable in any court of competent
+          jurisdiction. Notwithstanding the foregoing, you acknowledge that
+          unauthorized use of our proprietary materials, information or
+          technology may cause irreparable harm to Better Giving for which
+          monetary damages would be an inadequate remedy. Accordingly, we have
+          the right, without the necessity of posting bond, to seek injunctive
+          or other equitable relief from any court of competent jurisdiction to
+          protect our rights in intellectual property or confidential
+          information.
+        </p>
+        <p className="pt-5">
+          <strong>d.</strong> Governing Law. This Agreement will be governed by
+          and construed in accordance with the substantive laws of the State of
+          Delaware without regard to conflicts of laws and all disputes arising
+          under and relating to this Agreement shall be brought and resolved
+          exclusively in the State of Delaware.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Legal/TermsNonprofits.tsx
+++ b/src/pages/Legal/TermsNonprofits.tsx
@@ -1,0 +1,568 @@
+export default function TermsNonprofits() {
+  return (
+    <div className="padded-container min-h-screen pb-6">
+      <h1 className="font-bold uppercase col-span-full text-2xl lg:text-3xl break-words mt-6">
+        Terms of Use: Nonprofit Organizations
+      </h1>
+      <span className="text-gray text-sm">
+        Last modified: September 8, 2023
+      </span>
+      <section className="pt-8">
+        <h2 className="text-2xl">Introduction</h2>
+        <p className="pt-5">
+          These Terms of Use (the "Terms") are a binding contract ("Agreement")
+          by and between you and Altruistic Partners Empowering Society, Inc.,
+          d/b/a Better Giving ("Better Giving," "we," "us," or "our"). Better
+          Giving is a public charity recognized by the Internal Revenue Service
+          (the "IRS") under Section 501(c)(3) of the Internal Revenue Code
+          (Federal Tax ID # 87-3758939). Better Giving provides and offers a
+          charitable giving platform (the "Platform") through which we accept
+          and receive charitable contributions from donors ("Donors") and make
+          grants to qualified participating nonprofit organizations ("NPOs",
+          "you" or "your") to advance their charitable missions. The Platform
+          enables Donors to make donations of fiat currency, cryptocurrencies
+          and securities, and make grant recommendations to NPOs.
+        </p>
+        <p className="pt-5">
+          In furtherance of its charitable mission, Better Giving (1) maintains
+          a donor-advised fund (the "Fund") enabling Donors to donate assets to
+          Better Giving and make grant recommendations to NPOs; (2) provides
+          fiscal sponsorship services to qualifying NPOs, and accepting
+          donations and grants on their behalf; and (3) maintains and manages a
+          board designated endowment (or quasi-endowment) (hereinafter the
+          "Endowment") to accept unrestricted donations from Donors, to support
+          NPOs with sustainable grant funding, at Better Giving’s sole
+          discretion. Please read this Agreement carefully as these Terms
+          explain our commitments to you and our requirements of you as a NPO.
+        </p>
+        <p className="pt-5">
+          By using the Platform and/or registering your account, you acknowledge
+          and represent that you are at least eighteen (18) years of age and
+          have read, understand and agree to be bound by the Terms. If you are
+          agreeing to these Terms on behalf of an organization or legal entity,
+          you represent and warrant that you are authorized to agree to these
+          Terms on that organization’s or entity’s behalf and bind them to these
+          Terms (in which case, the references to "you" and "your" in these
+          Terms, except for in this sentence, refer to that organization or
+          entity). You further represent that you have the full authority to
+          enter into and comply with the Terms of this Agreement and have
+          obtained the required organizational approval to use the Platform. You
+          further represent that your access and use of the Platform will fully
+          comply with all applicable laws and regulations, as well as any and
+          all internal policies, including but not limited to, gift acceptance,
+          investment and fundraising policies. You agree that you will not
+          access or use the Platform to conduct, execute, promote, or otherwise
+          engage in any illegal activity.
+        </p>
+        <p className="pt-5">
+          We may revise and update these Terms from time to time in our sole
+          discretion. All changes are effective immediately when we post them.
+        </p>
+        <p className="pt-5">
+          Your continued use of the Platform following the posting of revised
+          Terms means that you accept and agree to the changes. You are expected
+          to check this page from time to time so you are aware of any changes,
+          as they are binding on you.
+        </p>
+        <p className="pt-5">
+          The headings and subheadings are for reference only and do not limit
+          the terms or application of the applicable section. Your trust is very
+          important to us. If you have questions about this Agreement please
+          contact, support@better.giving.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">1. Our relationship with you</h2>
+        <p className="pt-5">
+          <strong>a.</strong> We register vetted NPOs and provide information
+          about them to Donors that are interested in donating assets to Better
+          Giving and disburse grants to NPOs based on grant recommendations made
+          by Donors.
+        </p>
+        <p className="pt-5">
+          <strong>b.</strong> We accept donations of fiat currency, securities,
+          cryptocurrency and digital assets to make grants to NPOs. When Donors
+          donate to Better Giving, they may either (i) recommend a specific
+          qualified NPO to receive a one-time grant from Better Giving, or (ii)
+          may direct their contribution to the Better Giving Endowment and
+          recommend an NPO to be supported by the principal of that contribution
+          in perpetuity. Better Giving retains the ultimate authority and
+          discretion to approve and disburse any grants in accordance with this
+          Agreement and any applicable laws and regulations.
+        </p>
+        <p className="pt-5">
+          Donation for Immediate Grant. Donors may make a one-time donation to
+          the Better Giving Fund and recommend an NPO to receive a grant from
+          Better Giving, which will be disbursed to the NPO on a rolling basis.
+        </p>
+        <p className="pt-5">
+          Donation to Board Designated (or Quasi) Endowment. Donors may direct
+          their charitable contribution to the Better Giving Endowment, which is
+          a board designated endowment created and maintained by Better Giving
+          to support NPOs in perpetuity. When making contributions to the
+          Endowment, Donors may recommend NPOs to be supported by income
+          generated from the principal of their contribution(s) in perpetuity,
+          with grant disbursements issued to NPOs on a quarterly basis. All
+          contributions made by Donors to the Endowment are unrestricted
+          contributions and Donors understand that both principal and income are
+          available for expenditure by Better Giving at the discretion of its
+          board of directors. Although the Endowment allows for the withdrawal
+          of principal, the Better Giving board of directors views contributions
+          to the Endowment as long term investments with principal remaining
+          intact to support NPOs, as part of Better Giving’s charitable mission.
+        </p>
+        <p className="pt-5">
+          <strong>c.</strong> We facilitate the issuance of tax receipts showing
+          the donation transaction between the Donor and Better Giving. It is
+          the sole responsibility of the Donor to ensure that their contribution
+          qualifies for tax relief, if tax relief is sought, as permitted by
+          applicable tax law.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">2. Grant Eligibility</h2>
+        <p className="pt-5">
+          <strong>a.</strong> We take steps to confirm that each NPO is a
+          qualified nonprofit organization in good standing.
+          <ul className="pl-8 list-disc list-outside">
+            <li className="pt-2">
+              US Charities. If you are legally registered in the United States,
+              we take steps to confirm that you are recognized by the Internal
+              Revenue Service as exempt from federal income tax under Internal
+              Revenue Code 501(c)(3), and have public charity status under
+              section 509(a)(1) or 509(a)(2), and that such recognition is not
+              currently revoked.
+            </li>
+            <li className="pt-2">
+              Non-US Charities. If you are legally registered outside of the
+              United States, we take steps to confirm that you are recognized as
+              the equivalent of the charitable organization by the relevant
+              regulatory and/or governmental agencies in your jurisdiction, and
+              that such recognition is not currently revoked. If you are
+              registered outside of the United States and wish to receive grants
+              from Better Giving, you are required to enter into and comply with
+              the terms and conditions of the Fiscal Sponsorship and Grant
+              Agreement, which is incorporated by reference herein. In the event
+              that there is any conflict between this Agreement and any term or
+              condition in the Fiscal Sponsorship and Grant Agreement, the
+              Fiscal Sponsorship and Grant Agreement shall control.
+            </li>
+          </ul>
+        </p>
+        <p className="pt-5">
+          You must promptly update and notify us in case of any changes to your
+          status as a NPO, and/or if the Internal Revenue Service or any state,
+          local or national government agency initiates an inquiry into your
+          status. You agree to provide any information that we may reasonably
+          request related to your status as a NPO. NPOs may be required to
+          submit information to us which allows us to validate their continued
+          eligibility to use the Platform. We reserve the right to deny or
+          revoke NPO status to any organization that fails, in our sole
+          discretion and determination, to meet these standards.
+        </p>
+        <p className="pt-5">
+          <strong>b.</strong> To be eligible to receive grants from us you must
+          provide us with information which may include, but is not limited to
+          the following:
+          <ul className="pl-8 list-disc list-outside">
+            <li className="pt-2">
+              Your organization’s current legal name (or d/b/a) and, if you have
+              one, an electronic version of your logo that meets our technical
+              requirements;
+            </li>
+            <li className="pt-2">
+              A written statement that describes your charitable purposes;
+            </li>
+            <li className="pt-2">
+              A valid form of personal identification. (Only for Non-US NPOs);
+            </li>
+            <li className="pt-2">
+              Your organization’s registration/organizing documents, and any
+              certificates and/or other official documents issued by any
+              regulatory/governmental agencies evidencing charitable status in
+              the jurisdiction in which you are organized. (Only for Non-US
+              NPOs).
+            </li>
+            <li className="pt-2">
+              Bank account information for a current bank account held solely in
+              the name of your organization;
+            </li>
+            <li className="pt-2">
+              Bank account verification letter. (Only for Non-US NPOs);
+            </li>
+            <li className="pt-2">
+              If you are registered in the U.S., your organization’s Employer
+              Identification Number (EIN) or NPO reference number for your
+              jurisdiction;
+            </li>
+            <li className="pt-2">
+              A signed copy of the Fiscal Sponsorship document (Non-US NPOs);
+            </li>
+            <li className="pt-2">A valid, working email address; and</li>
+            <li className="pt-2">
+              Completion of the Better Giving registration form and process.
+            </li>
+          </ul>
+        </p>
+        <p className="pt-5">
+          <strong>c.</strong> You will be eligible to receive grants in
+          accordance with this Agreement only after we have reviewed your
+          submitted information and materials and approved you as a NPO.
+        </p>
+        <p className="pt-5">
+          <strong>d.</strong> We reserve the right to request any additional
+          information we may require to assess your eligibility as a qualified
+          NPO, on an ongoing basis and at our sole discretion.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">3. Your Obligations</h2>
+        <p className="pt-5">
+          <strong>a.</strong> You hereby grant Better Giving a non-exclusive
+          license to use your name and logo during the term of this Agreement.
+          We acknowledge that you retain ownership of your trademarks, trade
+          names and service marks and any associated goodwill.
+        </p>
+        <p className="pt-5">
+          <strong>b.</strong> NPOs bear sole responsibility for complying with
+          all laws, rules and regulations applicable to your activities under
+          this Agreement and to your status as a NPO and public charity. You
+          understand that you may have obligations to register under state
+          charitable solicitation laws. You agree that we have no liability for
+          your failure to register properly. You agree to bear all costs
+          associated with your compliance with such requirements. You agree
+          that, for purposes of state charitable solicitation laws or
+          regulations, nothing in this Agreement is intended to cause Better
+          Giving in any way to act as a professional fundraiser or fundraising
+          counsel on your behalf.
+        </p>
+        <p className="pt-5">
+          <strong>c.</strong> You hereby agree to promptly notify Better Giving
+          in the event there is any change to your status as a NPO, or ability
+          to carry out the charitable purposes for which you have received grant
+          disbursements.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">4. Receiving Donations</h2>
+        <p className="pt-5">
+          <strong>a.</strong> You acknowledge that we make no promise that you
+          will receive any grants from us as a result of your status as a NPO.
+        </p>
+        <p className="pt-5">
+          <strong>b.</strong>You understand that Donors make their donations to
+          Better Giving and not to NPOs. Better Giving retains exclusive legal
+          control over all donations received from Donors, and exercises sole
+          discretion in making any and all grants to NPOs. We make grant
+          distributions to qualified NPOs based upon recommendations made by
+          Donors, and consequently any grants received in accordance with this
+          Agreement will be received by you from Angel Giving.
+        </p>
+        <p className="pt-5">
+          c. Pursuant to our Privacy Policy, we may disclose to you information
+          about Donors, including name and contact information. You agree that
+          we disclose this information to you only for the purpose of enabling
+          you to acknowledge donations and to provide a reasonable amount of
+          information about your charitable work. You become the data controller
+          of the Donor’s personal information that we provide to you for this
+          limited purpose. You must not use the Donor’s personal information for
+          any other purpose without the Donor’s further consent, including but
+          not limited to for marketing purposes. You agree that you will obtain
+          consent from Donors to use the information we provide to you for any
+          purpose beyond what is contained in this clause.
+        </p>
+        <p className="pt-5">
+          <strong>d.</strong> On an ongoing basis, all grant recommendations
+          made by Donors are reviewed and approved by Better Giving. All grant
+          disbursements we may make to you, will be made by direct bank
+          transfer. As a condition of receiving grants in accordance with the
+          Agreement, you hereby represent and warrant that all bank account
+          information provided to Better Giving pertains to bank account(s) held
+          solely in the name of your NPO, and managed and maintained by duly
+          authorized legal representatives in accordance with any and all
+          applicable state, federal and national laws.
+        </p>
+        <p className="pt-5">
+          <strong>e.</strong> All grant disbursements made by Better Giving to
+          you may only be used for charitable purposes in accordance with any
+          and all applicable local, state, federal or national laws. Such
+          donations may not confer impermissible private benefit(s), and may
+          also not be used to engage in, support, or promote hate, violence,
+          terrorist activity, related training of any kind, money laundering, or
+          other illegal activities, or be used for any impermissible political
+          activities.
+        </p>
+        <p className="pt-5">
+          <strong>f.</strong> In the event you lose your status as an NPO, cease
+          your charitable operations or breach these Terms, Better Giving, in
+          its sole discretion may select another NPO to receive any grants or
+          use the donation(s) in any manner consistent with our charitable
+          purpose.
+        </p>
+        <p className="pt-5">
+          <strong>g.</strong> Fees: Use of the Platform as well as Better
+          Giving’s services are free for NPOs. We do not charge you a fee for
+          registering on the Platform nor for receiving grants from Better
+          Giving. There are no hidden fees or recurring charges.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">5. Warranties and Disclaimers</h2>
+        <p className="pt-5">
+          <strong>a.</strong> You represent and warrant to us that: (i) you are,
+          and at all times during the term of this Agreement will remain, a
+          eligible NPO as described in Section 2(a); (ii) you will utilize
+          grants received from Better Giving solely in a manner that is
+          consistent with such status; (iii) you will at all times be in
+          compliance with all applicable laws, rules and regulations, including
+          any requirements governing charitable status and solicitation of
+          charitable donations in your jurisdiction; (iv) all information you
+          have provided to us is true and accurate at all times; (v) you have
+          the right to enter into this Agreement on behalf of your organization;
+          (vi) you have the right to grant the licenses to Better Giving
+          hereunder; and our use, as contemplated by this Agreement, of
+          materials or rights licensed hereunder, will not infringe the
+          intellectual property rights or similar rights of any third party;
+          (vii) you will at all times comply with the terms and conditions of
+          this Agreement.
+        </p>
+        <p className="pt-5">
+          <strong>b.</strong> You agree and acknowledge that all Donors who make
+          grant recommendations to support you have not and will receive any
+          goods or services of value in return of their Donation to Better
+          Giving, except where such goods or services are disregarded in
+          accordance with guidance provided by the Internal Revenue Service.
+        </p>
+        <p className="pt-5">
+          <strong>c.</strong> You agree, represent and warrant that you shall
+          remain compliant at all times with all laws, statutes, and regulations
+          restricting U.S. persons from dealing with any individuals, entities
+          or groups subject to sanctions imposed or administered by the Office
+          of Foreign Assets Control of the United States Department of Treasury
+          ("OFAC").
+        </p>
+        <p className="pt-5">
+          <strong>d.</strong> Executive Orders and Laws of many countries,
+          including those of the United States, prohibit transactions with, and
+          the provision of resources and support to, individuals and
+          organizations associated with terrorism. You hereby represent and
+          warrant that you are compliant with all applicable provisions of such
+          Executive Orders and Laws, and that you have not provided, and will
+          take all reasonable steps to ensure that you do not and will not
+          knowingly provide, material support or resources to any individual or
+          entity that commits, attempts to commit, advocates, facilitates, or
+          participates in terrorist acts, or has committed, attempted to commit,
+          facilitate, or participated in terrorist acts.
+        </p>
+        <p className="pt-5">
+          <strong>e.</strong> You agree to indemnify, hold harmless, and, at our
+          option, defend Better Giving and its directors, employees, licensees,
+          agents and vendors from and against all claims, costs, losses,
+          damages, expenses (including attorneys’ fees and court costs) and
+          liabilities arising from your breach or alleged breach of any
+          obligation, covenant, representation or warranty under this Agreement.
+          If Better Giving requires you to provide defense of any matter for
+          which indemnity is or may be due hereunder, Better Giving may
+          participate in such defense by counsel of its choice at its own
+          expense. You will not settle any claim for which indemnity is due
+          hereunder unless such settlement completely and forever releases
+          Better Giving and the other indemnified parties with respect to such
+          claim, or unless Better Giving provides its prior written consent. Any
+          settlement imposing or requiring Better Giving to take or refrain from
+          taking any action will require the prior written consent of Better
+          Giving.
+        </p>
+        <p className="pt-5">
+          <strong>f.</strong> YOU ACKNOWLEDGE THAT THE PLATFORM AND OUR
+          PERFORMANCE HEREUNDER ARE PROVIDED ON AN "AS IS" BASIS, AND WE
+          DISCLAIM ALL REPRESENTATIONS AND WARRANTIES UNDER THIS AGREEMENT,
+          WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, WITHOUT LIMITATION,
+          ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+          TITLE, NON-INFRINGEMENT, QUIET ENJOYMENT, DATA ACCURACY OR SYSTEM
+          INTEGRATION. NO WARRANTY IS MADE BY US ON THE BASIS OF TRADE USAGE,
+          COURSE OF DEALING, OR COURSE OF PERFORMANCE. YOU ACKNOWLEDGE THAT WE
+          MAKE NO REPRESENTATIONS OR WARRANTIES REGARDING THE PERFORMANCE,
+          EFFICIENCY OR AVAILABILITY OF THE PLATFORM. NO REPRESENTATION OR
+          WARRANTY IS MADE THAT OPERATION OF THE PLATFORM WILL BE UNINTERRUPTED
+          OR ERROR-FREE, OR THAT THE PLATFORM WILL OPERATE AS EXPECTED OR WILL
+          MEET YOUR PARTICULAR NEEDS OR PURPOSES. YOU ACKNOWLEDGE THAT WE MAKE
+          NO REPRESENTATIONS OR WARRANTIES REGARDING ANY LEGAL REQUIREMENTS TO
+          WHICH YOUR ORGANIZATION MAY BE SUBJECT, SUCH AS, BY WAY OF EXAMPLE,
+          ANY REGISTRATION REQUIREMENTS RELATED TO CHARITABLE SOLICITATIONS; NOR
+          DO WE MAKE ANY REPRESENTATIONS OR WARRANTIES REGARDING THE
+          APPLICABILITY OF TAX LAWS TO YOUR ORGANIZATION OR TO ANY DONOR, SUCH
+          AS, BY WAY OF EXAMPLE, ANY DONOR’S ABILITY TO OBTAIN TAX DEDUCTIONS OR
+          OTHER TAX BENEFITS IN CONNECTION WITH DONATIONS MADE THROUGH THE
+          PLATFORM. YOU ACKNOWLEDGE THAT WE MAKE NO REPRESENTATIONS OR
+          WARRANTIES TO YOU THAT YOU WILL RECEIVE ANY MINIMUM AMOUNT OF
+          DONATIONS OR ANY DONATIONS AT ALL UNDER THIS AGREEMENT.
+        </p>
+        <p className="pt-5">
+          <strong>g.</strong> IN NO EVENT SHALL WE OR ANY OF OUR OFFICERS,
+          DIRECTORS, EMPLOYEES, CONTRACTORS OR AFFILIATES BE LIABLE TO YOU FOR
+          ANY INCIDENTAL, INDIRECT, SPECIAL, CONSEQUENTIAL OR PUNITIVE DAMAGES,
+          REGARDLESS OF THE NATURE OF THE CLAIM, INCLUDING, WITHOUT LIMITATION,
+          LOST REVENUES, COSTS OF DELAY, ANY FAILURE OF DELIVERY, BUSINESS
+          INTERRUPTION, COSTS OF LOST OR DAMAGED DATA OR DOCUMENTATION OR
+          LIABILITIES TO THIRD PARTIES ARISING FROM ANY SOURCE, NOR WILL WE BE
+          RESPONSIBLE FOR ANY DAMAGE, LOSS, OR INJURY RESULTING FROM HACKING,
+          TAMPERING, OR OTHER UNAUTHORIZED ACCESS OR USE OF THE PLATFORM OR THE
+          INFORMATION CONTAINED WITHIN IT. EVEN IF WE HAVE BEEN ADVISED OF THE
+          POSSIBILITY OF SUCH DAMAGES. OUR CUMULATIVE LIABILITY TO YOU FOR ALL
+          CLAIMS ARISING FROM OR RELATING TO THIS AGREEMENT, INCLUDING, WITHOUT
+          LIMITATION, ANY CAUSE OF ACTION SOUNDING IN CONTRACT, TORT OR STRICT
+          LIABILITY, SHALL NOT EXCEED THE AMOUNT YOU PAID TO US TO USE THE
+          PLATFORM, OR $100, WHICHEVER IS GREATER. THE FOREGOING LIMITATIONS AND
+          EXCLUSIONS OF LIABILITY ARE INTENDED TO APPLY WITHOUT REGARD TO
+          WHETHER OTHER PROVISIONS OF THIS AGREEMENT HAVE BEEN BREACHED OR HAVE
+          PROVEN INEFFECTIVE. IF YOU HAVE AUTHORIZED ANY THIRD PARTY TO ENTER
+          THIS AGREEMENT ON YOUR BEHALF (e.g., AN ASSOCIATION OF NONPROFIT
+          ORGANIZATIONS OR AGENT), OR TO PERFORM ON YOUR BEHALF (e.g., TO
+          RECEIVE AND PROCESS ANY DONATIONS MADE TO YOU), YOU UNDERSTAND AND
+          AGREE THAT YOU ARE RESPONSIBLE FOR THE ACTS AND OMISSIONS OF THAT
+          THIRD PARTY, AND WE HAVE NO RESPONSIBILITY UNDER THIS AGREEMENT OR ANY
+          LIABILITY TO YOU ARISING DIRECTLY OR INDIRECTLY FROM OR IN CONNECTION
+          WITH THAT THIRD PARTY’S ACTS OR OMISSIONS. YOU ACKNOWLEDGE THAT THE
+          PROVISIONS OF THIS PARAGRAPH AND THE PRECEDING PARAGRAPH FORM AN
+          ESSENTIAL BASIS OF THE ARRANGEMENT BETWEEN YOU AND US, AND ABSENT THE
+          DISCLAIMERS, LIMITATIONS AND EXCLUSIONS OF OUR LIABILITY SET FORTH
+          ABOVE, THE TERMS OF THIS AGREEMENT WOULD BE SUBSTANTIALLY DIFFERENT.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">6. Taxes</h2>
+        <p className="pt-5">
+          Notwithstanding your status as a NPO, you will be solely responsible
+          for any and all taxes, duties, levies, charges or assessments
+          applicable or payable in connection with any and all charitable grants
+          made to you pursuant to this Agreement.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">7. No Professional Advice</h2>
+        <p className="pt-5">
+          All information provided by Better Giving and the Platform is for
+          informational purposes only and should not be construed as
+          professional advice. Before accepting these Terms and using the
+          Platform, you should seek independent professional advice from an
+          individual who is licensed and qualified in the area for which such
+          advice would be appropriate. We do not offer any tax, accounting or
+          legal advice. Please consider engaging the appropriate professional to
+          address any questions you may have concerning the impact of utilizing
+          the Platform and receiving charitable grants in accordance with these
+          Terms.
+        </p>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">8. Term and Termination</h2>
+        <ol className="pl-5 list-decimal list-outside">
+          <li className="pt-2">
+            This Agreement becomes effective when you have accepted it by
+            following the instructions to register as a NPO on the Platform.
+            Once in effect, this Agreement will continue until terminated by
+            either you or us.
+          </li>
+          <li className="pt-2">
+            If you breach this Agreement at any time, you will not be considered
+            to be in good standing and we may suspend and/or withhold any grants
+            in our sole discretion. We may terminate this Agreement at any time
+            and for any reason by providing notice to you in accordance with
+            this Agreement.
+          </li>
+          <li className="pt-2">
+            Neither you nor Better Giving shall have any obligation to each
+            other following the termination of this Agreement, except those
+            obligations that survive this Agreement, as set forth in Section
+            9(e).
+          </li>
+          <li className="pt-2">
+            The obligations of Sections 3(b), 5, 7, 8, 9, and 10 will survive
+            the termination of this Agreement.
+          </li>
+        </ol>
+      </section>
+      <section className="pt-8">
+        <h2 className="text-2xl">9. Miscellaneous Terms and Conditions</h2>
+        <p className="pt-5">
+          <strong>a.</strong> This Agreement, together with any other documents
+          incorporated herein by reference constitutes the entire Agreement
+          between us and supersedes all previous negotiation, understandings and
+          agreements between us in relation to its subject matter.
+        </p>
+        <p className="pt-5">
+          <strong>b.</strong> You acknowledge that nothing in this Agreement
+          creates a partnership, joint venture, or employer-employee
+          relationship, and neither party is acting as an agent of the other
+          party. For purposes of clarity, neither party has any authority to
+          make any commitments on behalf of the other party or to purport to
+          bind the other party in any manner or to any extent.
+        </p>
+        <p className="pt-5">
+          <strong>c.</strong> We may give notice pursuant to this Agreement by
+          any means of contact you have provided us and notice will be effective
+          when sent. If you fail to provide valid and current contact
+          information as required, you waive your right to receive notices under
+          this Agreement during the period of such failure..
+        </p>
+        <p className="pt-5">
+          <strong>d.</strong> We may amend this Agreement at any time by posting
+          amended terms. We will send a message to the email address used to
+          register as a NPO, alerting you of such amendments. Except as
+          otherwise expressly stated in such a posting, all amended terms shall
+          automatically be effective and legally binding upon you seven (7) days
+          after having been posted. Your continuation as a NPO will constitute
+          your complete consent and acceptance to all such amended terms. If you
+          do not accept the amended terms you may terminate this Agreement as
+          set forth in Section 9 of this Agreement. Apart from such posting by
+          us, this Agreement may not otherwise be amended except in a written
+          document (i) that expressly references this Agreement and/or any
+          affected amended terms as posted by us and (ii) that is executed by
+          both you and us.
+        </p>
+        <p className="pt-5">
+          <strong>e.</strong> Should any provision of this Agreement be held by
+          a court or other tribunal of competent jurisdiction to be void,
+          illegal, invalid, inoperative, or unenforceable, the remaining
+          provisions of this Agreement shall not be affected and shall continue
+          in effect, and the invalid provision shall be deemed modified to the
+          least degree necessary to remedy such invalidity.
+        </p>
+        <p className="pt-5">
+          <strong>f.</strong> You may not assign this Agreement without our
+          prior written consent; any attempted assignment in violation of the
+          foregoing will be null and void. We may assign this Agreement to any
+          third party without your consent. All the terms and provisions of this
+          Agreement shall be binding upon, shall inure to the benefit of, and
+          shall be enforceable by the respective successors and permitted
+          assigns of you and us.
+        </p>
+        <p className="pt-5">
+          <strong>g.</strong> Our failure to partially or fully exercise any
+          right will not be considered a waiver of that right unless we so state
+          in writing to you. The waiver of any breach shall not prevent a
+          subsequent exercise of such right or be deemed a waiver of any
+          subsequent breach of the same or any other term of this Agreement. Any
+          remedies made available to us by the terms of this Agreement are
+          cumulative and are without prejudice to any other remedies that may be
+          available to us in law or equity.
+        </p>
+        <p className="pt-5">
+          <strong>h.</strong> Dispute Resolution. Any dispute between you and
+          Better Giving which cannot be resolved by negotiation shall be
+          submitted to mediation, and if mediation fails, arbitration, under the
+          rules of any entity that you and we may subsequently agree upon in
+          writing. Any arbitration award issued by the arbitrator shall be
+          final, binding, and enforceable in any court of competent
+          jurisdiction.
+        </p>
+        <p className="pt-5">
+          <strong>i.</strong> Governing Law. This Agreement will be governed by
+          and construed in accordance with the substantive laws of the State of
+          Delaware without regard to conflicts of laws and all disputes arising
+          under and relating to this Agreement shall be brought and resolved
+          exclusively in the State of Delaware.
+        </p>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Explanation of the solution
- Adds static pages for all three main legal docs that we have on WP pages today
- Adds links into Landing Page footer (new legal pages + blog link [ie. "News"])

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/1f2df0f8-20d6-4e2d-9b4d-1683176e5d34)