### PR TITLE
Stripe form integration test

### DIFF
--- a/src/components/CurrencySelector/CurrencySelector.tsx
+++ b/src/components/CurrencySelector/CurrencySelector.tsx
@@ -1,11 +1,16 @@
-import { Combobox, ComboboxButton, ComboboxInput } from "@headlessui/react";
+import {
+  Combobox,
+  ComboboxButton,
+  ComboboxInput,
+  Field,
+  Label,
+} from "@headlessui/react";
 import Icon from "components/Icon/Icon";
 import { unpack } from "helpers";
 import { useState } from "react";
 import type { CurrencyOption } from "types/components";
 import { type QueryState, isQuery } from "types/third-party/redux";
 import { DrawerIcon } from "../Icon";
-import { Label } from "../form";
 import CurrencyOptions from "./CurrencyOptions";
 
 type Classes = {
@@ -37,25 +42,25 @@ export default function CurrencySelector<T extends CurrencyOption>({
   const style = unpack(props.classes);
 
   return (
-    <div className={`field ${style.container}`}>
+    <Field
+      disabled={props.disabled || isCurrencyLoading || isCurrencyError}
+      className={`field ${style.container}`}
+    >
       <Label
-        htmlFor="wise__currency"
-        className={style.label}
-        required={props.required}
+        className={`${style.label} label`}
+        data-required={props.required}
         aria-required={props.required}
       >
         {props.label}
       </Label>
       <Combobox
-        disabled={props.disabled || isCurrencyLoading || isCurrencyError}
-        by={"code" as any}
+        by="code"
         value={props.value}
         onChange={(val) => val && props.onChange(val)}
         as="div"
         className={`relative items-center grid grid-cols-[1fr_auto] field-container ${style.combobox}`}
       >
         <ComboboxInput
-          id="wise__currency"
           className="w-full dark:border-navy px-4 py-3.5 text-sm leading-5 focus:ring-0"
           displayValue={(currency: T) =>
             !!currency.name
@@ -90,6 +95,6 @@ export default function CurrencySelector<T extends CurrencyOption>({
           currencies={currencies}
         />
       </Combobox>
-    </div>
+    </Field>
   );
 }

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.test.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.test.tsx
@@ -100,6 +100,24 @@ describe("Stripe form test", () => {
     });
     expect(programSelector).toBeInTheDocument();
   });
+  test("form is loading", () => {
+    currenciesQuery.mockReturnValueOnce({
+      refetch: () => ({}) as any,
+      data: undefined,
+      isLoading: true,
+    });
+    render(<Form step="donate-form" init={init} />);
+    expect(screen.getByText(/loading donate form/i));
+  });
+  test("failed to get currencies", () => {
+    currenciesQuery.mockReturnValueOnce({
+      refetch: () => ({}) as any,
+      isLoading: false,
+      isError: true,
+    });
+    render(<Form step="donate-form" init={init} />);
+    expect(screen.getByText(/failed to load donate form/i));
+  });
   test("blank state: program donations not allowed", () => {
     const init: Init = {
       source: "bg-marketplace",

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.test.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import * as apes from "services/apes";
+import * as programs from "services/aws/programs";
+import type { Program } from "types/aws";
+import type { DetailedCurrency } from "types/components";
+import { beforeEach, describe, expect, it, test, vi } from "vitest";
+import type { Init } from "../../types";
+import Form from "./Form";
+
+const defaultCurrency: DetailedCurrency = {
+  code: "PHP",
+  rate: 50,
+  min: 50,
+};
+const mockCurrencies: DetailedCurrency[] = [
+  { code: "USD", rate: 1, min: 1 },
+  { code: "EUR", rate: 0.92, min: 0.92 },
+  { code: "GBP", rate: 0.79, min: 0.79 },
+];
+
+vi.mock("store/accessors", () => ({
+  useGetter: vi.fn(() => ({ user: null })),
+}));
+
+vi.spyOn(apes, "useFiatCurrenciesQuery").mockReturnValue({
+  data: {
+    currencies: mockCurrencies,
+    defaultCurr: defaultCurrency,
+  },
+  isLoading: false,
+  isError: false,
+  error: null,
+} as any);
+
+const mockPrograms: Program[] = [
+  {
+    id: "program-1",
+    title: "Program 1",
+    description: "Description for Program 1",
+    milestones: [],
+  },
+  {
+    id: "program-2",
+    title: "Program 2",
+    description: "Description for Program 2",
+    milestones: [],
+  },
+];
+
+vi.spyOn(programs, "useProgramsQuery").mockReturnValue({
+  data: mockPrograms,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  //we don't need other  attributes
+} as any);
+
+vi.mock("../../Context", () => ({
+  useDonationState: vi.fn(() => ({ setState: vi.fn() })),
+}));
+
+const init: Init = {
+  source: "bg-marketplace",
+  mode: "live",
+  recipient: {
+    id: 123456,
+    name: "Example Endowment",
+  },
+  config: null,
+};
+
+describe("Stripe form test", () => {
+  test("stripe form loads", () => {
+    render(<Form step="donate-form" init={init} />);
+
+    screen.debug();
+  });
+});

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.test.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.test.tsx
@@ -1,10 +1,12 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach } from "node:test";
+import { getByRole, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import * as apes from "services/apes";
 import * as programs from "services/aws/programs";
 import type { Program } from "types/aws";
 import type { DetailedCurrency } from "types/components";
-import { beforeEach, describe, expect, it, test, vi } from "vitest";
-import type { Init } from "../../types";
+import { afterAll, describe, expect, test, vi } from "vitest";
+import type { Init, StripeDonationDetails } from "../../types";
 import Form from "./Form";
 
 const defaultCurrency: DetailedCurrency = {
@@ -13,24 +15,23 @@ const defaultCurrency: DetailedCurrency = {
   min: 50,
 };
 const mockCurrencies: DetailedCurrency[] = [
-  { code: "USD", rate: 1, min: 1 },
   { code: "EUR", rate: 0.92, min: 0.92 },
+  { code: "USD", rate: 1, min: 1 },
   { code: "GBP", rate: 0.79, min: 0.79 },
 ];
 
-vi.mock("store/accessors", () => ({
-  useGetter: vi.fn(() => ({ user: null })),
-}));
-
-vi.spyOn(apes, "useFiatCurrenciesQuery").mockReturnValue({
-  data: {
-    currencies: mockCurrencies,
-    defaultCurr: defaultCurrency,
-  },
-  isLoading: false,
-  isError: false,
-  error: null,
-} as any);
+const currenciesQuery = vi
+  .spyOn(apes, "useFiatCurrenciesQuery")
+  .mockReturnValue({
+    data: {
+      currencies: mockCurrencies,
+      defaultCurr: defaultCurrency,
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: () => ({}) as any,
+  });
 
 const mockPrograms: Program[] = [
   {
@@ -52,11 +53,16 @@ vi.spyOn(programs, "useProgramsQuery").mockReturnValue({
   isLoading: false,
   isFetching: false,
   isError: false,
-  //we don't need other  attributes
-} as any);
+  refetch: () => ({}) as any,
+});
 
+vi.mock("store/accessors", () => ({
+  useGetter: vi.fn(() => null),
+}));
+
+const mockSetState = vi.hoisted(() => vi.fn());
 vi.mock("../../Context", () => ({
-  useDonationState: vi.fn(() => ({ setState: vi.fn() })),
+  useDonationState: vi.fn(() => ({ setState: mockSetState })),
 }));
 
 const init: Init = {
@@ -70,9 +76,82 @@ const init: Init = {
 };
 
 describe("Stripe form test", () => {
-  test("stripe form loads", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("initial state", () => {
     render(<Form step="donate-form" init={init} />);
 
+    //give monthly is frequency default option
+    const freqOptions = screen.getAllByRole("radio");
+    expect(freqOptions[0]).toHaveTextContent(/give monthly/i);
+    expect(freqOptions[0]).toBeChecked();
+
+    const currencyInput = screen.getByRole("combobox");
+    expect(currencyInput).toHaveDisplayValue(/php/i); //based on mock value
+
+    //amount input doesn't have default value
+    const amountInput = screen.getByPlaceholderText(/enter amount/i);
+    expect(amountInput).toHaveDisplayValue("");
+
+    const programSelector = screen.getByRole("button", {
+      name: /general donation/i,
+    });
+    expect(programSelector).toBeInTheDocument();
     screen.debug();
+  });
+  test("initial state: program donations not allowed", () => {
+    const init: Init = {
+      source: "bg-marketplace",
+      mode: "live",
+      recipient: {
+        id: 123456,
+        name: "Example Endowment",
+        progDonationsAllowed: false,
+      },
+      config: null,
+    };
+    render(<Form step="donate-form" init={init} />);
+
+    const programSelector = screen.queryByRole("button", {
+      name: /general donation/i,
+    });
+    expect(programSelector).toBeNull();
+    screen.debug();
+  });
+
+  test("initial state: no default currency specified", () => {
+    currenciesQuery.mockReturnValueOnce({
+      refetch: () => ({}) as any,
+      data: { currencies: mockCurrencies },
+    });
+    render(<Form step="donate-form" init={init} />);
+    const currencySelector = screen.getByRole("combobox");
+    expect(currencySelector).toHaveDisplayValue(/usd/i);
+  });
+
+  test("form has initial state and user was able to continue", async () => {
+    const details: StripeDonationDetails = {
+      amount: "60",
+      currency: defaultCurrency,
+      frequency: "subscription",
+      method: "stripe",
+      program: { value: mockPrograms[0].id, label: mockPrograms[0].title },
+    };
+    render(<Form step="donate-form" init={init} details={details} />);
+
+    const amountInput = screen.getByPlaceholderText(/enter amount/i);
+    expect(amountInput).toHaveDisplayValue("60");
+
+    const programSelector = screen.getByRole("button", {
+      name: /program 1/i,
+    });
+    expect(programSelector).toBeInTheDocument();
+
+    const continueBtn = screen.getByRole("button", { name: /continue/i });
+    await userEvent.click(continueBtn);
+
+    expect(mockSetState).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -1,25 +1,20 @@
-import { yupResolver } from "@hookform/resolvers/yup";
 import CurrencySelector from "components/CurrencySelector";
 import QueryLoader from "components/QueryLoader";
 import { Form as FormContainer, NativeField } from "components/form";
 import { bgCookies, setCookie } from "helpers/cookie";
-import { useController, useForm } from "react-hook-form";
-import { schema, stringNumber } from "schemas/shape";
-import { requiredString } from "schemas/string";
 import { useFiatCurrenciesQuery } from "services/apes";
 import { useGetter } from "store/accessors";
 import { userIsSignedIn } from "types/auth";
-import type { Currency, DetailedCurrency } from "types/components";
+import type { Currency } from "types/components";
 import { useDonationState } from "../../Context";
 import ContinueBtn from "../../common/ContinueBtn";
 import { ProgramSelector } from "../../common/ProgramSelector";
-import { DEFAULT_PROGRAM } from "../../common/constants";
+import { USD_CODE } from "../../common/constants";
 import { nextFormState } from "../helpers";
 import Frequency from "./Frequency";
 import Incrementers from "./Incrementers";
-import type { FormValues as FV, Props } from "./types";
-
-const USD_CODE = "usd";
+import type { FormProps, Props } from "./types";
+import { useRhf } from "./useRhf";
 
 export default function Loader(props: Props) {
   const user = useGetter((state) => state.auth.user);
@@ -39,65 +34,14 @@ export default function Loader(props: Props) {
   );
 }
 
-type FormProps = Props & {
-  currencies: DetailedCurrency[];
-  defaultCurr?: DetailedCurrency;
-};
-
 function Form({ currencies, defaultCurr, ...props }: FormProps) {
   const { setState } = useDonationState();
 
-  const initial: FV = {
-    amount: "",
-    currency: defaultCurr || { code: USD_CODE, min: 1, rate: 1 },
-    frequency: "subscription",
-    program: DEFAULT_PROGRAM,
-  };
-
-  const currencyKey: keyof FV = "currency";
-  const {
-    control,
-    handleSubmit,
-    register,
-    setValue,
-    getValues,
-    trigger,
-    formState: { errors },
-  } = useForm<FV>({
-    defaultValues: props.details || initial,
-    resolver: yupResolver(
-      schema<FV>({
-        frequency: requiredString,
-        amount: stringNumber(
-          (s) => s.required("Please enter an amount"),
-          (n) =>
-            n
-              .positive("Amount must be greater than 0")
-              .when(currencyKey, (values, schema) => {
-                const [currency] = values as [Currency | undefined];
-                return currency?.min
-                  ? schema.min(currency.min, "less than min")
-                  : schema;
-              })
-        ),
-      })
-    ),
-  });
-
-  const { field: frequency } = useController<FV, "frequency">({
-    control: control,
-    name: "frequency",
-  });
-
-  const { field: currency } = useController<FV, "currency">({
-    control: control,
-    name: "currency",
-  });
-
-  const { field: program } = useController<FV, "program">({
-    control: control,
-    name: "program",
-  });
+  const { handleSubmit, currency, register, program, frequency, errors } =
+    useRhf({
+      ...props,
+      defaultCurr,
+    });
 
   return (
     <FormContainer
@@ -138,11 +82,7 @@ function Form({ currencies, defaultCurr, ...props }: FormProps) {
       />
       {currency.value.rate && (
         <Incrementers
-          onIncrement={(inc) => {
-            const amntNum = Number(getValues("amount"));
-            if (Number.isNaN(amntNum)) return trigger("amount");
-            setValue("amount", `${inc + amntNum}`);
-          }}
+          onIncrement={(inc) => {}}
           code={currency.value.code}
           rate={currency.value.rate}
         />

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -131,6 +131,7 @@ function Form({ currencies, defaultCurr, ...props }: FormProps) {
         label="Donation amount"
         placeholder="Enter amount"
         classes={{ label: "font-semibold", container: "field-donate" }}
+        error={errors.amount?.message}
         required
         // validation must be dynamicly set depending on which exact currency is selected
         tooltip={createTooltip(currency.value)}

--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.tsx
@@ -37,32 +37,28 @@ export default function Loader(props: Props) {
 function Form({ currencies, defaultCurr, ...props }: FormProps) {
   const { setState } = useDonationState();
 
-  const { handleSubmit, currency, register, program, frequency, errors } =
-    useRhf({
-      ...props,
-      defaultCurr,
-    });
+  const rhf = useRhf({ ...props, defaultCurr });
 
   return (
     <FormContainer
-      onSubmit={handleSubmit((fv) =>
+      onSubmit={rhf.handleSubmit((fv) =>
         setState((prev) => nextFormState(prev, { ...fv, method: "stripe" }))
       )}
       className="grid gap-4"
     >
       <Frequency
-        value={frequency.value}
-        onChange={frequency.onChange}
-        error={errors.frequency?.message}
+        value={rhf.frequency.value}
+        onChange={rhf.frequency.onChange}
+        error={rhf.errors.frequency?.message}
       />
       <CurrencySelector
         currencies={currencies}
         label="Currency"
         onChange={(c) => {
           setCookie(bgCookies.prefCode, c.code.toUpperCase());
-          currency.onChange(c);
+          rhf.currency.onChange(c);
         }}
-        value={currency.value}
+        value={rhf.currency.value}
         classes={{
           label: "font-semibold",
           combobox: "field-container-donate rounded-lg",
@@ -71,20 +67,20 @@ function Form({ currencies, defaultCurr, ...props }: FormProps) {
         required
       />
       <NativeField
-        {...register("amount")}
+        {...rhf.register("amount")}
         label="Donation amount"
         placeholder="Enter amount"
         classes={{ label: "font-semibold", container: "field-donate" }}
-        error={errors.amount?.message}
+        error={rhf.errors.amount?.message}
         required
         // validation must be dynamicly set depending on which exact currency is selected
-        tooltip={createTooltip(currency.value)}
+        tooltip={createTooltip(rhf.currency.value)}
       />
-      {currency.value.rate && (
+      {rhf.currency.value.rate && (
         <Incrementers
-          onIncrement={(inc) => {}}
-          code={currency.value.code}
-          rate={currency.value.rate}
+          onIncrement={rhf.onIncrement}
+          code={rhf.currency.value.code}
+          rate={rhf.currency.value.rate}
         />
       )}
 
@@ -92,8 +88,8 @@ function Form({ currencies, defaultCurr, ...props }: FormProps) {
         <ProgramSelector
           classes="mt-4"
           endowId={props.init.recipient.id}
-          program={program.value}
-          onChange={program.onChange}
+          program={rhf.program.value}
+          onChange={rhf.program.onChange}
         />
       )}
 

--- a/src/components/donation/Steps/DonateMethods/Stripe/Frequency.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Frequency.tsx
@@ -1,6 +1,6 @@
 import { Radio, RadioGroup } from "@headlessui/react";
 import Icon from "components/Icon";
-import { useController, useFormContext } from "react-hook-form";
+import type { FiatPaymentFrequency } from "types/aws";
 import type { FormValues as FV } from "./types";
 
 type Freq = FV["frequency"];
@@ -11,17 +11,12 @@ const styles = {
     "group border-gray-l3 rounded-lg px-2 @[21rem]/frequency:px-6 border h-[2.625rem] flex items-center justify-center @[21rem]/frequency:justify-start aria-checked:bg-[--accent-primary] aria-checked:text-white aria-checked:border-none select-none",
 };
 
-export default function Frequency() {
-  const { control } = useFormContext<FV>();
-
-  const {
-    field: { value, onChange },
-    fieldState: { error },
-  } = useController<FV, "frequency">({
-    control: control,
-    name: "frequency",
-  });
-
+interface Props {
+  value: FiatPaymentFrequency;
+  onChange: (freq: FiatPaymentFrequency) => void;
+  error?: string;
+}
+export default function Frequency({ value, onChange, error }: Props) {
   return (
     <RadioGroup
       value={value}
@@ -41,9 +36,7 @@ export default function Frequency() {
           <Icon type="Check" className={styles.icon} />
         </Radio>
       </div>
-      {error?.message && (
-        <p className="field-error static text-left mt-1">{error.message}</p>
-      )}
+      {error && <p className="field-error static text-left mt-1">{error}</p>}
       <p className="text-navy-l1 mt-3">
         <span className="text-navy-d4 font-medium">Monthly donations</span> help
         nonprofits focus on mission and long-term impact, not fundraising.

--- a/src/components/donation/Steps/DonateMethods/Stripe/Frequency.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Frequency.tsx
@@ -1,9 +1,8 @@
 import { Radio, RadioGroup } from "@headlessui/react";
 import Icon from "components/Icon";
-import type { FiatPaymentFrequency } from "types/aws";
-import type { FormValues as FV } from "./types";
+import type { FormValues } from "./types";
 
-type Freq = FV["frequency"];
+type Freq = FormValues["frequency"];
 
 const styles = {
   icon: "hidden @[21rem]/frequency:block text-[1.3rem] ml-1 group-aria-checked:text-white text-transparent relative bottom-px",
@@ -12,8 +11,8 @@ const styles = {
 };
 
 interface Props {
-  value: FiatPaymentFrequency;
-  onChange: (freq: FiatPaymentFrequency) => void;
+  value: Freq;
+  onChange: (freq: Freq) => void;
   error?: string;
 }
 export default function Frequency({ value, onChange, error }: Props) {

--- a/src/components/donation/Steps/DonateMethods/Stripe/Incrementers.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Incrementers.tsx
@@ -28,6 +28,7 @@ function Incrementer({ rate, inc, code, onIncrement }: IIncrementer) {
   const roundedVal = roundDownToNum(value, 0);
   return (
     <button
+      data-testid="incrementer"
       type="button"
       className="text-sm font-medium border border-gray-l4 hover:border-gray-l3 rounded-full w-[7rem] h-10"
       onClick={() => onIncrement(roundedVal)}

--- a/src/components/donation/Steps/DonateMethods/Stripe/Incrementers.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Incrementers.tsx
@@ -1,40 +1,38 @@
 import { humanize, roundDownToNum } from "helpers";
-import { useFormContext } from "react-hook-form";
-import type { FormValues } from "./types";
 
-export default function Incrementers({
-  rate,
-  code,
-}: {
+type OnIncrement = (increment: number) => void;
+interface Props {
   rate: number;
   code: string;
-}) {
+  onIncrement: OnIncrement;
+}
+
+const increments = [40, 100, 200];
+
+export default function Incrementers(props: Props) {
   return (
     <div className="flex justify-center flex-wrap gap-3">
-      <Incrementer value={40 * rate} curr={code} />
-      <Incrementer value={100 * rate} curr={code} />
-      <Incrementer value={200 * rate} curr={code} />
+      {increments.map((inc) => (
+        <Incrementer key={inc} inc={inc} {...props} />
+      ))}
     </div>
   );
 }
 
-function Incrementer({ value, curr }: { value: number; curr: string }) {
+interface IIncrementer extends Props {
+  inc: number;
+}
+
+function Incrementer({ rate, inc, code, onIncrement }: IIncrementer) {
+  const value = rate * inc;
   const roundedVal = roundDownToNum(value, 0);
-  const { setValue, trigger, getValues } = useFormContext<FormValues>();
   return (
     <button
       type="button"
       className="text-sm font-medium border border-gray-l4 hover:border-gray-l3 rounded-full w-[7rem] h-10"
-      onClick={() => {
-        const amount = Number(getValues("amount"));
-        if (Number.isNaN(amount)) {
-          trigger("amount");
-        } else {
-          setValue("amount", `${amount + roundedVal}`);
-        }
-      }}
+      onClick={() => onIncrement(roundedVal)}
     >
-      +{shortenHumanize(roundedVal)} {curr.toUpperCase()}
+      +{shortenHumanize(roundedVal)} {code.toUpperCase()}
     </button>
   );
 }

--- a/src/components/donation/Steps/DonateMethods/Stripe/Incrementers.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Incrementers.tsx
@@ -1,6 +1,6 @@
 import { humanize, roundDownToNum } from "helpers";
+import type { OnIncrement } from "./types";
 
-type OnIncrement = (increment: number) => void;
 interface Props {
   rate: number;
   code: string;

--- a/src/components/donation/Steps/DonateMethods/Stripe/types.ts
+++ b/src/components/donation/Steps/DonateMethods/Stripe/types.ts
@@ -1,4 +1,12 @@
+import type { DetailedCurrency } from "types/components";
 import type { StripeDonationDetails, StripeFormStep } from "../../types";
 
 export type Props = StripeFormStep;
 export type FormValues = Omit<StripeDonationDetails, "method">;
+
+export type FormProps = Props & {
+  currencies: DetailedCurrency[];
+  defaultCurr?: DetailedCurrency;
+};
+
+export type OnIncrement = (increment: number) => void;

--- a/src/components/donation/Steps/DonateMethods/Stripe/useRhf.ts
+++ b/src/components/donation/Steps/DonateMethods/Stripe/useRhf.ts
@@ -61,7 +61,7 @@ export function useRhf(props: Omit<FormProps, "currencies">) {
 
   const onIncrement: OnIncrement = (inc) => {
     const amntNum = Number(getValues("amount"));
-    if (Number.isNaN(amntNum)) return trigger("amount");
+    if (Number.isNaN(amntNum)) return trigger("amount", { shouldFocus: true });
     setValue("amount", `${inc + amntNum}`);
   };
 

--- a/src/components/donation/Steps/DonateMethods/Stripe/useRhf.ts
+++ b/src/components/donation/Steps/DonateMethods/Stripe/useRhf.ts
@@ -1,0 +1,77 @@
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useController, useForm } from "react-hook-form";
+import { schema, stringNumber } from "schemas/shape";
+import { requiredString } from "schemas/string";
+import type { Currency } from "types/components";
+import { DEFAULT_PROGRAM, usdOption } from "../../common/constants";
+import type { FormValues as FV, FormProps, OnIncrement } from "./types";
+
+export function useRhf(props: Omit<FormProps, "currencies">) {
+  const initial: FV = {
+    amount: "",
+    currency: props.defaultCurr || usdOption,
+    frequency: "subscription",
+    program: DEFAULT_PROGRAM,
+  };
+
+  const currencyKey: keyof FV = "currency";
+  const {
+    control,
+    handleSubmit,
+    register,
+    setValue,
+    getValues,
+    trigger,
+    formState: { errors },
+  } = useForm<FV>({
+    defaultValues: props.details || initial,
+    resolver: yupResolver(
+      schema<FV>({
+        frequency: requiredString,
+        amount: stringNumber(
+          (s) => s.required("Please enter an amount"),
+          (n) =>
+            n
+              .positive("Amount must be greater than 0")
+              .when(currencyKey, (values, schema) => {
+                const [currency] = values as [Currency | undefined];
+                return currency?.min
+                  ? schema.min(currency.min, "less than min")
+                  : schema;
+              })
+        ),
+      })
+    ),
+  });
+
+  const { field: frequency } = useController<FV, "frequency">({
+    control: control,
+    name: "frequency",
+  });
+
+  const { field: currency } = useController<FV, "currency">({
+    control: control,
+    name: "currency",
+  });
+
+  const { field: program } = useController<FV, "program">({
+    control: control,
+    name: "program",
+  });
+
+  const onIncrement: OnIncrement = (inc) => {
+    const amntNum = Number(getValues("amount"));
+    if (Number.isNaN(amntNum)) return trigger("amount");
+    setValue("amount", `${inc + amntNum}`);
+  };
+
+  return {
+    frequency,
+    currency,
+    program,
+    onIncrement,
+    register,
+    handleSubmit,
+    errors,
+  };
+}

--- a/src/components/donation/Steps/common/constants.ts
+++ b/src/components/donation/Steps/common/constants.ts
@@ -23,7 +23,9 @@ export const initTokenOption: TokenWithAmount = {
   amount: "",
 };
 
-export const usdOption: DetailedCurrency = { code: "usd", min: 1, rate: 1 };
+export const USD_CODE = "usd";
+
+export const usdOption: DetailedCurrency = { code: USD_CODE, min: 1, rate: 1 };
 
 export const initDetails = (
   methodId: DonateMethodId,

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -1,9 +1,11 @@
-import { ErrorMessage } from "@hookform/error-message";
 import { unpack } from "helpers";
+import type React from "react";
 import {
+  type ForwardedRef,
   type HTMLInputTypeAttribute,
   type ReactNode,
   createElement,
+  forwardRef,
 } from "react";
 import {
   type FieldValues,
@@ -18,52 +20,47 @@ const textarea = "textarea" as const;
 type TextArea = typeof textarea;
 type InputType = HTMLInputTypeAttribute | TextArea;
 
-type FieldProps<T extends FieldValues, K extends InputType> = Omit<
-  K extends TextArea
+type Props<T extends InputType> = Omit<
+  T extends TextArea
     ? React.TextareaHTMLAttributes<HTMLTextAreaElement>
     : React.InputHTMLAttributes<HTMLInputElement>,
-  "autoComplete" | "className" | "name" | "id" | "spellCheck" | "type"
+  "autoComplete" | "className" | "id" | "spellCheck" | "type"
 > & {
-  name: Path<T>;
   classes?: Classes | string;
   tooltip?: ReactNode;
   label: string;
-  type?: K;
+  type?: T;
 };
 
-export function Field<T extends FieldValues, K extends InputType = InputType>({
-  type = "text" as K,
-  label,
-  name,
-  classes,
-  tooltip,
-  required,
-  disabled,
-  ...props
-}: FieldProps<T, K>) {
-  const {
-    register,
-    formState: { errors, isSubmitting },
-  } = useFormContext();
-
+function _Field<T extends InputType = InputType>(
+  {
+    type = "text" as T,
+    label,
+    classes,
+    tooltip,
+    required, //extract from props to disable native validation
+    error,
+    ...props
+  }: Props<T> & { error?: string },
+  ref: ForwardedRef<HTMLInputElement | HTMLTextAreaElement>
+) {
   const style = unpack(classes);
 
-  const id = "__" + String(name);
+  const id = "__" + String(props.name);
 
   return (
-    <div className={style.container + " field"} aria-required={required}>
+    <div className={style.container + " field"}>
       <Label className={style.label} required={required} htmlFor={id}>
         {label}
       </Label>
 
       {createElement(type === textarea ? textarea : "input", {
+        ref,
         ...props,
-        ...register(name, { valueAsNumber: type === "number" }),
         ...(type === textarea ? {} : { type }),
         id,
-        "aria-invalid": !!get(errors, name)?.message,
-        disabled: isSubmitting || disabled,
-        "aria-disabled": isSubmitting || disabled,
+        "aria-invalid": !!error,
+        "aria-disabled": props.disabled,
         className: style.input,
         autoComplete: "off",
         spellCheck: false,
@@ -76,22 +73,38 @@ export function Field<T extends FieldValues, K extends InputType = InputType>({
           ) : (
             tooltip
           )}{" "}
-          <ErrorMessage
-            errors={errors}
-            name={name}
-            as="span"
-            className="text-red dark:text-red-l2 text-xs before:content-['('] before:mr-0.5 after:content-[')'] after:ml-0.5 empty:before:hidden empty:after:hidden"
-          />
+          <span className="empty:hidden text-red dark:text-red-l2 text-xs before:content-['('] before:mr-0.5 after:content-[')'] after:ml-0.5 empty:before:hidden empty:after:hidden">
+            {error}
+          </span>
         </p>
       )) || (
-        <ErrorMessage
-          data-error
-          errors={errors}
-          name={name}
-          as="span"
-          className={style.error}
-        />
+        <span data-error className={style.error + " empty:hidden"}>
+          {error}
+        </span>
       )}
     </div>
+  );
+}
+
+export const NativeField = forwardRef(_Field) as typeof _Field;
+
+export function Field<T extends FieldValues, K extends InputType = InputType>({
+  name,
+  disabled,
+  type,
+  ...rest
+}: Omit<Props<K>, "name"> & { name: Path<T> }) {
+  const {
+    register,
+    formState: { errors, isSubmitting },
+  } = useFormContext();
+
+  return (
+    <NativeField
+      {...register(name)}
+      {...rest}
+      disabled={disabled || isSubmitting}
+      error={get(errors, name)?.message}
+    />
   );
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -38,3 +38,12 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: vi.fn(),
   }),
 });
+
+/** used by @headlessui/react */
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserverMock;


### PR DESCRIPTION
Towards BG-1425
Towards BG-1418
## Explanation of the solution
* test stripe form interaction from loading, validation, to submission

### Others 
Towards BG-1171
- [x] extract `NativeField` out of field and use in stripe form. make sure `<Field/>` consumer behavior is unaltered -ok
* stripe form no longer is wrapped by hookform context
* incrementing invalid input now focuses the input field 

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
