### PR TITLE
Program metrics

### DIFF
--- a/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/ProgramInfo.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/ProgramInfo.tsx
@@ -68,11 +68,10 @@ export default function ProgramInfo(props: Program) {
           }}
         />
         <Field<FV>
-          classes="field-admin"
+          classes="field-admin mb-4"
           name="targetRaise"
           label="Target raise"
           placeholder="e.g. $1000"
-          required
         />
         <button
           disabled={!isDirty}

--- a/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/ProgramInfo.tsx
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/ProgramInfo.tsx
@@ -20,6 +20,7 @@ export default function ProgramInfo(props: Program) {
         preview: props.banner ?? "",
       },
       description: { value: props.description },
+      targetRaise: props.targetRaise?.toString() ?? "",
     },
     resolver: yupResolver(schema),
   });
@@ -65,6 +66,13 @@ export default function ProgramInfo(props: Program) {
             error: "static field-error -mt-4",
             charCounter: "text-navy-l1 dark:text-navy-l2",
           }}
+        />
+        <Field<FV>
+          classes="field-admin"
+          name="targetRaise"
+          label="Target raise"
+          placeholder="e.g. $1000"
+          required
         />
         <button
           disabled={!isDirty}

--- a/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/schema.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/schema.ts
@@ -1,4 +1,4 @@
-import { richTextContent } from "schemas/shape";
+import { richTextContent, stringNumber } from "schemas/shape";
 import { requiredString } from "schemas/string";
 import type { SchemaShape } from "schemas/types";
 import { type ObjectSchema, object } from "yup";
@@ -9,4 +9,8 @@ export const schema = object<any, SchemaShape<FV>>({
   title: requiredString.trim(),
   description: richTextContent({ maxChars: MAX_CHARS, required: true }),
   image: fileObj,
+  targetRaise: stringNumber(
+    (s) => s,
+    (num) => num.positive("must be greater than 0")
+  ),
 }) as ObjectSchema<FV>;

--- a/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/types.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/types.ts
@@ -5,4 +5,6 @@ export type FV = {
   title: string;
   image: ImgLink;
   description: RichTextContent;
+  /** USD  */
+  targetRaise: string;
 };

--- a/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/useSubmit.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/useSubmit.ts
@@ -32,6 +32,7 @@ export default function useSubmit(initProgram: Program) {
         banner: imageURL,
         description: fv.description.value,
         title: fv.title,
+        targetRaise: +fv.targetRaise,
       };
 
       await updateProgram({ endowId: id, ...cleanObject(update) }).unwrap();

--- a/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/useSubmit.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/useSubmit.ts
@@ -32,10 +32,13 @@ export default function useSubmit(initProgram: Program) {
         banner: imageURL,
         description: fv.description.value,
         title: fv.title,
-        targetRaise: +fv.targetRaise || null,
       };
 
