### PR TITLE
temp removal of paypal btns from checkout

### DIFF
--- a/src/components/donation/Steps/Splits/Splits.tsx
+++ b/src/components/donation/Steps/Splits/Splits.tsx
@@ -93,10 +93,9 @@ export default function Split({
       </div>
 
       <p className="text-sm text-navy-l1 mt-6">
-        Support {widgetConfig ? widgetConfig.endowment.name : "this nonprofit"}
-        's future by contributing to the Sustainability Fund, which invests your
-        donation for long-term growth to provide reliable, ongoing funding. Give
-        today, give forever.
+        Support this nonprofit's future by contributing to the Sustainability
+        Fund, which invests your donation for long-term growth to provide
+        reliable, ongoing funding. Give today, give forever.
       </p>
 
       <ContinueBtn

--- a/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
@@ -10,11 +10,9 @@ import { currency } from "../../common/Currency";
 import Summary from "../../common/Summary";
 import Loader from "../Loader";
 import Checkout from "./Checkout";
-import Paypal from "./Paypal";
 
 // Followed Stripe's custom flow docs
 // https://stripe.com/docs/payments/quickstart
-
 const stripePromise = loadStripe(PUBLIC_STRIPE_KEY);
 
 export default function StripeCheckout(props: StripeCheckoutStep) {
@@ -57,29 +55,6 @@ export default function StripeCheckout(props: StripeCheckoutStep) {
           : undefined
       }
     >
-      {details.frequency === "once" && (
-        <>
-          {/* we don't have subscriptions for paypal for now */}
-          <div className="has-[#paypal-failure-fallback]:hidden peer">
-            <p className="mb-2 font-medium">Express checkout</p>
-            <div className="flex items-center">
-              <ErrorBoundary
-                fallback={
-                  <div id="paypal-failure-fallback" className="hidden" />
-                }
-              >
-                <Paypal {...props} />
-              </ErrorBoundary>
-            </div>
-          </div>
-          <div className="relative border border-gray-l4 h-px w-full mb-8 mt-6 grid place-items-center peer-has-[.hidden]:hidden">
-            <span className="absolute bg-white px-4 text-navy-l2 text-xs">
-              OR
-            </span>
-          </div>
-        </>
-      )}
-
       <ErrorBoundary>
         {isLoading ? (
           <Loader msg="Loading payment form.." />


### PR DESCRIPTION
## Explanation of the solution
- Removal of PayPal buttons from Stripe checkout
- Unrelated fix of broken build from earlier commits (copy changes)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
