### PR TITLE
BG-1354: new account logins is not proceeding

### DIFF
--- a/src/slices/auth.ts
+++ b/src/slices/auth.ts
@@ -30,7 +30,7 @@ export const loadSession = createAsyncThunk<User, AuthUser | undefined>(
 
       type Payload = {
         /** csv */
-        endows: string;
+        endows?: string;
         "cognito:groups": string[];
         email: string;
       };
@@ -55,7 +55,7 @@ export const loadSession = createAsyncThunk<User, AuthUser | undefined>(
       return {
         token: idToken.toString(),
         groups,
-        endowments: endows.split(",").map(Number),
+        endowments: endows?.split(",").map(Number) ?? [],
         email: userEmail,
         firstName: userAttributes.givenName,
         lastName: userAttributes.familyName,


### PR DESCRIPTION
`endows` claim was incorrectly typed to be `string` where it is actually `string | undefined` (only set when there is an endowment credential)

``` js
//pre-token-gen-trigger.js
if (items.length > 0) {
            event.response = {
                claimsOverrideDetails: {
                    claimsToAddOrOverride: { endows: items.map(({ endowID }) => endowID).join(",") },
                },
            };
        }
```

## Explanation of the solution
* change type and update 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
