### PR TITLE
BG-1364 Cloudsearch query

### DIFF
--- a/src/services/aws/aws.ts
+++ b/src/services/aws/aws.ts
@@ -79,7 +79,7 @@ export const aws = createApi({
       providesTags: ["endowments"],
       query: (params) => {
         return {
-          url: "algolia-endowments",
+          url: "cloudsearch-nonprofits",
           params: {
             ...params,
             fields: endowCardFields,
@@ -92,7 +92,7 @@ export const aws = createApi({
       providesTags: ["endowments"],
       query: (params) => {
         return {
-          url: "algolia-endowments",
+          url: "cloudsearch-nonprofits",
           params: { ...params, fields: endowSelectorOptionFields, env: apiEnv },
         };
       },

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -103,7 +103,7 @@ export type Endowment = {
 
 export type EndowmentProfile = Endowment;
 
-/** from algolia index instead of DB */
+/** from CloudSearch index instead of DB */
 export type EndowmentCard = Pick<
   Endowment,
   | "id"


### PR DESCRIPTION
Towards BG-1364

## Explanation of the solution
Switches web app to use the new CloudSearch API endpoint (`/cloudsearch-nonprofits`).

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review
None