### PR TITLE
Add 'ukGiftAid' field in fiat donation payload

### DIFF
--- a/src/components/donation/Steps/common/constants.ts
+++ b/src/components/donation/Steps/common/constants.ts
@@ -93,5 +93,6 @@ export const toDonor = (fv: FormDonor): Donor => {
           country: "United Kingdom",
         }
       : undefined,
+    ukGiftAid: fv.ukTaxResident,
   };
 };

--- a/src/types/aws/apes/donation.ts
+++ b/src/types/aws/apes/donation.ts
@@ -19,6 +19,7 @@ export type Donor = {
   firstName: string;
   lastName: string;
   address?: DonorAddress;
+  ukGiftAid?: boolean;
 };
 
 export type GuestDonor = {


### PR DESCRIPTION
Related to BG-1428

## Explanation of the solution
Adds a new attribute for donation records, `ukGiftAid` which will signify if a fiat donation is eligible for UK Gift Aid.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- create crypto donation and verify that `ukGiftAid` is not included in payload
- create one-time donations
  - check UK tax payer for one and verify that `ukGiftAid === true`
  - do not check UK tax payer for the other and verify that `ukGiftAid === false`

## UI changes for review
No major UI changes.