### PR TITLE
BG-1437: Tribute notif UI

### DIFF
--- a/src/components/donation/Steps/Submit/Crypto/DirectMode.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/DirectMode.tsx
@@ -25,6 +25,7 @@ export default function DirectMode({ donation, classes = "" }: Props) {
     liquidSplitPct,
     donor: fvDonor,
     feeAllowance,
+    honorary,
   } = donation;
 
   const { data: intent, ...intentState } = useCreateCryptoIntentQuery({
@@ -39,6 +40,13 @@ export default function DirectMode({ donation, classes = "" }: Props) {
     endowmentId: init.recipient.id,
     source: init.config ? "bg-widget" : "bg-marketplace",
     donor: toDonor(fvDonor),
+    ...(honorary.honoraryFullName && {
+      inHonorOf: honorary.honoraryFullName,
+      tributeNotif: honorary.withTributeNotif
+        ? honorary.tributeNotif
+        : undefined,
+    }),
+    ...(details.program.value && { programId: details.program.value }),
   });
 
   return (

--- a/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/TxSubmit/TxSubmit.tsx
@@ -73,6 +73,9 @@ export default function TxSubmit({ wallet, donation, classes = "" }: Props) {
       donor: toDonor(fvDonor),
       ...(honorary.honoraryFullName && {
         inHonorOf: honorary.honoraryFullName,
+        tributeNotif: honorary.withTributeNotif
+          ? honorary.tributeNotif
+          : undefined,
       }),
       ...(details.program.value && { programId: details.program.value }),
     },

--- a/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
@@ -44,7 +44,12 @@ export default function StripeCheckout(props: StripeCheckoutStep) {
     splitLiq: liquidSplitPct,
     donor: toDonor(fvDonor),
     source: init.source,
-    ...(honorary.honoraryFullName && { inHonorOf: honorary.honoraryFullName }),
+    ...(honorary.honoraryFullName && {
+      inHonorOf: honorary.honoraryFullName,
+      tributeNotif: honorary.withTributeNotif
+        ? honorary.tributeNotif
+        : undefined,
+    }),
     ...(details.program.value && { programId: details.program.value }),
   });
 

--- a/src/components/donation/Steps/Summary/Summary.tsx
+++ b/src/components/donation/Steps/Summary/Summary.tsx
@@ -4,7 +4,7 @@ import { useDonationState } from "../Context";
 import { currency } from "../common/Currency";
 import SummaryContainer from "../common/Summary";
 import { token } from "../common/Token";
-import { initDonorTitleOption } from "../common/constants";
+import { initDonorTitleOption, initTributeNotif } from "../common/constants";
 import type { SummaryStep } from "../types";
 import SummaryForm from "./SummaryForm";
 
@@ -73,11 +73,7 @@ export default function Summary(props: SummaryStep) {
             withHonorary: false,
             honoraryFullName: "",
             withTributeNotif: false,
-            tributeNotif: {
-              toEmail: "",
-              toFullName: "",
-              fromMsg: "",
-            },
+            tributeNotif: initTributeNotif,
           }
         }
         onSubmit={({

--- a/src/components/donation/Steps/Summary/Summary.tsx
+++ b/src/components/donation/Steps/Summary/Summary.tsx
@@ -72,14 +72,31 @@ export default function Summary(props: SummaryStep) {
           honorary || {
             withHonorary: false,
             honoraryFullName: "",
+            withTributeNotif: false,
+            tributeNotif: {
+              toEmail: "",
+              toFullName: "",
+              fromMsg: "",
+            },
           }
         }
-        onSubmit={({ withHonorary, honoraryFullName, ...donor }) =>
+        onSubmit={({
+          withHonorary,
+          honoraryFullName,
+          withTributeNotif,
+          tributeNotif,
+          ...donor
+        }) =>
           setState({
             ...props,
             step: "submit",
             donor,
-            honorary: { withHonorary, honoraryFullName },
+            honorary: {
+              withHonorary,
+              honoraryFullName,
+              withTributeNotif,
+              tributeNotif,
+            },
           })
         }
         classes="mt-6"

--- a/src/components/donation/Steps/Summary/SummaryForm.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.tsx
@@ -4,7 +4,7 @@ import { CheckField, Field, Form, Label } from "components/form";
 import { useForm } from "react-hook-form";
 import { schema } from "schemas/shape";
 import type { DonateMethodId } from "types/lists";
-import { string } from "yup";
+import { mixed, object, string } from "yup";
 import ContinueBtn from "../common/ContinueBtn";
 import { initDonorTitleOption } from "../common/constants";
 import type { FormDonor, Honorary, Mode } from "../types";
@@ -21,6 +21,7 @@ type Props = {
 };
 const ukTaxResidentKey: keyof FV = "ukTaxResident";
 const withHonoraryKey: keyof FV = "withHonorary";
+const withTributeNotifKey: keyof FV = "withTributeNotif";
 const titleOptions: FV["title"][] = [
   initDonorTitleOption,
   { label: "Mr", value: "Mr" },
@@ -58,6 +59,16 @@ export default function SummaryForm({
           const [withHonorary] = values as [boolean];
           return withHonorary ? schema.required("required") : schema;
         }),
+        tributeNotif: mixed().when(withTributeNotifKey, (values, obj) => {
+          const [withTributeNotif] = values as [boolean];
+          return !withTributeNotif
+            ? obj.optional()
+            : schema<FV["tributeNotif"]>({
+                toFullName: string().required("required"),
+                toEmail: string().required("required").email("invalid email"),
+                fromMsg: string().max(250, "must be less than 250 characters"),
+              });
+        }),
       })
     ),
   });
