### PR TITLE
Added authorization header to registration update endpoint

### DIFF
--- a/src/services/aws/registration/registration.ts
+++ b/src/services/aws/registration/registration.ts
@@ -59,9 +59,10 @@ const registration_api = aws.injectEndpoints({
     updateReg: builder.mutation<any, RegistrationUpdate>({
       query: ({ reference, ...payload }) => {
         return {
-          url: `v7/registration/${reference}`,
+          url: `${v(7)}/registration/${reference}`,
           method: "PATCH",
           body: payload,
+          headers: { authorization: TEMP_JWT },
         };
       },
       transformErrorResponse(res, _meta, { type }) {


### PR DESCRIPTION
Related to BG-1262

## Explanation of the solution
Added an authorization header for the registration update endpoint in `staging`. The `v6` endpoint which is used in production does not require an auth.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- initiate a charity registration
- verify that at least the `ContactDetails` part works without a `401 Unauthorized` error

## UI changes for review
No major UI changes