### PR TITLE
BG-1296 Incrementors supports all currencies

### DIFF
--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -120,7 +120,9 @@ function Form({
         // validation must be dynamicly set depending on which exact currency is selected
         tooltip={createTooltip(currency)}
       />
-      {currency.code === USD_CODE && <Incrementers />}
+      {currency.rate && (
+        <Incrementers code={currency.code} rate={currency.rate} />
+      )}
 
       <p className="text-sm dark:text-navy-l2 mt-4">
         Please click the button below and follow the instructions provided to

--- a/src/components/donation/Steps/DonateMethods/Stripe/Incrementers.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Incrementers.tsx
@@ -1,32 +1,59 @@
+import { humanize, roundDownToNum } from "helpers";
 import { useFormContext } from "react-hook-form";
+import type { Currency } from "types/components";
 import type { FormValues } from "./types";
 
-export default function Incrementers() {
+export default function Incrementers({
+  rate,
+  code,
+}: { rate: number; code: string }) {
+  console.log(code, rate);
   return (
     <div className="flex justify-center gap-3">
-      <Incrementer value={40} />
-      <Incrementer value={100} />
-      <Incrementer value={200} />
+      <Incrementer value={40 * rate} curr={code} />
+      <Incrementer value={100 * rate} curr={code} />
+      <Incrementer value={200 * rate} curr={code} />
     </div>
   );
 }
 
-function Incrementer({ value }: { value: number }) {
+function Incrementer({ value, curr }: { value: number; curr: string }) {
+  const roundedVal = roundDownToNum(value, 0);
   const { setValue, trigger, getValues } = useFormContext<FormValues>();
   return (
     <button
       type="button"
-      className="text-sm font-medium border border-gray-l4 hover:border-gray-l3 rounded-full w-20 h-10"
+      className="text-sm font-medium border border-gray-l4 hover:border-gray-l3 rounded-full w-[7rem] h-10"
       onClick={() => {
         const amount = Number(getValues("amount"));
         if (Number.isNaN(amount)) {
           trigger("amount");
         } else {
-          setValue("amount", `${amount + value}`);
+          setValue("amount", `${amount + roundedVal}`);
         }
       }}
     >
-      +${value}
+      +{shortenHumanize(roundedVal)} {curr.toUpperCase()}
     </button>
   );
+}
+
+/**
+ * Humanize larger numbers, attempting to keep the numbers both readable and still
+ * containing enough precision to be of use to the end user. Numbers passed through
+ * should only have at most 5 digits in total (2 before the decimal, 3 digits after).
+ */
+function shortenHumanize(num: number): string {
+  if (num > 1e10) {
+    // numbers over 10 Billion
+    return `${humanize(num / 1e9, 3)}B`;
+  } else if (num > 1e7) {
+    // numbers over 10 Million
+    return `${humanize(num / 1e6, 3)}M`;
+  } else if (num > 1e4) {
+    // numbers over 10 Thousand
+    return `${humanize(num / 1e3, 3)}K`;
+  }
+  // all other numbers under 10 Thousand
+  return `${num}`;
 }


### PR DESCRIPTION
## Explanation of the solution
- Adapts the `Incrementors` and related components to work with currencies other than USD
- New function to adapt larger values (ex. see `HUF` currency) keeping as much precision as possible to be useful to the end user decided whether or not to add XX amount to their donation, whilst also keeping the widths of the amounts displayed in the buttons relatively consistent as numbers grow. 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- go to Stripe donations tab
- Choose a currency other than USD 
- Rates should reflect the rate * the USD set amounts (40, 100, 200)

## UI changes for review
### Low FX rate: HKD (no need to shorten amounts)
![incrementors_hkd](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/f2a468b2-8021-4cee-8904-ed32f37b4b08)

### High FX rate: HUF (shorten amounts)
![incrementors_huf](https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/85138450/a75c75f7-0e7b-4a6f-b388-b5d09db37c3a)