### PR TITLE
Rolled back stripe donation endpoint

### DIFF
--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -106,7 +106,7 @@ export const apes = createApi({
     }),
     stripePaymentIntent: builder.query<string, StripePaymentIntentParams>({
       query: (data) => ({
-        url: "fiat-donation/stripe/v2",
+        url: "fiat-donation/stripe",
         method: "POST",
         body: JSON.stringify(data),
       }),


### PR DESCRIPTION
Related to BG-1318

## Explanation of the solution
Rolling back the endpoint used for `stripe-proxy` in APES AWS to `/fiat-donation/stripe` because it already uses API Gateway's stage variables. This stage variable allows us to work on `staging` without overwriting the code in `production`. Setting the API endpoint is also a one-time thing because we don't have to update the endpoint's versions. We would only need to update the Lambda's aliases to point into the correct Lambda versions.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- create a `one-time` donation intent using Stripe
- verify that the intent appears in the `Awaiting Payment` tab
- pay the donation intent
- verify that the donation now appears in the `Pending` tab
- if donating as anon, verify that the record changes `status` and `transactionId` in the holding DB table in APES AWS

## UI changes for review
No major UI changes.