### PR TITLE
BG-1333 T&C for Widgets

### DIFF
--- a/src/pages/DonateWidget/Content.tsx
+++ b/src/pages/DonateWidget/Content.tsx
@@ -1,8 +1,10 @@
+import ExtLink from "components/ExtLink";
 import Seo from "components/Seo";
 import { ErrorStatus } from "components/Status";
 import { Steps } from "components/donation";
 import { APP_NAME, BASE_URL } from "constants/env";
 import { appRoutes } from "constants/routes";
+import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
 import { useEffect } from "react";
 import { type DonationRecipient, setRecipient } from "slices/donation";
 import { useSetter } from "store/accessors";
@@ -64,6 +66,26 @@ export default function Content({
         className="mt-5 w-full md:w-3/4 border border-gray-l4"
         donaterConfig={config}
       />
+      <p className="max-md:border-t max-md:border-gray-l3 px-4 mb-5 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2">
+        By making a donation to {APP_NAME}, you agree to our{" "}
+        <A href={TERMS_OF_USE_DONOR}>Terms of Service</A>,{" "}
+        <A href={PRIVACY_POLICY}>Privacy Policy</A>. 100% of your donation is
+        tax-deductible to the extent allowed by US law. Your donation is made to{" "}
+        {APP_NAME}, a tax-exempt US 501(c)(3) charity that grants unrestricted
+        funds to {profile.name} on your behalf. As a legal matter, {APP_NAME}{" "}
+        must provide any donations to {profile.name} on an unrestricted basis,
+        regardless of any designations or restrictions made by you.{" "}
+        <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
+      </p>
     </div>
   );
 }
+
+const A: typeof ExtLink = ({ className, ...props }) => {
+  return (
+    <ExtLink
+      {...props}
+      className={className + " font-medium hover:underline"}
+    />
+  );
+};

--- a/src/pages/DonateWidget/DonateWidget.tsx
+++ b/src/pages/DonateWidget/DonateWidget.tsx
@@ -1,9 +1,6 @@
-import ExtLink from "components/ExtLink";
 import { DappLogo } from "components/Image";
 import LoaderRing from "components/LoaderRing";
 import QueryLoader from "components/QueryLoader";
-import { APP_NAME } from "constants/env";
-import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
 import { idParamToNum, setToLightMode } from "helpers";
 import { useEffect } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
@@ -42,29 +39,9 @@ export default function DonateWidget() {
       >
         {(profile) => <Content profile={profile} searchParams={searchParams} />}
       </QueryLoader>
-      <p className="max-md:border-t max-md:border-gray-l3 px-4 mb-5 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2">
-        By making a donation to {APP_NAME}, you agree to our{" "}
-        <A href={TERMS_OF_USE_DONOR}>Terms of Service</A>,{" "}
-        <A href={PRIVACY_POLICY}>Privacy Policy</A>. 100% of your donation is
-        tax-deductible to the extent allowed by US law. Your donation is made to{" "}
-        {APP_NAME}, a tax-exempt US 501(c)(3) charity that grants unrestricted
-        funds to this nonprofit on your behalf. As a legal matter, {APP_NAME}{" "}
-        must provide any donations to this nonprofit on an unrestricted basis,
-        regardless of any designations or restrictions made by you.{" "}
-        <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
-      </p>
       <footer className="grid place-items-center h-20 w-full bg-blue dark:bg-blue-d3">
         <DappLogo classes="w-40" color="white" />
       </footer>
     </div>
   );
 }
-
-const A: typeof ExtLink = ({ className, ...props }) => {
-  return (
-    <ExtLink
-      {...props}
-      className={className + " font-medium hover:underline"}
-    />
-  );
-};

