### PR TITLE
BG-1341 Widget adaptations

### DIFF
--- a/src/components/donation/Steps/Submit/DAFCheckout/ManualDonation.tsx
+++ b/src/components/donation/Steps/Submit/DAFCheckout/ManualDonation.tsx
@@ -15,7 +15,10 @@ export default function ManualDonation(props: DafCheckoutStep) {
         information:
       </p>
       <div className="grid rounded bg-gray-l5 dark:bg-navy-d3 p-3 text-sm leading-relaxed my-4">
-        <p>Please make a one-time grant of ${props.details.amount} to:</p>
+        <p>
+          Please make a one-time grant of $
+          {props.details.amount + (props.tip ?? 0)} to:
+        </p>
         <br />
         <p>Altruistic Partners Empowering Society Inc (EIN: 87-3758939)</p>
         <p>16192 Costal Highway Lewes, DE 19958 USA</p>

--- a/src/components/donation/Steps/Submit/Stocks.tsx
+++ b/src/components/donation/Steps/Submit/Stocks.tsx
@@ -20,8 +20,8 @@ export default function Stocks(props: StockCheckoutStep) {
       </p>
       <div className="grid rounded bg-gray-l5 dark:bg-navy-d3 p-3 text-sm leading-relaxed mt-6">
         <p>
-          Please transfer [&nbsp;{props.details.numShares}&nbsp;] share(s) of
-          [&nbsp;{props.details.symbol}&nbsp;] to:
+          Please transfer [&nbsp;{props.details.numShares + (props.tip ?? 0)}
+          &nbsp;] share(s) of [&nbsp;{props.details.symbol}&nbsp;] to:
         </p>
         <p>Deliver to: Fidelity Investments</p>
         <p>DTC number: 0226</p>

--- a/src/components/donation/Steps/common/Summary.tsx
+++ b/src/components/donation/Steps/common/Summary.tsx
@@ -48,28 +48,36 @@ export default function Summary({
       <dl
         className={`text-navy-l1 py-3 gap-y-2 grid grid-cols-[1fr_auto] items-center justify-between border-y border-gray-l4 ${splitClass}`}
       >
-        <dt className="mr-auto text-navy-d4">
-          {props.tip
-            ? `Donation for ${props.tip.charityName}`
-            : "Total donation"}
-        </dt>
-        <Amount amount={props.amount} classes="text-navy-d4" />
-        <div className="flex items-center justify-between col-span-full">
-          <div className="mr-auto flex">
-            <dt className="text-sm mt-2">Sustainability Fund</dt>
-            <Image src={character} className="inline-block px-1 h-8" />
-          </div>
-          <Amount classes="text-sm" amount={locked} />
-        </div>
-        <div className="flex items-center justify-between col-span-full">
-          <dt className="mr-auto text-sm">Direct Donation</dt>
-          <Amount classes="text-sm" amount={liq} />
-        </div>
-        {props.tip && (
-          <div className="col-span-full grid grid-cols-[1fr_auto] border-y border-gray-l4 py-3">
-            <dt className="mr-auto">Donation for Better Giving</dt>
-            <Amount classes="text-sm" amount={props.tip.value} />
-          </div>
+        {(props.tip || locked > 0) && (
+          <>
+            <dt className="mr-auto text-navy-d4">
+              {props.tip
+                ? `Donation for ${props.tip.charityName}`
+                : "Total donation"}
+            </dt>
+            <Amount amount={props.amount} classes="text-navy-d4" />
+            {locked > 0 && (
+              <>
+                <div className="flex items-center justify-between col-span-full">
+                  <div className="mr-auto flex">
+                    <dt className="text-sm mt-2">Sustainability Fund</dt>
+                    <Image src={character} className="inline-block px-1 h-8" />
+                  </div>
+                  <Amount classes="text-sm" amount={locked} />
+                </div>
+                <div className="flex items-center justify-between col-span-full">
+                  <dt className="mr-auto text-sm">Direct Donation</dt>
+                  <Amount classes="text-sm" amount={liq} />
+                </div>
+              </>
+            )}
+            {props.tip && (
+              <div className="col-span-full grid grid-cols-[1fr_auto] border-y border-gray-l4 py-3">
+                <dt className="mr-auto">Donation for Better Giving</dt>
+                <Amount classes="text-sm" amount={props.tip.value} />
+              </div>
+            )}
+          </>
         )}
         <div className="col-span-full grid grid-cols-[1fr_auto] pt-1 font-medium">
           <dt className="mr-auto text-navy-d4">

--- a/src/components/donation/Steps/common/Summary.tsx
+++ b/src/components/donation/Steps/common/Summary.tsx
@@ -1,3 +1,6 @@
+// TODO: Swap with "pointing" character, once asset is available
+import character from "assets/images/waving-character.png";
+import Image from "components/Image/Image";
 import type { ReactNode } from "react";
 import type { FiatPaymentFrequency } from "types/aws";
 import Icon from "../../../Icon";
@@ -54,7 +57,10 @@ export default function Summary({
         {locked > 0 && (
           <>
             <div className="flex items-center justify-between col-span-full">
-              <dt className="mr-auto text-sm">Sustainability Fund</dt>
+              <div className="mr-auto flex">
+                <dt className="text-sm mt-2">Sustainability Fund</dt>
+                <Image src={character} className="inline-block px-1 h-8" />
+              </div>
               <Amount classes="text-sm" amount={locked} />
             </div>
             <div className="flex items-center justify-between col-span-full">
@@ -76,6 +82,15 @@ export default function Summary({
           <Amount amount={props.amount + (props.tip ? props.tip.value : 0)} />
         </div>
       </dl>
+      {locked > 0 && (
+        <div className="flex pt-3">
+          <Image src={character} className="inline-block mt-1 pl-1 pr-2 h-8" />
+          <div className="mr-auto text-sm text-navy-l3">
+            The Sustainability Fund invests your donation for long-term growth
+            to provide reliable, ongoing funding. Give today, give forever!
+          </div>
+        </div>
+      )}
 
       {props.children}
     </div>

--- a/src/components/donation/Steps/common/Summary.tsx
+++ b/src/components/donation/Steps/common/Summary.tsx
@@ -54,22 +54,18 @@ export default function Summary({
             : "Total donation"}
         </dt>
         <Amount amount={props.amount} classes="text-navy-d4" />
-        {locked > 0 && (
-          <>
-            <div className="flex items-center justify-between col-span-full">
-              <div className="mr-auto flex">
-                <dt className="text-sm mt-2">Sustainability Fund</dt>
-                <Image src={character} className="inline-block px-1 h-8" />
-              </div>
-              <Amount classes="text-sm" amount={locked} />
-            </div>
-            <div className="flex items-center justify-between col-span-full">
-              <dt className="mr-auto text-sm">Direct Donation</dt>
-              <Amount classes="text-sm" amount={liq} />
-            </div>
-          </>
-        )}
-        {props.tip && props.tip.value > 0 && (
+        <div className="flex items-center justify-between col-span-full">
+          <div className="mr-auto flex">
+            <dt className="text-sm mt-2">Sustainability Fund</dt>
+            <Image src={character} className="inline-block px-1 h-8" />
+          </div>
+          <Amount classes="text-sm" amount={locked} />
+        </div>
+        <div className="flex items-center justify-between col-span-full">
+          <dt className="mr-auto text-sm">Direct Donation</dt>
+          <Amount classes="text-sm" amount={liq} />
+        </div>
+        {props.tip && (
           <div className="col-span-full grid grid-cols-[1fr_auto] border-y border-gray-l4 py-3">
             <dt className="mr-auto">Donation for Better Giving</dt>
             <Amount classes="text-sm" amount={props.tip.value} />

--- a/src/components/donation/Steps/common/Summary.tsx
+++ b/src/components/donation/Steps/common/Summary.tsx
@@ -51,28 +51,30 @@ export default function Summary({
             : "Total donation"}
         </dt>
         <Amount amount={props.amount} classes="text-navy-d4" />
-        <div className="flex items-center justify-between col-span-full">
-          <dt className="mr-auto text-sm">Sustainability Fund</dt>
-          <Amount classes="text-sm" amount={locked} />
-        </div>
-        <div className="flex items-center justify-between col-span-full">
-          <dt className="mr-auto text-sm">Direct Donation</dt>
-          <Amount classes="text-sm" amount={liq} />
-        </div>
-        {props.tip && (
+        {locked > 0 && (
+          <>
+            <div className="flex items-center justify-between col-span-full">
+              <dt className="mr-auto text-sm">Sustainability Fund</dt>
+              <Amount classes="text-sm" amount={locked} />
+            </div>
+            <div className="flex items-center justify-between col-span-full">
+              <dt className="mr-auto text-sm">Direct Donation</dt>
+              <Amount classes="text-sm" amount={liq} />
+            </div>
+          </>
+        )}
+        {props.tip && props.tip.value > 0 && (
           <div className="col-span-full grid grid-cols-[1fr_auto] border-y border-gray-l4 py-3">
             <dt className="mr-auto">Donation for Better Giving</dt>
             <Amount classes="text-sm" amount={props.tip.value} />
           </div>
         )}
-        {props.tip && (
-          <div className="col-span-full grid grid-cols-[1fr_auto] pt-1 font-medium">
-            <dt className="mr-auto text-navy-d4">
-              Total {frequency === "subscription" ? "monthly " : ""}charge
-            </dt>
-            <Amount amount={props.amount + props.tip.value} />
-          </div>
-        )}
+        <div className="col-span-full grid grid-cols-[1fr_auto] pt-1 font-medium">
+          <dt className="mr-auto text-navy-d4">
+            Total {frequency === "subscription" ? "monthly " : ""}charge
+          </dt>
+          <Amount amount={props.amount + (props.tip ? props.tip.value : 0)} />
+        </div>
       </dl>
 
       {props.children}

--- a/src/slices/donation/donation.ts
+++ b/src/slices/donation/donation.ts
@@ -82,20 +82,6 @@ const donation = createSlice({
           ? { step: "donate-form", recipient: state.recipient }
           : state;
 
-      //skip donor,splits for stocks,daf, as not being used
-      if (payload.method === "stocks" || payload.method === "daf") {
-        return {
-          ...(curr as SplitsStep),
-          step: "submit",
-          details: payload,
-          //these steps where skipped so provide placeholders
-          tip: 0,
-          format: "pct",
-          donor: { firstName: "", lastName: "", email: "" },
-          liquidSplitPct: 50,
-        };
-      }
-
       return {
         ...(curr as SplitsStep),
         step: "splits",


### PR DESCRIPTION
## Explanation of the solution
Widget/Donations logic changes needed per Chauncey:
- [x] hide direct/SF breakdown lines on summary if SF portion is == 0
- [x] add SF explainer and Laira character to summary view if SF portion > 0
- [x] allow Split & BG Tip screen to be visited by Stocks and DAF for a more uniform donor flow
- [x] if `tip & SF portion === 0`, hide top total line item

### Notes:
- Need to replace the "waving" with "pointing" Laira character image, but can't find it. Will swap in when we have it. Noted a TODO comment in code addressing this.

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review (summary views)
### No Tip && No SF
![no-tip-no-sf](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/4b5953af-a808-4c29-91aa-ca9874baee59)

### Yes Tip && No SF
![yes-tip-no-sf](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/2fa2525a-de92-4eb6-b1d2-0d9c759d8b32)

### No Tip && Yes SF
![no-tip-yes-sf](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/9a847625-bb99-47df-aa0a-c10a5bfda12a)

### Yes Tip && Yes SF
![yes-tip-yes-sf](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/941c7f2c-462a-46da-a414-aafe7fecc6d6)