### PR TITLE
Endowment link: error marker

### DIFF
--- a/src/App/Header/UserMenu/EndowmentLink.tsx
+++ b/src/App/Header/UserMenu/EndowmentLink.tsx
@@ -13,7 +13,7 @@ export default function EndowmentLink({ endowId }: Props) {
       queryState={query}
       messages={{
         loading: <Skeleton />,
-        error: <_Link id={endowId} classes="text-red" />,
+        error: <_Link id={endowId} />,
       }}
     >
       {(endow) => <_Link {...endow} id={endowId} />}
@@ -25,12 +25,11 @@ type LinkProps = {
   id: number;
   name?: string;
   logo?: string;
-  classes?: string;
 };
 const _Link = (props: LinkProps) => (
   <Link
     to={appRoutes.admin + `/${props.id}`}
-    className={`${props.classes} hover:text-blue-d1 text-sm flex items-center gap-2`}
+    className="hover:text-blue-d1 text-sm flex items-center gap-2"
   >
     <Image src={props.logo} className="object-cover h-[20px] w-[20px]" />
     <span>{props.name ?? `Endowment: ${props.id}`}</span>

--- a/src/App/Header/UserMenu/EndowmentLink.tsx
+++ b/src/App/Header/UserMenu/EndowmentLink.tsx
@@ -13,7 +13,7 @@ export default function EndowmentLink({ endowId }: Props) {
       queryState={query}
       messages={{
         loading: <Skeleton />,
-        error: <_Link id={endowId} />,
+        error: <_Link id={endowId} classes="text-red" />,
       }}
     >
       {(endow) => <_Link {...endow} id={endowId} />}
@@ -21,13 +21,19 @@ export default function EndowmentLink({ endowId }: Props) {
   );
 }
 
-const _Link = (props: { name?: string; id: number; logo?: string }) => (
+type LinkProps = {
+  id: number;
+  name?: string;
+  logo?: string;
+  classes?: string;
+};
+const _Link = (props: LinkProps) => (
   <Link
     to={appRoutes.admin + `/${props.id}`}
-    className="hover:text-blue-d1 text-sm flex items-center gap-2"
+    className={`${props.classes} hover:text-blue-d1 text-sm flex items-center gap-2`}
   >
     <Image src={props.logo} className="object-cover h-[20px] w-[20px]" />
-    <span>{props.name ?? `Endowment:${props.id}`}</span>
+    <span>{props.name ?? `Endowment: ${props.id}`}</span>
   </Link>
 );
 

--- a/src/App/Header/UserMenu/EndowmentLink.tsx
+++ b/src/App/Header/UserMenu/EndowmentLink.tsx
@@ -13,21 +13,23 @@ export default function EndowmentLink({ endowId }: Props) {
       queryState={query}
       messages={{
         loading: <Skeleton />,
-        error: <></>,
+        error: <_Link id={endowId} />,
       }}
     >
-      {({ name, logo }) => (
-        <Link
-          to={appRoutes.admin + `/${endowId}`}
-          className="hover:text-blue-d1 text-sm flex items-center gap-2"
-        >
-          <Image src={logo} className="object-cover h-[20px] w-[20px]" />
-          <span>{name}</span>
-        </Link>
-      )}
+      {(endow) => <_Link {...endow} id={endowId} />}
     </QueryLoader>
   );
 }
+
+const _Link = (props: { name?: string; id: number; logo?: string }) => (
+  <Link
+    to={appRoutes.admin + `/${props.id}`}
+    className="hover:text-blue-d1 text-sm flex items-center gap-2"
+  >
+    <Image src={props.logo} className="object-cover h-[20px] w-[20px]" />
+    <span>{props.name ?? `Endowment:${props.id}`}</span>
+  </Link>
+);
 
 function Skeleton() {
   return (


### PR DESCRIPTION
Towards BG-1334 
since user can still access admin, given url `admin/:endowId` it means, user token contains appropriate endowment access. The only reason the link won't show is if the logo and name fetch fails (which is likely not since querying reported endow ids in the same endpoint works)

## Explanation of the solution
* show fallback link when fetching logo,name fails
(failed endows here are residual endows in my email) 
<img width="321" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/2fb7945b-af5d-4910-bcde-b7ec2920b9c0">

* check from user if they see fallback link (means they are encountering error fetching link metadata )

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
