### PR TITLE
Add staging endpoint for S3 file uploading

### DIFF
--- a/src/helpers/uploadFiles.ts
+++ b/src/helpers/uploadFiles.ts
@@ -1,4 +1,5 @@
 import { APIs } from "constants/urls";
+import { version as v } from "services/helpers";
 import { isEmpty } from "./isEmpty";
 import { jwtToken } from "./jwt-token";
 
@@ -20,7 +21,7 @@ export async function uploadFiles(
 
   await Promise.all(
     files.map((f, idx) =>
-      fetch(APIs.aws + "/v2/file-upload", {
+      fetch(APIs.aws + `/${v(2)}/file-upload`, {
         method: "POST",
         body: JSON.stringify({
           bucket,


### PR DESCRIPTION
Resolves BG-1444

## Explanation of the solution
To avoid requests with `origin === undefined`, the Cognito auth that we have for both `production` and `staging` are now also applied to the file upload endpoint. The `/v2` endpoint is now exclusively used in production and the `/staging` endpoint for staging.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- verify that `POST /staging/file-upload` endpoint is used when uploading files to S3

## UI changes for review
No major UI changes.