### PR TITLE
Marketplace Card comma fix

### DIFF
--- a/src/pages/Marketplace/Cards/Card.tsx
+++ b/src/pages/Marketplace/Cards/Card.tsx
@@ -70,7 +70,7 @@ export default function Card({
               <span className="font-semibold">Active in:</span>{" "}
               {isEmpty(active_in_countries)
                 ? hq_country
-                : active_in_countries.join(" ,")}
+                : active_in_countries.join(", ")}
             </p>
           </div>
           <div className="mt-auto empty:hidden grid gap-3">


### PR DESCRIPTION
## Explanation of the solution
Minor Marketplace Card change when listing the countries from `" ,"` to `", "`.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to Marketplace and check if countries list appears as `"United States, Singapore, France"` for example

## UI changes for review
No major UI changes.