-      await updateProgram({ endowId: id, ...cleanObject(update) }).unwrap();
+      await updateProgram({
+        endowId: id,
+        ...cleanObject(update),
+        targetRaise: +fv.targetRaise || null,
+      }).unwrap();
       showModal(Prompt, {
         type: "success",
         children: "Program information updated",

--- a/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/useSubmit.ts
+++ b/src/pages/Admin/Charity/ProgramEditor/ProgramInfo/useSubmit.ts
@@ -32,7 +32,7 @@ export default function useSubmit(initProgram: Program) {
         banner: imageURL,
         description: fv.description.value,
         title: fv.title,
-        targetRaise: +fv.targetRaise,
+        targetRaise: +fv.targetRaise || null,
       };
 
       await updateProgram({ endowId: id, ...cleanObject(update) }).unwrap();

--- a/src/pages/Profile/Body/Program/Program.tsx
+++ b/src/pages/Profile/Body/Program/Program.tsx
@@ -1,6 +1,7 @@
 import ContentLoader from "components/ContentLoader";
 import QueryLoader from "components/QueryLoader";
 import RichText from "components/RichText";
+import { humanize } from "helpers";
 import { useProfileContext } from "pages/Profile/ProfileContext";
 import { useParams } from "react-router-dom";
 import { useProgramQuery } from "services/aws/programs";
@@ -28,6 +29,12 @@ export default function Program({ className = "" }) {
               readOnly
               classes={{ container: "m-6" }}
             />
+            {p.targetRaise && (
+              <TargetProgress
+                target={p.targetRaise}
+                total={p.totalDonations ?? 0}
+              />
+            )}
           </Container>
           <Milestones
             classes="self-start lg:sticky lg:top-28"
@@ -51,6 +58,31 @@ function Skeleton({ className = "" }) {
         <ContentLoader className="h-40" />
         <ContentLoader className="h-40" />
       </div>
+    </div>
+  );
+}
+
+type ProgressProps = {
+  target: number;
+  total: number;
+};
+function TargetProgress({ target, total }: ProgressProps) {
+  const progressPct = Math.min(1, total / target) * 100;
+  return (
+    <div className="m-6 border-t border-gray-l4 pt-2 font-heading">
+      <div className="mb-2 flex items-center gap-2">
+        <p className="font-medium">Target raise:</p>
+        <p className="font-bold text-navy-l1">${humanize(target)}</p>
+      </div>
+      <div className="h-4 rounded-full bg-gray-l4 relative overflow-clip">
+        <div className="h-full bg-green" style={{ width: `${progressPct}%` }} />
+      </div>
+      {total ? (
+        <div className="mt-1 flex items-center gap-2 text-sm text-navy-l1">
+          <p>Donations received</p>
+          <p>${humanize(total)}</p>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/pages/Profile/Body/Program/Program.tsx
+++ b/src/pages/Profile/Body/Program/Program.tsx
@@ -29,12 +29,12 @@ export default function Program({ className = "" }) {
               readOnly
               classes={{ container: "m-6" }}
             />
-            {p.targetRaise && (
+            {p.targetRaise ? (
               <TargetProgress
                 target={p.targetRaise}
                 total={p.totalDonations ?? 0}
               />
-            )}
+            ) : null}
           </Container>
           <Milestones
             classes="self-start lg:sticky lg:top-28"

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -152,7 +152,10 @@ export type EndowmentSettingsUpdate = Pick<
 export type NewProgram = Omit<Program, "id" | "milestones"> & {
   milestones: Omit<Milestone, "id">[];
 };
-export type ProgramUpdate = PartialExcept<Omit<Program, "milestones">, "id">;
+export type ProgramUpdate = PartialExcept<
+  Omit<Program, "milestones" | "targetRaise">,
+  "id"
+> & { targetRaise?: number };
 
 export type NewMilestone = Omit<Milestone, "id">;
 export type MilestoneUpdate = PartialExcept<Milestone, "id">;

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -19,6 +19,8 @@ export type Program = {
   id: string;
   title: string;
   milestones: Milestone[];
+  targetRaise?: number;
+  totalDonations?: number;
 };
 
 export type Media = {

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -19,7 +19,7 @@ export type Program = {
   id: string;
   title: string;
   milestones: Milestone[];
-  targetRaise?: number;
+  targetRaise?: number | null;
   totalDonations?: number;
 };
 
@@ -155,7 +155,7 @@ export type NewProgram = Omit<Program, "id" | "milestones"> & {
 export type ProgramUpdate = PartialExcept<
   Omit<Program, "milestones" | "targetRaise">,
   "id"
-> & { targetRaise?: number };
+> & { targetRaise?: number | null /** unsets the target */ };
 
 export type NewMilestone = Omit<Milestone, "id">;
 export type MilestoneUpdate = PartialExcept<Milestone, "id">;


### PR DESCRIPTION
Towards BG-662

## Explanation of the solution
* add edit `targetRaise` field
<img width="997" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/6df44eec-d7d6-4489-bc2e-a9424b82e55e">

* display target raise and total in program page
<img width="1470" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/b45cf18d-2034-4723-bebb-39de20e76007">


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
