### PR TITLE
Bump prod(future) program delete endpoint 

### DIFF
--- a/src/services/aws/programs.ts
+++ b/src/services/aws/programs.ts
@@ -13,7 +13,7 @@ const programs = aws.injectEndpoints({
     program: builder.query<Program, { endowId: number; programId: string }>({
       providesTags: ["program"],
       query: ({ endowId, programId }) =>
-        `/${v(1)}/endowments/${endowId}/programs/${programId}`,
+        `/${v(2)}/endowments/${endowId}/programs/${programId}`,
     }),
     newProgram: builder.mutation<
       { id: string },


### PR DESCRIPTION
## Explanation of the solution
`/v1` is already used in prod, bump to `/v2` so no need to update this after merge 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
