### PR TITLE
Terms-widget-2

### DIFF
--- a/src/components/donation/DonationTermsAndConditions.tsx
+++ b/src/components/donation/DonationTermsAndConditions.tsx
@@ -1,0 +1,35 @@
+import { APP_NAME } from "constants/env";
+import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
+import ExtLink from "../ExtLink";
+
+type Props = {
+  endowName: string;
+  classes?: string;
+};
+
+export default function DonationTermsAndConditions(props: Props) {
+  return (
+    <p
+      className={`${props.classes} text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2`}
+    >
+      By making a donation to {APP_NAME}, you agree to our{" "}
+      <A href={TERMS_OF_USE_DONOR}>Terms of Service</A>,{" "}
+      <A href={PRIVACY_POLICY}>Privacy Policy</A>. 100% of your donation is
+      tax-deductible to the extent allowed by US law. Your donation is made to{" "}
+      {APP_NAME}, a tax-exempt US 501(c)(3) charity that grants unrestricted
+      funds to {props.endowName} on your behalf. As a legal matter, {APP_NAME}{" "}
+      must provide any donations to {props.endowName} on an unrestricted basis,
+      regardless of any designations or restrictions made by you.{" "}
+      <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
+    </p>
+  );
+}
+
+const A: typeof ExtLink = ({ className, ...props }) => {
+  return (
+    <ExtLink
+      {...props}
+      className={className + " font-medium hover:underline"}
+    />
+  );
+};

--- a/src/components/donation/index.ts
+++ b/src/components/donation/index.ts
@@ -1,2 +1,3 @@
 export { Steps } from "./Steps";
 export { default as Share } from "./Steps/Share";
+export { default as DonationTermsAndConditions } from "./DonationTermsAndConditions";

--- a/src/pages/Donate/Content.tsx
+++ b/src/pages/Donate/Content.tsx
@@ -3,9 +3,10 @@ import ExtLink from "components/ExtLink";
 import { DappLogo } from "components/Image";
 import QueryLoader from "components/QueryLoader";
 import { Steps } from "components/donation";
-import { APP_NAME, INTERCOM_HELP } from "constants/env";
+import { DonationTermsAndConditions } from "components/donation";
+import { INTERCOM_HELP } from "constants/env";
 import { appRoutes } from "constants/routes";
-import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
+import { PRIVACY_POLICY } from "constants/urls";
 import { memo, useEffect, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useIntentQuery } from "services/apes";
