### PR TITLE
Node proxies

### DIFF
--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/tokenBalance.ts
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/tokenBalance.ts
@@ -13,7 +13,7 @@ export const tokenBalance = async (
   chainID: SupportedChainId,
   holder: string
 ): Promise<number> => {
-  const { lcd, rpc } = chains[chainID];
+  const { nodeUrl } = chains[chainID];
 
   switch (type) {
     case "juno-native":
@@ -23,19 +23,19 @@ export const tokenBalance = async (
     case "kujira-native":
     case "ibc": {
       return fetch(
-        lcd +
+        nodeUrl +
           `/cosmos/bank/v1beta1/balances/${holder}/by_denom?denom=${token_id}`
       )
         .then<CosmosBalance>((res) => res.json())
         .then((d) => condenseToNum(d.balance.amount, decimals));
     }
     case "cw20":
-      return cw20Balance(token_id, holder, lcd).then((bal) =>
+      return cw20Balance(token_id, holder, nodeUrl).then((bal) =>
         condenseToNum(bal, decimals)
       );
 
     case "erc20":
-      return erc20Balance(token_id, holder, rpc).then((bal) =>
+      return erc20Balance(token_id, holder, nodeUrl).then((bal) =>
         condenseToNum(bal, decimals)
       );
 
@@ -43,7 +43,7 @@ export const tokenBalance = async (
       return request({
         method: "eth_getBalance",
         params: [holder, "latest"],
-        rpcURL: rpc,
+        rpcURL: nodeUrl,
       }).then((hex) => condenseToNum(hex, decimals));
     }
     default: {

--- a/src/constants/chainOptions.ts
+++ b/src/constants/chainOptions.ts
@@ -1,41 +1,42 @@
-import type { WalletControllerChainOptions } from "@terra-money/wallet-provider";
+import type {
+  NetworkInfo,
+  WalletControllerChainOptions,
+} from "@terra-money/wallet-provider";
 import { IS_TEST } from "./env";
+import { APIs } from "./urls";
 
+const baseProxyURL = APIs.nodeProxy;
 /**
  * from: https://assets.terra.money/chains.json
  * FUTURE: convert to top level await
  * export const chains:Type = await fetch('https://assets.terra.money/chains.json').then(r => r.json())
  */
-const chains = {
+
+/** LCD endpoints provided here are used by ` terra.useWallet().post` */
+const chains: Record<string, NetworkInfo> = {
   mainnet: {
     name: "mainnet",
     chainID: "phoenix-1",
-    lcd: "https://phoenix-lcd.terra.dev",
-    api: "https://phoenix-api.terra.dev",
-    hive: "https://phoenix-hive.terra.dev/graphql",
+    lcd: baseProxyURL + "/terra/lcd/main",
     walletconnectID: 1,
   },
   classic: {
     name: "classic",
     chainID: "columbus-5",
-    lcd: "https://terra-classic-lcd.publicnode.com",
-    api: "https://terra-classic-public-api.publicnode.com",
-    mantle: "https://columbus-mantle.terra.dev",
+    lcd: baseProxyURL + "/terra/lcd/classic",
     walletconnectID: 2,
   },
   testnet: {
     name: "testnet",
     chainID: "pisco-1",
-    lcd: "https://pisco-lcd.terra.dev",
-    api: "https://pisco-api.terra.dev",
-    hive: "https://pisco-hive.terra.dev/graphql",
+    lcd: baseProxyURL + "/terra/lcd/test",
     walletconnectID: 0,
   },
   localterra: {
     name: "localterra",
     chainID: "localterra",
     lcd: "http://localhost:1317",
-    mantle: "http://localhost:1337",
+    walletconnectID: 0,
   },
 };
 

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -171,7 +171,7 @@ export const osmosis: SupportedChain = {
   coingeckoPlatformId: "osmosis",
   brand: "osmosis",
   name: "Osmosis",
-  nodeUrl: "https://lcd.osmosis.zone",
+  nodeUrl: baseProxyURL + "/osmosis",
   blockExplorer: "https://www.mintscan.io/osmosis",
   nativeToken: {
     id: "uosmo",
@@ -359,7 +359,7 @@ export const osmosisTestnet: SupportedChain = {
   coingeckoPlatformId: "osmosis",
   brand: "osmosis",
   name: "Osmosis Testnet",
-  nodeUrl: "https://lcd.testnet.osmosis.zone",
+  nodeUrl: baseProxyURL + "/osmosis-test",
   blockExplorer: "https://www.mintscan.io/osmosis",
   nativeToken: {
     id: "uosmo",

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -7,8 +7,9 @@ import type {
   UnsupportedChains,
 } from "types/chain";
 import { IS_TEST } from "./env";
+import { APIs } from "./urls";
 
-const baseProxyURL = "https://59vigz9r91.execute-api.us-east-1.amazonaws.com";
+const baseProxyURL = APIs.nodeProxy;
 
 //mainnets
 export const polygon: SupportedChain = {
@@ -197,7 +198,7 @@ export const terraMainnet: SupportedChain = {
   coingeckoPlatformId: "terra",
   brand: "terra",
   name: "Terra",
-  lcd: "https://phoenix-lcd.terra.dev",
+  lcd: baseProxyURL + "/terra/lcd/main",
   rpc: "",
   blockExplorer: "https://finder.terra.money/mainnet",
   nativeToken: {
@@ -324,7 +325,7 @@ export const terraTestnet: SupportedChain = {
   coingeckoPlatformId: terraMainnet.coingeckoPlatformId,
   brand: "terra",
   name: "Terra Pisco",
-  lcd: "https://pisco-lcd.terra.dev",
+  lcd: baseProxyURL + "/terra/lcd/test",
   rpc: "",
   blockExplorer: "https://finder.terra.money/testnet",
   nativeToken: {

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -71,9 +71,9 @@ export const optimism: SupportedChain = {
   coingeckoPlatformId: "optimistic-ethereum",
   brand: "optimism",
   name: "Optimism",
-  rpc: "https://mainnet.optimism.io",
+  rpc: baseProxyURL + "/optimism",
   lcd: "",
-  blockExplorer: baseProxyURL + "/optimism",
+  blockExplorer: "https://optimistic.etherscan.io",
   nativeToken: {
     id: "10",
     symbol: "ETH",
@@ -270,7 +270,7 @@ export const optimismSepolia: SupportedChain = {
   coingeckoPlatformId: optimism.coingeckoPlatformId,
   brand: "optimism",
   name: "Optimism Sepolia",
-  rpc: baseProxyURL + "/optimism-sepolia",
+  rpc: baseProxyURL + "/optimism-test",
   lcd: "",
   blockExplorer: "https://sepolia-optimistic.etherscan.io",
   nativeToken: {

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -73,7 +73,7 @@ export const optimism: SupportedChain = {
   name: "Optimism",
   rpc: "https://mainnet.optimism.io",
   lcd: "",
-  blockExplorer: "https://optimistic.etherscan.io",
+  blockExplorer: baseProxyURL + "/optimism",
   nativeToken: {
     id: "10",
     symbol: "ETH",
@@ -270,7 +270,7 @@ export const optimismSepolia: SupportedChain = {
   coingeckoPlatformId: optimism.coingeckoPlatformId,
   brand: "optimism",
   name: "Optimism Sepolia",
-  rpc: "https://sepolia.optimism.io",
+  rpc: baseProxyURL + "/optimism-sepolia",
   lcd: "",
   blockExplorer: "https://sepolia-optimistic.etherscan.io",
   nativeToken: {

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -89,7 +89,7 @@ export const base: SupportedChain = {
   coingeckoPlatformId: "base",
   brand: "base",
   name: "Base",
-  rpc: "https://mainnet.base.org",
+  rpc: baseProxyURL + "/base",
   lcd: "",
   blockExplorer: "https://mainnet.basescan.org",
   nativeToken: {
@@ -288,7 +288,7 @@ export const baseSepolia: SupportedChain = {
   coingeckoPlatformId: base.coingeckoPlatformId,
   brand: "base",
   name: "Base Sepolia",
-  rpc: "https://sepolia.base.org",
+  rpc: baseProxyURL + "/base-test",
   lcd: "",
   blockExplorer: "https://sepolia.basescan.org",
   nativeToken: {

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -154,7 +154,7 @@ export const kujira: SupportedChain = {
   coingeckoPlatformId: "kujira",
   brand: "kujira",
   name: "Kujira",
-  nodeUrl: "https://kujira-rpc.publicnode.com",
+  nodeUrl: baseProxyURL + "/kujira",
   blockExplorer: "https://finder.kujira.network/kaiyo-1",
   nativeToken: {
     id: "ukuji",
@@ -342,7 +342,7 @@ export const kujiraTestnet: SupportedChain = {
   coingeckoPlatformId: kujira.coingeckoPlatformId,
   brand: "kujira",
   name: "Kujira Testnet",
-  nodeUrl: "https://test-lcd-kujira.mintthemoon.xyz",
+  nodeUrl: baseProxyURL + "/kujira-test",
   blockExplorer: "https://finder.kujira.network/harpoon-4",
   nativeToken: {
     id: "ukuji",

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -18,8 +18,7 @@ export const polygon: SupportedChain = {
   coingeckoPlatformId: "polygon-pos",
   brand: "polygon",
   name: "Polygon",
-  rpc: baseProxyURL + "/polygon",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/polygon",
   blockExplorer: "https://polygonscan.com",
   nativeToken: {
     id: "137",
@@ -36,8 +35,7 @@ export const ethereum: SupportedChain = {
   coingeckoPlatformId: "ethereum",
   brand: "ethereum",
   name: "Ethereum",
-  rpc: baseProxyURL + "/ethereum",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/ethereum",
   blockExplorer: "https://etherscan.io",
   nativeToken: {
     id: "1",
@@ -54,8 +52,7 @@ export const arbitrum: SupportedChain = {
   coingeckoPlatformId: "arbitrum-one",
   brand: "arbitrum",
   name: "Arbitrum One",
-  rpc: baseProxyURL + "/arbitrum",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/arbitrum",
   blockExplorer: "https://arbiscan.io",
   nativeToken: {
     id: "42161",
@@ -72,8 +69,7 @@ export const optimism: SupportedChain = {
   coingeckoPlatformId: "optimistic-ethereum",
   brand: "optimism",
   name: "Optimism",
-  rpc: baseProxyURL + "/optimism",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/optimism",
   blockExplorer: "https://optimistic.etherscan.io",
   nativeToken: {
     id: "10",
@@ -90,8 +86,7 @@ export const base: SupportedChain = {
   coingeckoPlatformId: "base",
   brand: "base",
   name: "Base",
-  rpc: baseProxyURL + "/base",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/base",
   blockExplorer: "https://mainnet.basescan.org",
   nativeToken: {
     id: "8453",
@@ -108,8 +103,7 @@ export const binance: SupportedChain = {
   coingeckoPlatformId: "binance-smart-chain",
   brand: "binance",
   name: "Binance",
-  rpc: baseProxyURL + "/bsc",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/bsc",
   blockExplorer: "https://bscscan.com",
   nativeToken: {
     id: "56",
@@ -126,8 +120,7 @@ export const juno: SupportedChain = {
   coingeckoPlatformId: "juno",
   brand: "juno",
   name: "Juno",
-  lcd: "https://juno-api.polkachu.com",
-  rpc: "https://juno-rpc.polkachu.com",
+  nodeUrl: baseProxyURL + "/juno",
   blockExplorer: "https://www.mintscan.io/juno",
   nativeToken: {
     id: "ujuno",
@@ -144,8 +137,7 @@ export const stargaze: SupportedChain = {
   coingeckoPlatformId: "stargaze",
   brand: "stargaze",
   name: "Stargaze",
-  lcd: "https://stargaze-rest.publicnode.com",
-  rpc: "https://stargaze-rpc.publicnode.com:443",
+  nodeUrl: baseProxyURL + "/stargaze",
   blockExplorer: "https://www.mintscan.io/stargaze",
   nativeToken: {
     id: "ustars",
@@ -162,8 +154,7 @@ export const kujira: SupportedChain = {
   coingeckoPlatformId: "kujira",
   brand: "kujira",
   name: "Kujira",
-  lcd: "https://kujira-rpc.publicnode.com",
-  rpc: "https://kujira-rpc.publicnode.com:443",
+  nodeUrl: "https://kujira-rpc.publicnode.com",
   blockExplorer: "https://finder.kujira.network/kaiyo-1",
   nativeToken: {
     id: "ukuji",
@@ -180,8 +171,7 @@ export const osmosis: SupportedChain = {
   coingeckoPlatformId: "osmosis",
   brand: "osmosis",
   name: "Osmosis",
-  lcd: "https://lcd.osmosis.zone",
-  rpc: "https://rpc.osmosis.zone:443",
+  nodeUrl: "https://lcd.osmosis.zone",
   blockExplorer: "https://www.mintscan.io/osmosis",
   nativeToken: {
     id: "uosmo",
@@ -198,8 +188,7 @@ export const terraMainnet: SupportedChain = {
   coingeckoPlatformId: "terra",
   brand: "terra",
   name: "Terra",
-  lcd: baseProxyURL + "/terra/lcd/main",
-  rpc: "",
+  nodeUrl: baseProxyURL + "/terra/lcd/main",
   blockExplorer: "https://finder.terra.money/mainnet",
   nativeToken: {
     id: "uluna",
@@ -217,8 +206,7 @@ export const polygonAmoy: SupportedChain = {
   brand: "polygonAmoy",
   coingeckoPlatformId: polygon.coingeckoPlatformId,
   name: "Polygon Amoy Testnet",
-  rpc: baseProxyURL + "/polygonAmoy",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/polygonAmoy",
   blockExplorer: "https://amoy.polygonscan.com",
   nativeToken: {
     id: "80002",
@@ -235,8 +223,7 @@ export const sepolia: SupportedChain = {
   coingeckoPlatformId: ethereum.coingeckoPlatformId,
   brand: "sepolia",
   name: "Ethereum Sepolia",
-  rpc: baseProxyURL + "/sepolia",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/sepolia",
   blockExplorer: "https://sepolia.etherscan.io",
   nativeToken: {
     id: "11155111",
@@ -253,8 +240,7 @@ export const arbitrumSepolia: SupportedChain = {
   coingeckoPlatformId: arbitrum.coingeckoPlatformId,
   brand: "arbitrum",
   name: "Arbitrum Sepolia",
-  rpc: baseProxyURL + "/arbitrum-test",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/arbitrum-test",
   blockExplorer: "https://sepolia.arbiscan.io",
   nativeToken: {
     id: "421614",
@@ -271,8 +257,7 @@ export const optimismSepolia: SupportedChain = {
   coingeckoPlatformId: optimism.coingeckoPlatformId,
   brand: "optimism",
   name: "Optimism Sepolia",
-  rpc: baseProxyURL + "/optimism-test",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/optimism-test",
   blockExplorer: "https://sepolia-optimistic.etherscan.io",
   nativeToken: {
     id: "11155420",
@@ -289,8 +274,7 @@ export const baseSepolia: SupportedChain = {
   coingeckoPlatformId: base.coingeckoPlatformId,
   brand: "base",
   name: "Base Sepolia",
-  rpc: baseProxyURL + "/base-test",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/base-test",
   blockExplorer: "https://sepolia.basescan.org",
   nativeToken: {
     id: "84532",
@@ -307,8 +291,7 @@ export const binanceTestnet: SupportedChain = {
   coingeckoPlatformId: binance.coingeckoPlatformId,
   brand: "binance",
   name: "Binance Testnet",
-  rpc: baseProxyURL + "/bsc-test",
-  lcd: "",
+  nodeUrl: baseProxyURL + "/bsc-test",
   blockExplorer: "https://testnet.bscscan.com",
   nativeToken: {
     id: "97",
@@ -325,8 +308,7 @@ export const terraTestnet: SupportedChain = {
   coingeckoPlatformId: terraMainnet.coingeckoPlatformId,
   brand: "terra",
   name: "Terra Pisco",
-  lcd: baseProxyURL + "/terra/lcd/test",
-  rpc: "",
+  nodeUrl: baseProxyURL + "/terra/lcd/test",
   blockExplorer: "https://finder.terra.money/testnet",
   nativeToken: {
     id: "uluna",
@@ -343,8 +325,7 @@ export const stargazeTestnet: SupportedChain = {
   brand: "stargaze",
   coingeckoPlatformId: stargaze.coingeckoPlatformId,
   name: "Stargaze Testnet",
-  lcd: "https://rest.elgafar-1.stargaze-apis.com",
-  rpc: "https://rpc.elgafar-1.stargaze-apis.com",
+  nodeUrl: baseProxyURL + "/stargaze-test",
   blockExplorer: "https://www.mintscan.io/stargaze",
   nativeToken: {
     id: "ustars",
@@ -361,8 +342,7 @@ export const kujiraTestnet: SupportedChain = {
   coingeckoPlatformId: kujira.coingeckoPlatformId,
   brand: "kujira",
   name: "Kujira Testnet",
-  lcd: "https://test-lcd-kujira.mintthemoon.xyz",
-  rpc: "https://rpc-kujira.mintthemoon.xyz",
+  nodeUrl: "https://test-lcd-kujira.mintthemoon.xyz",
   blockExplorer: "https://finder.kujira.network/harpoon-4",
   nativeToken: {
     id: "ukuji",
@@ -379,8 +359,7 @@ export const osmosisTestnet: SupportedChain = {
   coingeckoPlatformId: "osmosis",
   brand: "osmosis",
   name: "Osmosis Testnet",
-  lcd: "https://lcd.testnet.osmosis.zone",
-  rpc: "https://rpc.testnet.osmosis.zone",
+  nodeUrl: "https://lcd.testnet.osmosis.zone",
   blockExplorer: "https://www.mintscan.io/osmosis",
   nativeToken: {
     id: "uosmo",

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -188,7 +188,7 @@ export const terraMainnet: SupportedChain = {
   coingeckoPlatformId: "terra",
   brand: "terra",
   name: "Terra",
-  nodeUrl: baseProxyURL + "/terra/lcd/main",
+  nodeUrl: baseProxyURL + "/terra",
   blockExplorer: "https://finder.terra.money/mainnet",
   nativeToken: {
     id: "uluna",
@@ -308,7 +308,7 @@ export const terraTestnet: SupportedChain = {
   coingeckoPlatformId: terraMainnet.coingeckoPlatformId,
   brand: "terra",
   name: "Terra Pisco",
-  nodeUrl: baseProxyURL + "/terra/lcd/test",
+  nodeUrl: baseProxyURL + "/terra-test",
   blockExplorer: "https://finder.terra.money/testnet",
   nativeToken: {
     id: "uluna",

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -3,7 +3,8 @@ import { BASE_URL, ENVIRONMENT } from "./env";
 export const APIs = {
   aws: "https://ap-api.better.giving",
   apes: `https://apes-api.better.giving/${ENVIRONMENT}`,
-  wordpress: `https://wp-blog.better.giving/wp-json/wp/v2`,
+  wordpress: "https://wp-blog.better.giving/wp-json/wp/v2",
+  nodeProxy: "https://59vigz9r91.execute-api.us-east-1.amazonaws.com",
 };
 
 export const LITEPAPER = `${BASE_URL}/docs/litepaper-introduction/`;

--- a/src/contexts/WalletContext/useInjectedProvider.ts
+++ b/src/contexts/WalletContext/useInjectedProvider.ts
@@ -87,7 +87,7 @@ export default function useInjectedWallet(
                     symbol: chain.nativeToken.symbol,
                     decimals: chain.nativeToken.decimals,
                   },
-                  rpcUrls: [chain.rpc],
+                  rpcUrls: [chain.nodeUrl],
                   blockExplorerUrls: [chain.blockExplorer],
                 },
               ],

--- a/src/helpers/tx/estimateTx/estimateCosmosFee.ts
+++ b/src/helpers/tx/estimateTx/estimateCosmosFee.ts
@@ -28,7 +28,7 @@ export async function estimateCosmosFee(
 ): Promise<EstimateResult> {
   const chain = chains[chainID];
   const { account } = await fetch(
-    chain.lcd + `/cosmos/auth/v1beta1/accounts/${sender}`
+    chain.nodeUrl + `/cosmos/auth/v1beta1/accounts/${sender}`
   ).then<{ account: JSONAccount }>((res) => res.json());
 
   const pub = PubKey.fromJSON({ key: account.pub_key.key });
@@ -70,7 +70,7 @@ export async function estimateCosmosFee(
     signatures: [new Uint8Array(0)],
   };
 
-  const res = await fetch(chain.lcd + "/cosmos/tx/v1beta1/simulate", {
+  const res = await fetch(chain.nodeUrl + "/cosmos/tx/v1beta1/simulate", {
     method: "POST",
     body: JSON.stringify({
       tx_bytes: base64FromU8a(TxRaw.encode(simTx).finish()),

--- a/src/helpers/tx/estimateTx/estimateEVMfee.ts
+++ b/src/helpers/tx/estimateTx/estimateEVMfee.ts
@@ -12,21 +12,21 @@ export async function estimateEVMFee(
   sender: string,
   tx: SimulTx
 ): Promise<EstimateResult> {
-  const { rpc, nativeToken } = chains[chainID];
+  const { nodeUrl, nativeToken } = chains[chainID];
   const [nonce, gas, gasPrice] = await Promise.all([
     request({
       method: EIPMethods.eth_getTransactionCount,
       params: [sender, "latest"],
-      rpcURL: rpc,
+      rpcURL: nodeUrl,
     }),
     request({
       method: EIPMethods.eth_estimateGas,
       params: [tx],
-      rpcURL: rpc,
+      rpcURL: nodeUrl,
     }),
     request({
       method: EIPMethods.eth_gasPrice,
-      rpcURL: rpc,
+      rpcURL: nodeUrl,
     }),
   ]);
 

--- a/src/helpers/tx/estimateTx/estimateTerraFee.ts
+++ b/src/helpers/tx/estimateTx/estimateTerraFee.ts
@@ -9,10 +9,10 @@ export default async function estimateTerraFee(
   sender: string,
   msgs: Msg[]
 ): Promise<EstimateResult> {
-  const { lcd, nativeToken } = chains[chainID];
+  const { nodeUrl, nativeToken } = chains[chainID];
   const client = new LCDClient({
     chainID,
-    URL: lcd,
+    URL: nodeUrl,
     gasAdjustment: 1.6,
     //https://station-assets.terra.money/chains.json
     gasPrices: [new Coin("uluna", 0.015)],

--- a/src/helpers/tx/sendTx/sendCosmosTx.ts
+++ b/src/helpers/tx/sendTx/sendCosmosTx.ts
@@ -18,7 +18,7 @@ export async function sendCosmosTx(
   doc: SignDoc,
   sign: Keplr["signDirect"]
 ): Promise<TxResult> {
-  const { lcd } = chains[chainID];
+  const { nodeUrl } = chains[chainID];
   const { signature, signed } = await sign(chainID, sender, doc);
 
   const tx: TxRaw = {
@@ -27,7 +27,7 @@ export async function sendCosmosTx(
     signatures: [u8aFromBase64(signature.signature)],
   };
 
-  const result = await fetch(lcd + "/cosmos/tx/v1beta1/txs", {
+  const result = await fetch(nodeUrl + "/cosmos/tx/v1beta1/txs", {
     method: "POST",
     body: JSON.stringify({
       tx_bytes: base64FromU8a(TxRaw.encode(tx).finish()),
@@ -48,7 +48,7 @@ export async function sendCosmosTx(
   }
 
   const receipt = await _receipt(
-    lcd + `/cosmos/tx/v1beta1/txs/${txhash}`,
+    nodeUrl + `/cosmos/tx/v1beta1/txs/${txhash}`,
     10,
     txhash,
     chainID

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -69,8 +69,8 @@ export type SupportedChain = {
   coingeckoPlatformId: string;
   brand: string; //
   name: string;
-  rpc: string;
-  lcd: string;
+  /** evm: rpc, cosmos: lcd */
+  nodeUrl: string;
   blockExplorer: string;
   nativeToken: {
     id: ChainID | NativeAtomicUnit | IBCDenom;


### PR DESCRIPTION
Towards BG-1435
## Explanation of the solution
* proxy remaining endpoints (proxied url can now be freely changed in AWS/LCD/RPC proxies API)
* renamed `lcd,rpc` -> `nodeUrl` as evms only use `rpc` while cosmos uses `lcd`

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
