### PR TITLE
Wise validation display

### DIFF
--- a/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
+++ b/src/components/BankDetails/RecipientDetails/RecipientDetailsForm/RecipientDetailsForm.tsx
@@ -101,9 +101,7 @@ export default function RecipientDetailsForm({
 
           //filter "NOT_VALID"
           const _errs = content.errors;
-          const validations = content.errors.filter(
-            (err) => err.code === "NOT_VALID"
-          );
+          const validations = _errs.filter((err) => err.code === "NOT_VALID");
 
           if (isEmpty(validations)) return displayError(_errs[0].message);
 

--- a/src/services/aws/wise.ts
+++ b/src/services/aws/wise.ts
@@ -4,7 +4,6 @@ import {
   Quote,
   V1RecipientAccount,
   V2RecipientAccount,
-  ValidationContent,
   WiseCurrency,
 } from "types/aws";
 import { Currency } from "types/components";
@@ -26,12 +25,6 @@ export const wise = aws.injectEndpoints({
           body: payload,
           headers: { "Content-Type": "application/json" },
         };
-      },
-      transformErrorResponse(res) {
-        if (res.status === 422) {
-          return (res.data as ValidationContent).errors[0].message;
-        }
-        return "Failed to create recipient";
       },
     }),
     recipient: builder.query<V2RecipientAccount, string>({


### PR DESCRIPTION
I remember prior to `v1.9.2`, prod doesn't parse wise validation errors and just displays validation error in modal. The refactored banking form in `v1.9.2` displays error inline instead - prob missed in conflict resolution


## Explanation of the solution
* remove error transform in endpoint

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
