### PR TITLE
new chains integrated

### DIFF
--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/estimateDonation.ts
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/estimateDonation.ts
@@ -29,12 +29,22 @@ export async function estimateDonation(
     // ///////////// GET TX CONTENT ///////////////
 
     switch (chainID) {
+      //juno
       case "juno-1":
-      case "uni-6": {
+      case "uni-6":
+      //kujira
+      case "kaiyo-1":
+      case "harpoon-4":
+      //stargaze
+      case "stargaze-1":
+      case "elgafar-1": {
         const scaledAmount = scaleToStr(grossAmount, token.decimals);
         const to = apWallets.junoDeposit;
         const msg =
-          token.type === "juno-native" || token.type === "ibc"
+          token.type === "juno-native" ||
+          token.type === "kujira-native" ||
+          token.type === "stargaze-native" ||
+          token.type === "ibc"
             ? createCosmosMsg(sender, "recipient.send", {
                 recipient: to,
                 amount: scaledAmount,
@@ -49,7 +59,6 @@ export async function estimateDonation(
         toEstimate = { chainID, val: [msg] };
         break;
       }
-
       case "pisco-1":
       case "phoenix-1": {
         const scaledAmount = scaleToStr(grossAmount, token.decimals);

--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/tokenBalance.ts
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/tokenBalance.ts
@@ -18,6 +18,8 @@ export const tokenBalance = async (
   switch (type) {
     case "juno-native":
     case "terra-native":
+    case "stargaze-native":
+    case "kujira-native":
     case "ibc": {
       return fetch(
         lcd +

--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/txPackage.ts
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/txPackage.ts
@@ -8,14 +8,22 @@ export const txPackage = (
   const { address: sender } = wallet;
 
   switch (estimate.chainID) {
+    //terra
     case "phoenix-1":
     case "pisco-1": {
       if (!isTerra(wallet)) throw new Error("User selected wrong wallet");
       const { toSend, chainID } = estimate;
       return { toSend, chainID, sender, post: wallet.post };
     }
+    //juno
     case "juno-1":
-    case "uni-6": {
+    case "uni-6":
+    //kujira
+    case "kaiyo-1":
+    case "harpoon-4":
+    //stargaze
+    case "stargaze-1":
+    case "elgafar-1": {
       const { toSend, chainID } = estimate;
       if (!isCosmos(wallet)) throw new Error("User selected wrong wallet");
       return {

--- a/src/constants/chainIds.ts
+++ b/src/constants/chainIds.ts
@@ -10,6 +10,8 @@ export const chainIds: { [key in Chains]: ChainID } = IS_TEST
       binance: "97",
       ethereum: "11155111",
       juno: "uni-6",
+      stargaze: "elgafar-1",
+      kujira: "harpoon-4",
       polygon: "80002",
       terra: "pisco-1",
     }

--- a/src/constants/chainIds.ts
+++ b/src/constants/chainIds.ts
@@ -5,6 +5,8 @@ import { IS_TEST } from "./env";
 export const chainIds: { [key in Chains]: ChainID } = IS_TEST
   ? {
       arbitrum: "421614",
+      optimism: "11155420",
+      base: "84532",
       binance: "97",
       ethereum: "11155111",
       juno: "uni-6",
@@ -13,9 +15,13 @@ export const chainIds: { [key in Chains]: ChainID } = IS_TEST
     }
   : {
       arbitrum: "42161",
+      optimism: "10",
+      base: "8453",
       binance: "56",
       ethereum: "1",
       juno: "juno-1",
+      stargaze: "stargaze-1",
+      kujira: "kaiyo-1",
       polygon: "137",
       terra: "phoenix-1",
     };

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -58,6 +58,38 @@ export const arbitrum: SupportedChain = {
   },
 };
 
+export const optimism: SupportedChain = {
+  isTest: false,
+  id: "10",
+  brand: "optimism",
+  name: "Optimism",
+  rpc: "https://mainnet.optimism.io",
+  lcd: "",
+  blockExplorer: "https://optimistic.etherscan.io",
+  nativeToken: {
+    id: "10",
+    symbol: "ETH",
+    decimals: 18,
+    coinGeckoId: "ethereum",
+  },
+};
+
+export const base: SupportedChain = {
+  isTest: false,
+  id: "8453",
+  brand: "base",
+  name: "Base",
+  rpc: "https://mainnet.base.org",
+  lcd: "",
+  blockExplorer: "https://mainnet.basescan.org",
+  nativeToken: {
+    id: "8453",
+    symbol: "ETH",
+    decimals: 18,
+    coinGeckoId: "ethereum",
+  },
+};
+
 export const binance: SupportedChain = {
   isTest: false,
   id: "56",
@@ -87,6 +119,38 @@ export const juno: SupportedChain = {
     symbol: "JUNO",
     decimals: 6,
     coinGeckoId: "juno-network",
+  },
+};
+
+export const stargaze: SupportedChain = {
+  isTest: false,
+  id: "stargaze-1",
+  brand: "stargaze",
+  name: "Stargaze",
+  lcd: "https://stargaze-rest.publicnode.com",
+  rpc: "https://stargaze-rpc.publicnode.com:443",
+  blockExplorer: "https://www.mintscan.io/stargaze",
+  nativeToken: {
+    id: "ustars",
+    symbol: "STARS",
+    decimals: 6,
+    coinGeckoId: "stargaze",
+  },
+};
+
+export const kujira: SupportedChain = {
+  isTest: false,
+  id: "kaiyo-1",
+  brand: "kujira",
+  name: "Kujira",
+  lcd: "https://kujira-rpc.publicnode.com",
+  rpc: "https://kujira-rpc.publicnode.com:443",
+  blockExplorer: "https://finder.kujira.network/kaiyo-1",
+  nativeToken: {
+    id: "ukuji",
+    symbol: "KUJI",
+    decimals: 6,
+    coinGeckoId: "kujira",
   },
 };
 
@@ -127,7 +191,7 @@ export const sepolia: SupportedChain = {
   isTest: true,
   id: "11155111",
   brand: "sepolia",
-  name: "Ethereum Sepolia Testnet",
+  name: "Ethereum Sepolia",
   rpc: baseProxyURL + "/sepolia",
   lcd: "",
   blockExplorer: "https://sepolia.etherscan.io",
@@ -149,6 +213,38 @@ export const arbitrumSepolia: SupportedChain = {
   blockExplorer: "https://sepolia.arbiscan.io",
   nativeToken: {
     id: "421614",
+    symbol: "ETH",
+    decimals: 18,
+    coinGeckoId: "ethereum",
+  },
+};
+
+export const optimismSepolia: SupportedChain = {
+  isTest: true,
+  id: "11155420",
+  brand: "optimism",
+  name: "Optimism Sepolia",
+  rpc: "https://sepolia.optimism.io",
+  lcd: "",
+  blockExplorer: "https://sepolia-optimistic.etherscan.io",
+  nativeToken: {
+    id: "11155420",
+    symbol: "ETH",
+    decimals: 18,
+    coinGeckoId: "ethereum",
+  },
+};
+
+export const baseSepolia: SupportedChain = {
+  isTest: true,
+  id: "84532",
+  brand: "base",
+  name: "Base Sepolia",
+  rpc: "https://sepolia.base.org",
+  lcd: "",
+  blockExplorer: "https://sepolia.basescan.org",
+  nativeToken: {
+    id: "84532",
     symbol: "ETH",
     decimals: 18,
     coinGeckoId: "ethereum",
@@ -219,12 +315,18 @@ const supportedChainList: SupportedChain[] = [
   polygon,
   ethereum,
   arbitrum,
+  optimism,
+  base,
   binance,
   juno,
+  kujira,
+  stargaze,
   terraMainnet,
   sepolia,
   polygonAmoy,
   arbitrumSepolia,
+  optimismSepolia,
+  baseSepolia,
   binanceTestnet,
   terraTestnet,
 ];
@@ -256,5 +358,14 @@ export const EVMChains: EVMChainID[] = [
   "56",
   "80002",
   "97",
+  "10",
+  "11155420",
+  "8453",
+  "84532",
 ];
-export const cosmosChains: CosmosChainID[] = ["juno-1", "uni-6"];
+export const cosmosChains: CosmosChainID[] = [
+  "juno-1",
+  "uni-6",
+  "stargaze-1",
+  "kaiyo-1",
+];

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -283,6 +283,38 @@ export const terraTestnet: SupportedChain = {
   },
 };
 
+export const stargazeTestnet: SupportedChain = {
+  isTest: true,
+  id: "elgafar-1",
+  brand: "stargaze",
+  name: "Stargaze Testnet",
+  lcd: "https://rest.elgafar-1.stargaze-apis.com",
+  rpc: "https://rpc.elgafar-1.stargaze-apis.com",
+  blockExplorer: "https://www.mintscan.io/stargaze",
+  nativeToken: {
+    id: "ustars",
+    symbol: "STARS",
+    decimals: 6,
+    coinGeckoId: "stargaze",
+  },
+};
+
+export const kujiraTestnet: SupportedChain = {
+  isTest: true,
+  id: "harpoon-4",
+  brand: "kujira",
+  name: "Kujira Testnet",
+  lcd: "https://test-lcd-kujira.mintthemoon.xyz",
+  rpc: "https://rpc-kujira.mintthemoon.xyz",
+  blockExplorer: "https://finder.kujira.network/harpoon-4",
+  nativeToken: {
+    id: "ukuji",
+    symbol: "KUJI",
+    decimals: 6,
+    coinGeckoId: "kujira",
+  },
+};
+
 export const bitcoin: UnsupportedChain = {
   isTest: IS_TEST,
   id: `btc-${IS_TEST ? "testnet" : "mainnet"}`,
@@ -329,6 +361,8 @@ const supportedChainList: SupportedChain[] = [
   baseSepolia,
   binanceTestnet,
   terraTestnet,
+  kujiraTestnet,
+  stargazeTestnet,
 ];
 
 const unsupportedChainList: UnsupportedChain[] = [
@@ -367,5 +401,7 @@ export const cosmosChains: CosmosChainID[] = [
   "juno-1",
   "uni-6",
   "stargaze-1",
+  "elgafar-1",
   "kaiyo-1",
+  "harpoon-4",
 ];

--- a/src/contexts/WalletContext/useKeplr/useKeplr.ts
+++ b/src/contexts/WalletContext/useKeplr/useKeplr.ts
@@ -1,4 +1,4 @@
-import { juno, terraMainnet } from "constants/chains";
+import { juno, kujira, stargaze, terraMainnet } from "constants/chains";
 import { useEffect, useState } from "react";
 import type { ChainID } from "types/chain";
 import type { CosmosProviderState, Wallet, WalletMeta } from "types/wallet";
@@ -10,7 +10,7 @@ const keplrIcon = "/icons/wallets/keplr.png";
 const meta: WalletMeta = {
   name: "Keplr",
   logo: keplrIcon,
-  supportedChains: ["juno-1", "phoenix-1"],
+  supportedChains: ["juno-1", "phoenix-1", "kaiyo-1", "stargaze-1"],
 };
 
 export default function useKeplr(): Wallet {
@@ -30,7 +30,12 @@ export default function useKeplr(): Wallet {
         return window.open(INSTALL_URL, "_blank", "noopener noreferrer");
       }
       setState({ status: "loading" });
-      await window.keplr.enable([juno.id, terraMainnet.id]);
+      await window.keplr.enable([
+        juno.id,
+        terraMainnet.id,
+        stargaze.id,
+        kujira.id,
+      ]);
       const key = await window.keplr.getKey(juno.id);
 
       setState({

--- a/src/contexts/WalletContext/wallet-connect/useKeplrWC.ts
+++ b/src/contexts/WalletContext/wallet-connect/useKeplrWC.ts
@@ -55,7 +55,7 @@ export function useKeplrWC(): Wallet {
         requiredNamespaces: {
           cosmos: {
             methods: ["cosmos_signDirect", "cosmos_signAmino"],
-            chains: ["cosmos:juno-1"],
+            chains: ["cosmos:juno-1", "cosmos:kaiyo-1", "cosmos:stargaze-1"],
             events: [],
           },
         },
@@ -100,7 +100,7 @@ export function useKeplrWC(): Wallet {
   const meta: WalletMeta = {
     logo: keplrIcon,
     name: "Keplr mobile",
-    supportedChains: ["juno-1"],
+    supportedChains: ["juno-1", "kaiyo-1", "stargaze-1"],
   };
 
   return {

--- a/src/helpers/tx/estimateTx/estimateTx.ts
+++ b/src/helpers/tx/estimateTx/estimateTx.ts
@@ -10,11 +10,19 @@ export default async function estimateTx(
 ): Promise<EstimateResult | null> {
   try {
     switch (toEstimate.chainID) {
+      //juno
       case "juno-1":
-      case "uni-6": {
+      case "uni-6":
+      //kujira
+      case "kaiyo-1":
+      case "harpoon-4":
+      //stargaze
+      case "stargaze-1":
+      case "elgafar-1": {
         const { val, chainID } = toEstimate;
         return estimateCosmosFee(chainID, sender.address, val);
       }
+      //terra
       case "phoenix-1":
       case "pisco-1": {
         const { chainID, val } = toEstimate;

--- a/src/helpers/tx/sendTx/sendTx.ts
+++ b/src/helpers/tx/sendTx/sendTx.ts
@@ -5,11 +5,19 @@ import { sendTerraTx } from "./sendTerraTx";
 
 export default function sendTx({ sender, ...txPackage }: TxPackage) {
   switch (txPackage.chainID) {
+    //juno
     case "juno-1":
-    case "uni-6": {
+    case "uni-6":
+    //kujira
+    case "kaiyo-1":
+    case "harpoon-4":
+    //stargaze
+    case "stargaze-1":
+    case "elgafar-1": {
       const { chainID, toSend, sign } = txPackage;
       return sendCosmosTx(chainID, sender, toSend, sign);
     }
+    //terra
     case "phoenix-1":
     case "pisco-1": {
       const { chainID, toSend, post } = txPackage;

--- a/src/schemas/string.ts
+++ b/src/schemas/string.ts
@@ -2,6 +2,8 @@ import type { SupportedChainId } from "types/chain";
 import * as Yup from "yup";
 
 export const junoAddrPattern = /^juno1[a-z0-9]{38,58}$/i;
+export const stargazeAddrPattern = /^stars1[a-z0-9]{38,58}$/i;
+export const kujiraAddrPattern = /^kujira1[a-z0-9]{38,58}$/i;
 export const terraAddrPattern = /^terra1[a-z0-9]{38}$/i;
 export const alphanumeric = /^[0-9a-zA-Z]+$/;
 const evmAddrPattern = /^0x[a-fA-F0-9]{40}$/;
@@ -43,6 +45,10 @@ export function walletAddrPatten(chainId: SupportedChainId) {
     case "42161":
     case "80002":
     case "421614":
+    case "10":
+    case "11155420":
+    case "8453":
+    case "84532":
       return evmAddrPattern;
     case "pisco-1":
     case "phoenix-1":
@@ -50,7 +56,12 @@ export function walletAddrPatten(chainId: SupportedChainId) {
     case "juno-1":
     case "uni-6":
       return junoAddrPattern;
-
+    case "kaiyo-1":
+    case "harpoon-4":
+      return kujiraAddrPattern;
+    case "stargaze-1":
+    case "elgafar-1":
+      return stargazeAddrPattern;
     default:
       const x: never = chainId;
       throw new Error(`unhandled ${x}`);

--- a/src/types/aws/apes/index.ts
+++ b/src/types/aws/apes/index.ts
@@ -10,6 +10,8 @@ export type QrTokenType =
 
 export type TokenType =
   | "juno-native"
+  | "stargaze-native"
+  | "kujira-native"
   | "terra-native"
   | "evm-native"
   | "erc20"

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -18,7 +18,13 @@ export type EVMChainID =
   | "8453"
   | "84532";
 
-export type CosmosChainID = "juno-1" | "uni-6" | "kaiyo-1" | "stargaze-1";
+export type CosmosChainID =
+  | "juno-1"
+  | "uni-6"
+  | "kaiyo-1"
+  | "stargaze-1"
+  | "harpoon-4"
+  | "elgafar-1";
 //would remove this type once terra tooling is unified to that of cosmos (keplr)
 export type TerraChainID = "phoenix-1" | "pisco-1";
 

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -10,9 +10,15 @@ export type EVMChainID =
   | "421614"
   //binance
   | "56"
-  | "97";
+  | "97"
+  //optimism
+  | "10"
+  | "11155420"
+  //base
+  | "8453"
+  | "84532";
 
-export type CosmosChainID = "juno-1" | "uni-6";
+export type CosmosChainID = "juno-1" | "uni-6" | "kaiyo-1" | "stargaze-1";
 //would remove this type once terra tooling is unified to that of cosmos (keplr)
 export type TerraChainID = "phoenix-1" | "pisco-1";
 

--- a/src/types/lists.ts
+++ b/src/types/lists.ts
@@ -5,8 +5,12 @@ export type DonationSource = "bg-marketplace" | "bg-widget";
 export type Chains =
   | "terra"
   | "juno"
+  | "stargaze"
+  | "kujira"
   | "ethereum"
   | "arbitrum"
+  | "optimism"
+  | "base"
   | "binance"
   | "polygon";
 export type UNSDG_NUMS =


### PR DESCRIPTION
Closes BG-1404 
Closes BG-1405 

## Explanation of the solution
Adds support for new Cosmos and EVM chains to the Web App:
- Kujira (mainnet & testnet)
- Stargaze (mainnet & testnet)
- Optimism (mainnet & sepoia)
- Base (mainnet & sepoia)

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