@@ -71,15 +82,15 @@ export default function SummaryForm({
     <Form
       methods={methods}
       onSubmit={handleSubmit(onSubmit)}
-      className={`grid grid-cols-2 gap-4 ${classes}`}
+      className={`grid grid-cols-2 gap-x-4 ${classes}`}
     >
-      <Label className="-mb-2 text-base font-medium">Title</Label>
+      <Label className="mb-2 text-base font-medium">Title</Label>
       <Selector<FV, "title", string>
         name="title"
         options={titleOptions}
         classes={{
           button: "field-input-donate",
-          container: "col-span-full",
+          container: "col-span-full mb-4",
         }}
       />
       <Field<FV>
@@ -96,7 +107,7 @@ export default function SummaryForm({
         name="lastName"
         label=""
         placeholder="Last Name"
-        classes={{ container: "field-donate" }}
+        classes={{ container: "field-donate mb-4" }}
       />
       <Field<FV>
         name="email"
@@ -104,40 +115,39 @@ export default function SummaryForm({
         placeholder="Email address"
         classes={{
           label: "font-medium text-base",
-          container: "col-span-full field-donate",
+          container: "col-span-full field-donate mb-4",
         }}
         required
       />
       {method !== "crypto" && (
-        <CheckField<FV> name="ukTaxResident" classes="col-span-full mt-4">
+        <CheckField<FV> name="ukTaxResident" classes="col-span-full">
           UK Taxpayer? Supercharge your donation with gift aid
         </CheckField>
       )}
       {ukTaxResident && (
-        <>
+        <div className="grid col-span-full gap-y-4 mt-2 mb-6">
           <Field<FV>
             name="streetAddress"
             label="House number"
             placeholder="e.g. 100 Better Giving Rd"
-            classes={{ container: "col-span-full field-donate" }}
+            classes={{ container: "field-donate" }}
             required
           />
           <Field<FV>
             name="zipCode"
             label="Postal code"
             placeholder="e.g. BG21 1BG"
-            classes={{ container: "col-span-full field-donate" }}
+            classes={{ container: "field-donate" }}
             required
           />
-        </>
+        </div>
       )}
-
       <CheckField<FV> name="withHonorary" classes="col-span-full mt-4">
         Dedicate my donation
       </CheckField>
 
       {withHonorary && (
-        <div className="col-span-full p-4 bg-blue-l5 rounded">
+        <div className="col-span-full p-4 bg-blue-l5 rounded-lg mt-2 shadow-inner">
           <Field<FV>
             name="honoraryFullName"
             label="Honoree's name"
@@ -147,13 +157,13 @@ export default function SummaryForm({
           />
           <CheckField<FV>
             name="withTributeNotif"
-            classes="col-span-full mt-2 text-sm"
+            classes="col-span-full mt-3 text-sm"
           >
             Notify someone about this tribute
           </CheckField>
 
           {withTributeNotif && (
-            <div className="grid gap-y-3 mt-4 rounded p-4 bg-white">
+            <div className="grid gap-y-3 mt-4 rounded-lg p-4 bg-white shadow-inner">
               <Field<FV>
                 name="tributeNotif.toFullName"
                 label="Recipient name"
@@ -164,7 +174,7 @@ export default function SummaryForm({
               <Field<FV>
                 name="tributeNotif.toEmail"
                 label="Email address"
-                placeholder="e.g. Jane Doe"
+                placeholder="e.g. janedoe@better.giving"
                 classes="field-donate [&_label]:text-sm [&_input]:text-sm"
                 required
               />
@@ -173,7 +183,10 @@ export default function SummaryForm({
                 name="tributeNotif.fromMsg"
                 label="Custom message"
                 placeholder="Message to recipient"
-                classes="field-donate [&_label]:text-sm [&_input]:text-sm"
+                classes={{
+                  container: "field-donate [&_label]:text-sm [&_input]:text-sm",
+                  input: "supports-[field-sizing]:[field-sizing:content]",
+                }}
                 required={false}
               />
             </div>

--- a/src/components/donation/Steps/Summary/SummaryForm.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.tsx
@@ -4,7 +4,7 @@ import { CheckField, Field, Form, Label } from "components/form";
 import { useForm } from "react-hook-form";
 import { schema } from "schemas/shape";
 import type { DonateMethodId } from "types/lists";
-import { mixed, object, string } from "yup";
+import { mixed, string } from "yup";
 import ContinueBtn from "../common/ContinueBtn";
 import { initDonorTitleOption } from "../common/constants";
 import type { FormDonor, Honorary, Mode } from "../types";

--- a/src/components/donation/Steps/Summary/SummaryForm.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.tsx
@@ -42,6 +42,7 @@ export default function SummaryForm({
   mode,
   method,
 }: Props) {
+  const CUSTOM_MSG_MAX_LENGTH = 250;
   const methods = useForm<FV>({
     defaultValues: {
       ...donor,
@@ -74,17 +75,25 @@ export default function SummaryForm({
             : schema<FV["tributeNotif"]>({
                 toFullName: string().required("required"),
                 toEmail: string().required("required").email("invalid email"),
-                fromMsg: string().max(250, "must be less than 250 characters"),
+                fromMsg: string().max(
+                  CUSTOM_MSG_MAX_LENGTH,
+                  "must be less than 250 characters"
+                ),
               });
         }),
       })
     ),
   });
 
-  const { handleSubmit, watch } = methods;
+  const {
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = methods;
   const ukTaxResident = watch("ukTaxResident");
   const withHonorary = watch("withHonorary");
   const withTributeNotif = watch("withTributeNotif");
+  const customMsg = watch("tributeNotif.fromMsg");
 
   return (
     <Form
@@ -205,6 +214,12 @@ export default function SummaryForm({
                 }}
                 required={false}
               />
+              <p
+                data-exceed={errors.tributeNotif?.fromMsg?.type === "max"}
+                className="text-xs text-navy-l4 -mt-2 data-[exceed='true']:text-red"
+              >
+                {customMsg.length}/{CUSTOM_MSG_MAX_LENGTH}
+              </p>
             </div>
           )}
         </div>

--- a/src/components/donation/Steps/Summary/SummaryForm.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.tsx
@@ -136,7 +136,7 @@ export default function SummaryForm({
         </CheckField>
       )}
       {method !== "crypto" && (
-        <CheckField<FV> name="ukTaxResident" classes="col-span-full">
+        <CheckField<FV> name="ukTaxResident" classes="col-span-full mt-4">
           UK Taxpayer? Supercharge your donation with gift aid
         </CheckField>
       )}

--- a/src/components/donation/Steps/Summary/SummaryForm.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.tsx
@@ -195,13 +195,13 @@ export default function SummaryForm({
                 required
               />
               <Field<FV, "textarea">
+                rows={2}
                 type="textarea"
                 name="tributeNotif.fromMsg"
                 label="Custom message"
                 placeholder="Message to recipient"
                 classes={{
                   container: "field-donate [&_label]:text-sm [&_input]:text-sm",
-                  input: "supports-[field-sizing]:[field-sizing:content]",
                 }}
                 required={false}
               />

--- a/src/components/donation/Steps/Summary/SummaryForm.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.tsx
@@ -65,6 +65,7 @@ export default function SummaryForm({
   const { handleSubmit, watch } = methods;
   const ukTaxResident = watch("ukTaxResident");
   const withHonorary = watch("withHonorary");
+  const withTributeNotif = watch("withTributeNotif");
 
   return (
     <Form
@@ -132,17 +133,52 @@ export default function SummaryForm({
       )}
 
       <CheckField<FV> name="withHonorary" classes="col-span-full mt-4">
-        Donating in honor of someone?
+        Dedicate my donation
       </CheckField>
 
       {withHonorary && (
-        <Field<FV>
-          name="honoraryFullName"
-          label="In Honor Of"
-          placeholder="e.g. Jane Doe"
-          classes={{ container: "col-span-full field-donate" }}
-          required
-        />
+        <div className="col-span-full p-4 bg-blue-l5 rounded">
+          <Field<FV>
+            name="honoraryFullName"
+            label="Honoree's name"
+            placeholder="e.g. Jane Doe"
+            classes="w-full field-donate [&_input]:bg-white"
+            required
+          />
+          <CheckField<FV>
+            name="withTributeNotif"
+            classes="col-span-full mt-2 text-sm"
+          >
+            Notify someone about this tribute
+          </CheckField>
+
+          {withTributeNotif && (
+            <div className="grid gap-y-3 mt-4 rounded p-4 bg-white">
+              <Field<FV>
+                name="tributeNotif.toFullName"
+                label="Recipient name"
+                placeholder="e.g. Jane Doe"
+                classes="field-donate [&_label]:text-sm [&_input]:text-sm"
+                required
+              />
+              <Field<FV>
+                name="tributeNotif.toEmail"
+                label="Email address"
+                placeholder="e.g. Jane Doe"
+                classes="field-donate [&_label]:text-sm [&_input]:text-sm"
+                required
+              />
+              <Field<FV, "textarea">
+                type="textarea"
+                name="tributeNotif.fromMsg"
+                label="Custom message"
+                placeholder="Message to recipient"
+                classes="field-donate [&_label]:text-sm [&_input]:text-sm"
+                required={false}
+              />
+            </div>
+          )}
+        </div>
       )}
       <ContinueBtn
         type="submit"

--- a/src/components/donation/Steps/common/constants.ts
+++ b/src/components/donation/Steps/common/constants.ts
@@ -3,7 +3,7 @@ import type { ChainID } from "types/chain";
 import type { DetailedCurrency, OptionType } from "types/components";
 import type { DonateMethodId } from "types/lists";
 import type { TokenWithAmount } from "types/tx";
-import type { DonationDetails, FormDonor } from "../types";
+import type { DonationDetails, FormDonor, TributeNotif } from "../types";
 
 export const DEFAULT_PROGRAM: OptionType<""> = {
   label: "General Donation",
@@ -95,4 +95,10 @@ export const toDonor = (fv: FormDonor): Donor => {
       : undefined,
     ukGiftAid: fv.ukTaxResident,
   };
+};
+
+export const initTributeNotif: TributeNotif = {
+  toEmail: "",
+  toFullName: "",
+  fromMsg: "",
 };

--- a/src/components/donation/Steps/index.tsx
+++ b/src/components/donation/Steps/index.tsx
@@ -4,7 +4,11 @@ import type { OptionType } from "types/components";
 import type { DonationSource } from "types/lists";
 import Context from "./Context";
 import CurrentStep from "./CurrentStep";
-import { initDetails, initDonorTitleOption } from "./common/constants";
+import {
+  initDetails,
+  initDonorTitleOption,
+  initTributeNotif,
+} from "./common/constants";
 import type {
   Config,
   DonationRecipient,
@@ -106,6 +110,8 @@ function initialState({
       honorary: {
         withHonorary: !!intent.inHonorOf,
         honoraryFullName: intent.inHonorOf ?? "",
+        withTributeNotif: !!intent.tributeNotif,
+        tributeNotif: intent.tributeNotif ?? initTributeNotif,
       },
     };
   }
@@ -129,6 +135,8 @@ function initialState({
     honorary: {
       withHonorary: !!intent.inHonorOf,
       honoraryFullName: intent.inHonorOf ?? "",
+      withTributeNotif: !!intent.tributeNotif,
+      tributeNotif: intent.tributeNotif ?? initTributeNotif,
     },
   };
 }

--- a/src/components/donation/Steps/types.ts
+++ b/src/components/donation/Steps/types.ts
@@ -112,16 +112,19 @@ export type FormDonor = Pick<Donor, "email" | "firstName" | "lastName"> & {
   streetAddress: string;
 };
 
+export type TributeNotif = {
+  toFullName: string;
+  toEmail: string;
+  /** may be empty */
+  fromMsg: string;
+};
+
 export type Honorary = {
   withHonorary: boolean;
   /** initially empty `''` */
   honoraryFullName: string;
   withTributeNotif: boolean;
-  tributeNotif: {
-    toFullName: string;
-    toEmail: string;
-    fromMsg: string;
-  };
+  tributeNotif: TributeNotif;
 };
 
 export type SummaryStep = {

--- a/src/components/donation/Steps/types.ts
+++ b/src/components/donation/Steps/types.ts
@@ -116,6 +116,12 @@ export type Honorary = {
   withHonorary: boolean;
   /** initially empty `''` */
   honoraryFullName: string;
+  withTributeNotif: boolean;
+  tributeNotif: {
+    toFullName: string;
+    toEmail: string;
+    fromMsg: string;
+  };
 };
 
 export type SummaryStep = {

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import {
   type ForwardedRef,
   type HTMLInputTypeAttribute,
+  type ReactElement,
   type ReactNode,
   createElement,
   forwardRef,
@@ -28,7 +29,7 @@ type Props<T extends InputType> = Omit<
 > & {
   classes?: Classes | string;
   tooltip?: ReactNode;
-  label: string;
+  label: string | ReactElement;
   type?: T;
 };
 

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -91,7 +91,6 @@ export const NativeField = forwardRef(_Field) as typeof _Field;
 export function Field<T extends FieldValues, K extends InputType = InputType>({
   name,
   disabled,
-  type,
   ...rest
 }: Omit<Props<K>, "name"> & { name: Path<T> }) {
   const {

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,4 +1,4 @@
-import { BASE_URL, ENVIRONMENT } from "./env";
+import { BASE_URL, ENVIRONMENT, IS_TEST } from "./env";
 
 export const APIs = {
   aws: "https://ap-api.better.giving",

--- a/src/types/aws/apes/donation.ts
+++ b/src/types/aws/apes/donation.ts
@@ -38,6 +38,13 @@ export type ReceiptPayload = {
   transactionId: string; // tx hash
 };
 
+export type TributeNotif = {
+  toFullName: string;
+  toEmail: string;
+  /** may be empty */
+  fromMsg: string;
+};
+
 export type CryptoDonation = {
   transactionId?: string;
   programId?: string;
@@ -56,6 +63,7 @@ export type CryptoDonation = {
   donor: Donor;
   /** honorary full name - may be empty `""` */
   inHonorOf?: string;
+  tributeNotif?: TributeNotif;
 };
 
 export type FiatDonation = {
@@ -72,6 +80,7 @@ export type FiatDonation = {
   source: DonationSource;
   /** honorary full name - may be empty `""` */
   inHonorOf?: string;
+  tributeNotif?: TributeNotif;
 };
 
 export type DonationIntent =


### PR DESCRIPTION
## Explanation of the solution

* Tribute notif UI 
<img width="867" alt="image" src="https://github.com/AngelProtocolFinance/angelprotocol-web-app/assets/89639563/146ef626-966d-4eff-a5fa-da0865dd5203">

* wiring per https://github.com/AngelProtocolFinance/devops/pull/644


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
