### PR TITLE
Implement share in stripe success page

### DIFF
--- a/src/components/donation/Steps/Result/Success/index.tsx
+++ b/src/components/donation/Steps/Result/Success/index.tsx
@@ -1,6 +1,4 @@
 import char from "assets/images/celebrating-character.png";
-import Image from "components/Image";
-import Signup from "components/Signup";
 import { appRoutes } from "constants/routes";
 import { confetti } from "helpers/confetti";
 import { Link } from "react-router-dom";
@@ -8,7 +6,9 @@ import type { DonationRecipient } from "slices/donation";
 import { useGetter } from "store/accessors";
 import { userIsSignedIn } from "types/auth";
 import type { GuestDonor } from "types/aws";
-import Share, { type SocialMedia } from "./Share";
+import Image from "../../../../Image";
+import Signup from "../../../../Signup";
+import Share from "../../Share";
 
 type Props = {
   classes?: string;
@@ -38,18 +38,7 @@ export default function Success({ classes, guestDonor, recipient }: Props) {
         The donation process is complete, and we are grateful for your support.
       </p>
 
-      <h2 className="mt-2 w-full pt-2 text-center font-medium text-blue-d2">
-        Spread the word!
-      </h2>
-      <p className="text-center text-navy-l1 text-sm max-w-sm">
-        Encourage your friends to join in and contribute, making a collective
-        impact through donations.
-      </p>
-      <div className="flex items-center gap-2 mt-1 mb-2">
-        {socials.map(([type, size]) => (
-          <Share key={type} iconSize={size} type={type} recipient={recipient} />
-        ))}
-      </div>
+      <Share recipient={recipient} className="mt-2" />
 
       {!userIsSignedIn(user) && guestDonor && (
         <Signup
@@ -70,10 +59,3 @@ export default function Success({ classes, guestDonor, recipient }: Props) {
     </div>
   );
 }
-
-const socials: [SocialMedia, number][] = [
-  ["Twitter", 21],
-  ["Telegram", 21],
-  ["Linkedin", 21],
-  ["FacebookCircle", 22],
-];

--- a/src/components/donation/Steps/Share.tsx
+++ b/src/components/donation/Steps/Share.tsx
@@ -1,23 +1,59 @@
-import ExtLink from "components/ExtLink";
-import Icon, { type IconType } from "components/Icon";
-import Modal from "components/Modal";
 import { BASE_URL } from "constants/env";
 import { useModalContext } from "contexts/ModalContext";
 import { useCallback, useState } from "react";
 import type { DonationRecipient } from "slices/donation";
+import ExtLink from "../../ExtLink";
+import Icon, { type IconType } from "../../Icon";
+import Modal from "../../Modal";
 
-export type SocialMedia = Extract<
+type SocialMedia = Extract<
   IconType,
   "FacebookCircle" | "Twitter" | "Telegram" | "Linkedin"
 >;
 
-type Props = {
+const socials: [SocialMedia, number][] = [
+  ["Twitter", 21],
+  ["Telegram", 21],
+  ["Linkedin", 21],
+  ["FacebookCircle", 22],
+];
+
+type ShareProps = {
+  recipient: DonationRecipient;
+  className?: string;
+};
+
+export default function ShareContainer(props: ShareProps) {
+  return (
+    <div className={`${props.className ?? ""} grid justify-items-center py-2`}>
+      <h2 className="w-full pt-2 text-center font-medium text-blue-d2 mb-2">
+        Spread the word!
+      </h2>
+      <p className="text-center text-navy-l1 text-sm max-w-sm">
+        Encourage your friends to join in and contribute, making a collective
+        impact through donations.
+      </p>
+      <div className="flex items-center gap-2 mt-1">
+        {socials.map(([type, size]) => (
+          <Share
+            key={type}
+            iconSize={size}
+            type={type}
+            recipient={props.recipient}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type ShareBtnProps = {
   type: SocialMedia;
   iconSize: number;
   recipient: DonationRecipient;
 };
 
-export default function Share(props: Props) {
+function Share(props: ShareBtnProps) {
   const { type, iconSize } = props;
   const { showModal } = useModalContext();
 
@@ -33,7 +69,7 @@ export default function Share(props: Props) {
   );
 }
 
-function Prompt({ type, iconSize, recipient: { name } }: Props) {
+function Prompt({ type, iconSize, recipient: { name } }: ShareBtnProps) {
   const { closeModal } = useModalContext();
 
   //shareText will always hold some value

--- a/src/components/donation/index.ts
+++ b/src/components/donation/index.ts
@@ -1,1 +1,2 @@
-export * from "./Steps";
+export { Steps } from "./Steps";
+export { default as Share } from "./Steps/Share";

--- a/src/pages/DonateFiatThanks.tsx
+++ b/src/pages/DonateFiatThanks.tsx
@@ -13,6 +13,7 @@ import type { GuestDonor } from "types/aws";
 export type DonateFiatThanksState = {
   guestDonor?: GuestDonor;
   recipientName?: string;
+  recipientId?:number;
 };
 
 export default function DonateFiatThanks({ widgetVersion = false }) {

--- a/src/pages/DonateFiatThanks.tsx
+++ b/src/pages/DonateFiatThanks.tsx
@@ -2,6 +2,7 @@ import char from "assets/images/celebrating-character.png";
 import ExtLink from "components/ExtLink";
 import Image from "components/Image";
 import Signup from "components/Signup";
+import { Share } from "components/donation";
 import { BASE_URL } from "constants/env";
 import { appRoutes } from "constants/routes";
 import { confetti } from "helpers/confetti";
@@ -13,7 +14,7 @@ import type { GuestDonor } from "types/aws";
 export type DonateFiatThanksState = {
   guestDonor?: GuestDonor;
   recipientName?: string;
-  recipientId?:number;
+  recipientId?: number;
 };
 
 export default function DonateFiatThanks({ widgetVersion = false }) {
@@ -46,6 +47,12 @@ export default function DonateFiatThanks({ widgetVersion = false }) {
           ? ""
           : " You can safely navigate away using the button below."}
       </p>
+
+      <Share
+        recipient={{ id: 1, name: "Hello world" }}
+        className="mt-6 border border-gray-l3 rounded-xl"
+      />
+
       <p className="text-center text-navy-l1 mt-8 mb-2 text-[15px]">
         If you need a receipt for your donation, please fill out the KYC form
         for this transaction on your{" "}

--- a/src/pages/StripePaymentStatus.tsx
+++ b/src/pages/StripePaymentStatus.tsx
@@ -6,7 +6,7 @@ import { EMAIL_SUPPORT } from "constants/env";
 import { appRoutes, donateWidgetRoutes } from "constants/routes";
 import { useCallback, useEffect } from "react";
 import { Link, Navigate } from "react-router-dom";
-import { useGetStripePaymentStatusQuery } from "services/apes";
+import { useStripePaymentStatusQuery } from "services/apes";
 import { useGetter } from "store/accessors";
 import type { GuestDonor } from "types/aws";
 import type { DonateFiatThanksState } from "./DonateFiatThanks";
@@ -15,7 +15,7 @@ export default function StripePaymentStatus() {
   const paymentIntentId =
     new URLSearchParams(window.location.search).get("payment_intent") ?? "";
 
-  const queryState = useGetStripePaymentStatusQuery(
+  const queryState = useStripePaymentStatusQuery(
     { paymentIntentId },
     { skip: !paymentIntentId }
   );

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -120,7 +120,7 @@ export const apes = createApi({
       Pick<PaymentIntent, "status"> & {
         guestDonor?: GuestDonor;
         recipientName?: string;
-        recipientId?:number;
+        recipientId?: number;
       },
       { paymentIntentId: string }
     >({

--- a/src/services/apes/apes.ts
+++ b/src/services/apes/apes.ts
@@ -116,10 +116,11 @@ export const apes = createApi({
     endowBalance: builder.query<EndowmentBalances, number>({
       query: (endowId) => `${v(1)}/balances/${endowId}`,
     }),
-    getStripePaymentStatus: builder.query<
+    stripePaymentStatus: builder.query<
       Pick<PaymentIntent, "status"> & {
         guestDonor?: GuestDonor;
         recipientName?: string;
+        recipientId?:number;
       },
       { paymentIntentId: string }
     >({
@@ -142,7 +143,7 @@ export const {
   useStripePaymentIntentQuery,
   usePaypalOrderMutation,
   useEndowBalanceQuery,
-  useGetStripePaymentStatusQuery,
+  useStripePaymentStatusQuery,
   useTokensQuery,
   util: {
     invalidateTags: invalidateApesTags,


### PR DESCRIPTION
## Explanation of the solution
* extract `<Share/>` component from crypto success and reuse
* update status query type per https://github.com/AngelProtocolFinance/devops/pull/588

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
stripe success page with share (crypto still the same)
![image](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/0fc6dbed-be1b-4ba2-a4b7-7f999a839d85)

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
