### PR TITLE
Admin Settings: fee corrected & copy updates

### DIFF
--- a/src/pages/Admin/Charity/Settings/Form.tsx
+++ b/src/pages/Admin/Charity/Settings/Form.tsx
@@ -95,7 +95,9 @@ export default function Form(props: Props) {
 
       <HideBGTipCheckbox />
 
-      <label className="mt-6 font-medium">Define default split value:</label>
+      <label className="mt-6 font-medium">
+        Define default split value (Marketplace only):
+      </label>
       <LockedSplitSlider
         onChange={onSplitLockedPctChanged}
         value={splitLockedPct}

--- a/src/pages/Admin/Charity/Settings/HideBGTipCheckbox.tsx
+++ b/src/pages/Admin/Charity/Settings/HideBGTipCheckbox.tsx
@@ -12,7 +12,7 @@ export default function HideBGTipCheckbox() {
         tip Better Giving any amount they desire alongside their donation to you
         - the amount they tip will not affect the donation amount you receive.
         You may choose to turn this step off in the donation flow by ticking the
-        checkbox above and we will instead apply a fixed 1.5% fee to any
+        checkbox above and we will instead apply a fixed 2.9% fee to any
         donation amount you receive.
       </span>
     </div>


### PR DESCRIPTION
## Explanation of the solution
- Fix fee for opt-out to 2.9%
- add note that split default is for Marketplace only

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
