### PR TITLE
Donation Form SF msg bottom padding

### DIFF
--- a/src/components/donation/Steps/common/Summary.tsx
+++ b/src/components/donation/Steps/common/Summary.tsx
@@ -87,7 +87,7 @@ export default function Summary({
         </div>
       </dl>
       {locked > 0 && (
-        <div className="flex pt-3">
+        <div className="flex py-3">
           <Image src={character} className="inline-block mt-1 pl-1 pr-2 h-8" />
           <div className="mr-auto text-sm text-navy-l3">
             The Sustainability Fund invests your donation for long-term growth


### PR DESCRIPTION
## Explanation of the solution
- Adds small padding to bottom of SF msg so doesn't run into payment form

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