--- a/src/pages/DonateWidget/DonateWidget.tsx
+++ b/src/pages/DonateWidget/DonateWidget.tsx
@@ -48,8 +48,8 @@ export default function DonateWidget() {
         <A href={PRIVACY_POLICY}>Privacy Policy</A>. 100% of your donation is
         tax-deductible to the extent allowed by US law. Your donation is made to{" "}
         {APP_NAME}, a tax-exempt US 501(c)(3) charity that grants unrestricted
-        funds to {profile.name} on your behalf. As a legal matter, {APP_NAME}{" "}
-        must provide any donations to {profile.name} on an unrestricted basis,
+        funds to this nonprofit on your behalf. As a legal matter, {APP_NAME}{" "}
+        must provide any donations to this nonprofit on an unrestricted basis,
         regardless of any designations or restrictions made by you.{" "}
         <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
       </p>

--- a/src/pages/DonateWidget/DonateWidget.tsx
+++ b/src/pages/DonateWidget/DonateWidget.tsx
@@ -1,6 +1,9 @@
+import ExtLink from "components/ExtLink";
 import { DappLogo } from "components/Image";
 import LoaderRing from "components/LoaderRing";
 import QueryLoader from "components/QueryLoader";
+import { APP_NAME } from "constants/env";
+import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
 import { idParamToNum, setToLightMode } from "helpers";
 import { useEffect } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
@@ -39,9 +42,29 @@ export default function DonateWidget() {
       >
         {(profile) => <Content profile={profile} searchParams={searchParams} />}
       </QueryLoader>
+      <p className="max-md:border-t max-md:border-gray-l3 px-4 mb-5 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2">
+        By making a donation to {APP_NAME}, you agree to our{" "}
+        <A href={TERMS_OF_USE_DONOR}>Terms of Service</A>,{" "}
+        <A href={PRIVACY_POLICY}>Privacy Policy</A>. 100% of your donation is
+        tax-deductible to the extent allowed by US law. Your donation is made to{" "}
+        {APP_NAME}, a tax-exempt US 501(c)(3) charity that grants unrestricted
+        funds to {profile.name} on your behalf. As a legal matter, {APP_NAME}{" "}
+        must provide any donations to {profile.name} on an unrestricted basis,
+        regardless of any designations or restrictions made by you.{" "}
+        <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
+      </p>
       <footer className="grid place-items-center h-20 w-full bg-blue dark:bg-blue-d3">
         <DappLogo classes="w-40" color="white" />
       </footer>
     </div>
   );
 }
+
+const A: typeof ExtLink = ({ className, ...props }) => {
+  return (
+    <ExtLink
+      {...props}
+      className={className + " font-medium hover:underline"}
+    />
+  );
+};

--- a/src/pages/Widget/Preview.tsx
+++ b/src/pages/Widget/Preview.tsx
@@ -1,10 +1,13 @@
+import ExtLink from "components/ExtLink";
 import { DappLogo } from "components/Image";
 import { Steps } from "components/donation";
+import { APP_NAME } from "constants/env";
+import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
 import { useGetter } from "store/accessors";
 
 export default function Preview({ classes = "" }) {
   const { endowment, ...config } = useGetter((state) => state.widget);
-  const endowName = endowment.name || "nonprofit name";
+  const endowName = endowment.name || "this nonprofit";
 
   return (
     <section className={`${classes} @container/preview pb-4`}>
@@ -30,6 +33,17 @@ export default function Preview({ classes = "" }) {
               liquidSplitPct: config.liquidSplitPct,
             }}
           />
+          <p className="max-md:border-t max-md:border-gray-l3 px-4 mb-5 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2">
+            By making a donation to {APP_NAME}, you agree to our{" "}
+            <A href={TERMS_OF_USE_DONOR}>Terms of Service</A>,{" "}
+            <A href={PRIVACY_POLICY}>Privacy Policy</A>. 100% of your donation
+            is tax-deductible to the extent allowed by US law. Your donation is
+            made to {APP_NAME}, a tax-exempt US 501(c)(3) charity that grants
+            unrestricted funds to {endowName} on your behalf. As a legal matter,{" "}
+            {APP_NAME} must provide any donations to {endowName} on an
+            unrestricted basis, regardless of any designations or restrictions
+            made by you. <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
+          </p>
           <footer className="mt-auto grid place-items-center h-20 w-full bg-blue">
             <DappLogo classes="w-40" color="white" />
           </footer>
@@ -38,3 +52,12 @@ export default function Preview({ classes = "" }) {
     </section>
   );
 }
+
+const A: typeof ExtLink = ({ className, ...props }) => {
+  return (
+    <ExtLink
+      {...props}
+      className={className + " font-medium hover:underline"}
+    />
+  );
+};


### PR DESCRIPTION
Towards BG-1333

## Explanation of the solution
Adds basic Terms and Conditions to the Widget and the Preview component on the Configuration page. Did not add FAQs part as it doesn't exist on the widget view vs the marketplace donation page. 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