@@ -106,17 +107,10 @@ function LoadedContent(props: Props & { intent?: DonationIntent }) {
           />
         </div>
         <FAQ classes="max-md:px-4 md:col-start-2 md:row-span-5 md:w-[18.875rem]" />
-        <p className="max-md:border-t max-md:border-gray-l3 max-md:px-4 max-md:pt-4 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2">
-          By making a donation to {APP_NAME}, you agree to our{" "}
-          <A href={TERMS_OF_USE_DONOR}>Terms of Service</A>,{" "}
-          <A href={PRIVACY_POLICY}>Privacy Policy</A>. 100% of your donation is
-          tax-deductible to the extent allowed by US law. Your donation is made
-          to {APP_NAME}, a tax-exempt US 501(c)(3) charity that grants
-          unrestricted funds to {props.name} on your behalf. As a legal matter,{" "}
-          {APP_NAME} must provide any donations to {props.name} on an
-          unrestricted basis, regardless of any designations or restrictions
-          made by you. <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
-        </p>
+        <DonationTermsAndConditions
+          endowName={props.name}
+          classes="max-md:border-t max-md:border-gray-l3 max-md:px-4 max-md:pt-4 col-start-1"
+        />
         <p className="max-md:px-4 mb-4 max-mbcol-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2">
           <span className="block mb-0.5">
             Need help? See{" "}

--- a/src/pages/DonateWidget/DonateWidget.tsx
+++ b/src/pages/DonateWidget/DonateWidget.tsx
@@ -1,9 +1,7 @@
-import ExtLink from "components/ExtLink";
 import { DappLogo } from "components/Image";
 import LoaderRing from "components/LoaderRing";
 import QueryLoader from "components/QueryLoader";
-import { APP_NAME } from "constants/env";
-import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
+import { DonationTermsAndConditions } from "components/donation";
 import { idParamToNum, setToLightMode } from "helpers";
 import { useEffect } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
@@ -29,7 +27,7 @@ export default function DonateWidget() {
   }, []);
 
   return (
-    <div className="grid grid-rows-[1fr_auto] justify-items-center gap-10">
+    <div className="grid grid-rows-[1fr_auto] justify-items-center gap-10 @container">
       <QueryLoader
         queryState={queryState}
         messages={{
@@ -42,29 +40,13 @@ export default function DonateWidget() {
       >
         {(profile) => <Content profile={profile} searchParams={searchParams} />}
       </QueryLoader>
-      <p className="max-md:border-t max-md:border-gray-l3 px-4 mb-5 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2">
-        By making a donation to {APP_NAME}, you agree to our{" "}
-        <A href={TERMS_OF_USE_DONOR}>Terms of Service</A>,{" "}
-        <A href={PRIVACY_POLICY}>Privacy Policy</A>. 100% of your donation is
-        tax-deductible to the extent allowed by US law. Your donation is made to{" "}
-        {APP_NAME}, a tax-exempt US 501(c)(3) charity that grants unrestricted
-        funds to this nonprofit on your behalf. As a legal matter, {APP_NAME}{" "}
-        must provide any donations to this nonprofit on an unrestricted basis,
-        regardless of any designations or restrictions made by you.{" "}
-        <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
-      </p>
+      <DonationTermsAndConditions
+        endowName={queryState.data?.name ?? "this nonprofit"}
+        classes="border-t @3xl:border-none border-gray-l3 px-4 pt-4"
+      />
       <footer className="grid place-items-center h-20 w-full bg-blue dark:bg-blue-d3">
         <DappLogo classes="w-40" color="white" />
       </footer>
     </div>
   );
 }
-
-const A: typeof ExtLink = ({ className, ...props }) => {
-  return (
-    <ExtLink
-      {...props}
-      className={className + " font-medium hover:underline"}
-    />
-  );
-};

--- a/src/pages/DonateWidget/DonateWidget.tsx
+++ b/src/pages/DonateWidget/DonateWidget.tsx
@@ -27,7 +27,7 @@ export default function DonateWidget() {
   }, []);
 
   return (
-    <div className="grid grid-rows-[1fr_auto] justify-items-center gap-10 @container">
+    <div className="grid grid-rows-[1fr_auto_auto] justify-items-center">
       <QueryLoader
         queryState={queryState}
         messages={{
@@ -42,7 +42,7 @@ export default function DonateWidget() {
       </QueryLoader>
       <DonationTermsAndConditions
         endowName={queryState.data?.name ?? "this nonprofit"}
-        classes="border-t @3xl:border-none border-gray-l3 px-4 pt-4"
+        classes="px-4 pb-4"
       />
       <footer className="grid place-items-center h-20 w-full bg-blue dark:bg-blue-d3">
         <DappLogo classes="w-40" color="white" />

--- a/src/pages/Widget/Preview.tsx
+++ b/src/pages/Widget/Preview.tsx
@@ -1,8 +1,6 @@
-import ExtLink from "components/ExtLink";
 import { DappLogo } from "components/Image";
 import { DonationTermsAndConditions, Steps } from "components/donation";
-import { APP_NAME } from "constants/env";
-import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
+
 import { useGetter } from "store/accessors";
 
 export default function Preview({ classes = "" }) {
@@ -37,17 +35,6 @@ export default function Preview({ classes = "" }) {
             endowName={endowName}
             classes="border-t @3xl/preview:border-none border-gray-l3 px-4 pt-4"
           />
-          <p className="max-md:border-t max-md:border-gray-l3 px-4 mb-5 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2">
-            By making a donation to {APP_NAME}, you agree to our{" "}
-            <A href={TERMS_OF_USE_DONOR}>Terms of Service</A>,{" "}
-            <A href={PRIVACY_POLICY}>Privacy Policy</A>. 100% of your donation
-            is tax-deductible to the extent allowed by US law. Your donation is
-            made to {APP_NAME}, a tax-exempt US 501(c)(3) charity that grants
-            unrestricted funds to {endowName} on your behalf. As a legal matter,{" "}
-            {APP_NAME} must provide any donations to {endowName} on an
-            unrestricted basis, regardless of any designations or restrictions
-            made by you. <A href={TERMS_OF_USE_DONOR}>See Terms.</A>
-          </p>
           <footer className="mt-auto grid place-items-center h-20 w-full bg-blue">
             <DappLogo classes="w-40" color="white" />
           </footer>
@@ -56,12 +43,3 @@ export default function Preview({ classes = "" }) {
     </section>
   );
 }
-
-const A: typeof ExtLink = ({ className, ...props }) => {
-  return (
-    <ExtLink
-      {...props}
-      className={className + " font-medium hover:underline"}
-    />
-  );
-};

--- a/src/pages/Widget/Preview.tsx
+++ b/src/pages/Widget/Preview.tsx
@@ -33,7 +33,7 @@ export default function Preview({ classes = "" }) {
           />
           <DonationTermsAndConditions
             endowName={endowName}
-            classes="border-t @3xl/preview:border-none border-gray-l3 px-4 pt-4"
+            classes="border-t @3xl/preview:border-none border-gray-l3 px-4 py-4"
           />
           <footer className="mt-auto grid place-items-center h-20 w-full bg-blue">
             <DappLogo classes="w-40" color="white" />

--- a/src/pages/Widget/Preview.tsx
+++ b/src/pages/Widget/Preview.tsx
@@ -33,7 +33,7 @@ export default function Preview({ classes = "" }) {
           />
           <DonationTermsAndConditions
             endowName={endowName}
-            classes="border-t @3xl/preview:border-none border-gray-l3 px-4 py-4"
+            classes="p-4 pt-0"
           />
           <footer className="mt-auto grid place-items-center h-20 w-full bg-blue">
             <DappLogo classes="w-40" color="white" />

--- a/src/pages/Widget/Preview.tsx
+++ b/src/pages/Widget/Preview.tsx
@@ -1,6 +1,6 @@
 import ExtLink from "components/ExtLink";
 import { DappLogo } from "components/Image";
-import { Steps } from "components/donation";
+import { DonationTermsAndConditions, Steps } from "components/donation";
 import { APP_NAME } from "constants/env";
 import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
 import { useGetter } from "store/accessors";
@@ -32,6 +32,10 @@ export default function Preview({ classes = "" }) {
               splitDisabled: config.splitDisabled,
               liquidSplitPct: config.liquidSplitPct,
             }}
+          />
+          <DonationTermsAndConditions
+            endowName={endowName}
+            classes="border-t @3xl/preview:border-none border-gray-l3 px-4 pt-4"
           />
           <p className="max-md:border-t max-md:border-gray-l3 px-4 mb-5 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2">
             By making a donation to {APP_NAME}, you agree to our{" "}

--- a/test.html
+++ b/test.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <iframe src="http://localhost:4200/donate-widget/54?isDescriptionTextShown=true&splitDisabled=false&liquidSplitPct=50" width="400" height="900" style="border: 0px;"></iframe>
+</body>
+</html>


### PR DESCRIPTION
## Explanation of the solution
* factor out tnc in a component and reuse (3 locations)
* make sure `border` is screen/container agnostic (`:md` is only accurate if TnC is rendered in `/donate`, if inside of `iframe` (screen size is iframe width), if rendered in `preview` (screen size is screen width)) -  use screen `md:` to or container `@3xl` depending on where tnc is rendered

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
