### PR TITLE
Summary form integration test

### DIFF
--- a/src/components/Selector/index.ts
+++ b/src/components/Selector/index.ts
@@ -3,6 +3,6 @@ import { styles } from "./constants";
 export { default as FocusableInput } from "./FocusableInput";
 export { MultiSelector } from "./MultiSelector";
 export { NativeSelect } from "./NativeSelect";
-export { Selector } from "./Selector";
+export { Selector, List } from "./Selector";
 
 export const { selectorButton: selectorButtonStyle } = styles;

--- a/src/components/Selector/types.ts
+++ b/src/components/Selector/types.ts
@@ -27,6 +27,14 @@ export interface Props<
   children?: (selected: OptionType<V>) => ReactNode;
 }
 
+export interface ControlledProps<T extends ValKey> extends BaseProps {
+  value: OptionType<T>;
+  onChange: (opt: OptionType<T>) => void;
+  options: OptionType<T>[];
+  children?: (selected: OptionType<T>) => ReactNode;
+  error?: string;
+}
+
 export interface MultiselectorProps<
   T extends FieldValues,
   K extends Path<T>,

--- a/src/components/donation/Steps/Summary/SummaryForm.test.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, expectTypeOf, test, vi } from "vitest";
 import type { FormDonor, Honorary } from "../types";
 import SummaryForm, { type Props } from "./SummaryForm";
 
@@ -70,13 +70,10 @@ describe("summary form: expandable fields", async () => {
       <SummaryForm
         {...props}
         donor={{
+          ...donor,
           firstName: "first",
           lastName: "last",
           email: "donor@mail.com",
-          ukTaxResident: false,
-          title: { label: "Select", value: "" },
-          zipCode: "",
-          streetAddress: "",
         }}
       />
     );
@@ -102,10 +99,91 @@ describe("summary form: expandable fields", async () => {
     await userEvent.click(checkoutBtn);
     expect(mockOnSubmit).not.toHaveBeenCalled();
     expect(houseNumberInput).toHaveAccessibleErrorMessage(/required/i);
+    expect(houseNumberInput).toHaveFocus();
     expect(postalCodeInput).toHaveAccessibleErrorMessage(/required/i);
 
     await userEvent.type(houseNumberInput, "221B Baker Street");
     await userEvent.type(postalCodeInput, "2000");
+    await userEvent.click(checkoutBtn);
+    expect(mockOnSubmit).toHaveBeenCalledOnce();
+    mockOnSubmit.mockClear();
+  });
+
+  test("dedication fields", async () => {
+    render(
+      <SummaryForm
+        {...props}
+        donor={{
+          ...donor,
+          firstName: "first",
+          lastName: "last",
+          email: "donor@mail.com",
+        }}
+      />
+    );
+
+    //form is good for submission nonetheless
+    const checkoutBtn = screen.getByRole("button", { name: /checkout/i });
+    await userEvent.click(checkoutBtn);
+    expect(mockOnSubmit).toHaveBeenCalledOnce();
+    mockOnSubmit.mockClear();
+
+    //user intends to add honorary
+    const withHonoraryCheckField =
+      screen.getByLabelText(/dedicate my donation/i);
+    await userEvent.click(withHonoraryCheckField);
+    const honoreeInput = screen.getByLabelText(/honoree's name/i);
+    const tributeNotifCheckbox = screen.getByLabelText(
+      /notify someone about this tribute/i
+    );
+    expect(honoreeInput).toBeInTheDocument();
+    expect(tributeNotifCheckbox).toBeInTheDocument();
+
+    //user needs to fill out honoree's name
+    await userEvent.click(checkoutBtn);
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+    expect(honoreeInput).toHaveAccessibleErrorMessage(/required/i);
+    expect(honoreeInput).toHaveFocus();
+
+    //user inputs honoree's name
+    await userEvent.type(honoreeInput, "first last");
+
+    //form is good for submission
+    await userEvent.click(checkoutBtn);
+    expect(mockOnSubmit).toHaveBeenCalledOnce();
+    mockOnSubmit.mockClear();
+
+    //user intends to notify someone of the honorary
+    await userEvent.click(tributeNotifCheckbox);
+    const recipientNameInput = screen.getByLabelText(/recipient name/i);
+    const emailAddrInput = screen.getByLabelText(/email address/i);
+    const msgInput = screen.getByLabelText(/custom message/i);
+
+    expect(recipientNameInput).toBeInTheDocument();
+    expect(emailAddrInput).toBeInTheDocument();
+    expect(msgInput).toBeInTheDocument();
+
+    //user needs to fill-out additional information
+    await userEvent.click(checkoutBtn);
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+    expect(recipientNameInput).toHaveAccessibleErrorMessage(/required/i);
+    expect(recipientNameInput).toHaveFocus();
+    expect(emailAddrInput).toHaveAccessibleErrorMessage(/required/i);
+
+    //user populates additional fields
+    await userEvent.type(recipientNameInput, "first last");
+    expect(recipientNameInput).not.toHaveAccessibleErrorMessage();
+
+    //wrong email
+    await userEvent.type(emailAddrInput, "email");
+    expect(emailAddrInput).toHaveAccessibleErrorMessage(/invalid email/i);
+
+    //user corrects email
+    await userEvent.clear(emailAddrInput);
+    await userEvent.type(emailAddrInput, "mail@mail.com");
+    expect(emailAddrInput).not.toHaveAccessibleErrorMessage();
+
+    //form is good for submission
     await userEvent.click(checkoutBtn);
     expect(mockOnSubmit).toHaveBeenCalledOnce();
     mockOnSubmit.mockClear();

--- a/src/components/donation/Steps/Summary/SummaryForm.test.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import type { FormDonor, Honorary } from "../types";
+import SummaryForm, { type Props } from "./SummaryForm";
+
+const mockOnSubmit = vi.fn();
+
+const donor: FormDonor = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  ukTaxResident: false,
+  title: { label: "Select", value: "" },
+  zipCode: "",
+  streetAddress: "",
+};
+
+const honorary: Honorary = {
+  withHonorary: false,
+  honoraryFullName: "",
+  withTributeNotif: false,
+  tributeNotif: {
+    fromMsg: "",
+    toEmail: "",
+    toFullName: "",
+  },
+};
+
+const props: Props = {
+  onSubmit: mockOnSubmit,
+  donor,
+  honorary,
+  coverFee: false,
+  nonprofitName: "Test Nonprofit",
+  mode: "live",
+  method: "stripe",
+};
+
+const coverFeeCheckboxText = /cover payment processing fees/i;
+const ukGiftAidCheckboxLabel =
+  /uk taxpayer\? supercharge your donation with gift aid/i;
+
+describe("summary form: fields based on donation method", () => {
+  test("stocks: no cover fee option, with gift aid option", () => {
+    render(<SummaryForm {...props} method="stocks" />);
+    expect(screen.queryByText(coverFeeCheckboxText)).toBeNull();
+    expect(screen.getByLabelText(ukGiftAidCheckboxLabel)).toBeInTheDocument();
+  });
+  test("daf: no cover fee option, with gift aid option", () => {
+    render(<SummaryForm {...props} method="daf" />);
+    expect(screen.queryByText(coverFeeCheckboxText)).toBeNull();
+    expect(screen.getByLabelText(ukGiftAidCheckboxLabel)).toBeInTheDocument();
+  });
+  test("stripe: with cover fee option, with gift aid option", () => {
+    render(<SummaryForm {...props} method="stripe" />);
+    expect(screen.getByText(coverFeeCheckboxText)).toBeInTheDocument();
+    expect(screen.getByLabelText(ukGiftAidCheckboxLabel)).toBeInTheDocument();
+  });
+  test("crypto: with cover fee option, without gift aid option", () => {
+    render(<SummaryForm {...props} method="crypto" />);
+    expect(screen.getByText(coverFeeCheckboxText)).toBeInTheDocument();
+    expect(screen.queryByLabelText(ukGiftAidCheckboxLabel)).toBeNull();
+  });
+});
+
+describe("summary form: expandable fields", async () => {
+  test("checking uk gift aid, shows additional fields", async () => {
+    render(
+      <SummaryForm
+        {...props}
+        donor={{
+          firstName: "first",
+          lastName: "last",
+          email: "donor@mail.com",
+          ukTaxResident: false,
+          title: { label: "Select", value: "" },
+          zipCode: "",
+          streetAddress: "",
+        }}
+      />
+    );
+    expect(screen.queryByLabelText(/house number/i)).toBeNull();
+    expect(screen.queryByLabelText(/postal code/i)).toBeNull();
+
+    //form is good for submission nonetheless
+    const checkoutBtn = screen.getByRole("button", { name: /checkout/i });
+    await userEvent.click(checkoutBtn);
+    expect(mockOnSubmit).toHaveBeenCalledOnce();
+    mockOnSubmit.mockClear();
+
+    //user checks uk gift aid
+    const ukGiftAidCheckbox = screen.getByLabelText(ukGiftAidCheckboxLabel);
+    await userEvent.click(ukGiftAidCheckbox);
+
+    const houseNumberInput = screen.getByLabelText(/house number/i);
+    const postalCodeInput = screen.getByLabelText(/postal code/i);
+    expect(houseNumberInput).toBeInTheDocument();
+    expect(postalCodeInput).toBeInTheDocument();
+
+    //user needs to populate uk gift aid fields
+    await userEvent.click(checkoutBtn);
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+    expect(houseNumberInput).toHaveAccessibleErrorMessage(/required/i);
+    expect(postalCodeInput).toHaveAccessibleErrorMessage(/required/i);
+
+    await userEvent.type(houseNumberInput, "221B Baker Street");
+    await userEvent.type(postalCodeInput, "2000");
+    await userEvent.click(checkoutBtn);
+    expect(mockOnSubmit).toHaveBeenCalledOnce();
+    mockOnSubmit.mockClear();
+  });
+});

--- a/src/components/donation/Steps/Summary/SummaryForm.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.tsx
@@ -16,7 +16,7 @@ import type { FormDonor, Honorary, Mode } from "../types";
 
 type FV = FormDonor & Honorary & { coverFee: boolean };
 
-type Props = {
+export type Props = {
   onSubmit(formValues: FV): void;
   classes?: string;
   donor: FormDonor;

--- a/src/components/donation/Steps/Summary/SummaryForm.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.tsx
@@ -1,6 +1,11 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import { List } from "components/Selector";
-import { CheckField, NativeField as Field, Form, Label } from "components/form";
+import {
+  NativeCheckField as CheckField,
+  NativeField as Field,
+  Form,
+  Label,
+} from "components/form";
 import { useController, useForm } from "react-hook-form";
 import { schema } from "schemas/shape";
 import type { DonateMethodId } from "types/lists";
@@ -146,7 +151,7 @@ export default function SummaryForm({
         required
       />
       {(method === "crypto" || method === "stripe") && (
-        <CheckField<FV> name="coverFee" classes="col-span-full">
+        <CheckField {...register("coverFee")} classes="col-span-full">
           Cover payment processing fees for your donation{" "}
           <span className="text-navy-l1 text-sm">
             (&nbsp;{nonprofitName} receives the full amount&nbsp;)
@@ -154,7 +159,7 @@ export default function SummaryForm({
         </CheckField>
       )}
       {method !== "crypto" && (
-        <CheckField<FV> name="ukTaxResident" classes="col-span-full mt-4">
+        <CheckField {...register("ukTaxResident")} classes="col-span-full mt-4">
           UK Taxpayer? Supercharge your donation with gift aid
         </CheckField>
       )}
@@ -178,7 +183,7 @@ export default function SummaryForm({
           />
         </div>
       )}
-      <CheckField<FV> name="withHonorary" classes="col-span-full mt-4">
+      <CheckField {...register("withHonorary")} classes="col-span-full mt-4">
         Dedicate my donation
       </CheckField>
 
@@ -192,8 +197,8 @@ export default function SummaryForm({
             required
             error={errors.honoraryFullName?.message}
           />
-          <CheckField<FV>
-            name="withTributeNotif"
+          <CheckField
+            {...register("withTributeNotif")}
             classes="col-span-full mt-3 text-sm"
           >
             Notify someone about this tribute

--- a/src/components/donation/Steps/Summary/SummaryForm.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.tsx
@@ -1,7 +1,7 @@
 import { yupResolver } from "@hookform/resolvers/yup";
-import { Selector } from "components/Selector";
-import { CheckField, Field, Form, Label } from "components/form";
-import { useForm } from "react-hook-form";
+import { List } from "components/Selector";
+import { CheckField, NativeField as Field, Form, Label } from "components/form";
+import { useController, useForm } from "react-hook-form";
 import { schema } from "schemas/shape";
 import type { DonateMethodId } from "types/lists";
 import { mixed, string } from "yup";
@@ -43,7 +43,13 @@ export default function SummaryForm({
   method,
 }: Props) {
   const CUSTOM_MSG_MAX_LENGTH = 250;
-  const methods = useForm<FV>({
+  const {
+    handleSubmit,
+    watch,
+    formState: { errors },
+    register,
+    control,
+  } = useForm<FV>({
     defaultValues: {
       ...donor,
       ...honorary,
@@ -85,11 +91,11 @@ export default function SummaryForm({
     ),
   });
 
-  const {
-    handleSubmit,
-    watch,
-    formState: { errors },
-  } = methods;
+  const { field: title } = useController<FV, "title">({
+    name: "title",
+    control,
+  });
+
   const ukTaxResident = watch("ukTaxResident");
   const withHonorary = watch("withHonorary");
   const withTributeNotif = watch("withTributeNotif");
@@ -97,21 +103,21 @@ export default function SummaryForm({
 
   return (
     <Form
-      methods={methods}
       onSubmit={handleSubmit(onSubmit)}
       className={`grid grid-cols-2 gap-x-4 ${classes}`}
     >
       <Label className="mb-2 text-base font-medium">Title</Label>
-      <Selector<FV, "title", string>
-        name="title"
+      <List
+        value={title.value}
+        onChange={title.onChange}
         options={titleOptions}
         classes={{
           button: "field-input-donate",
           container: "col-span-full mb-4",
         }}
       />
-      <Field<FV>
-        name="firstName"
+      <Field
+        {...register("firstName")}
         label="Your name"
         placeholder="First Name"
         required
@@ -119,21 +125,24 @@ export default function SummaryForm({
           label: "font-semibold text-base font-heading",
           container: "field-donate",
         }}
+        error={errors.firstName?.message}
       />
-      <Field<FV>
-        name="lastName"
+      <Field
+        {...register("lastName")}
         label=""
         placeholder="Last Name"
         classes={{ container: "field-donate mb-4" }}
+        error={errors.lastName?.message}
       />
-      <Field<FV>
-        name="email"
+      <Field
+        {...register("email")}
         label="Your email"
         placeholder="Email address"
         classes={{
           label: "font-medium text-base",
           container: "col-span-full field-donate mb-4",
         }}
+        error={errors.email?.message}
         required
       />
       {(method === "crypto" || method === "stripe") && (
@@ -151,19 +160,21 @@ export default function SummaryForm({
       )}
       {ukTaxResident && (
         <div className="grid col-span-full gap-y-4 mt-2 mb-6">
-          <Field<FV>
-            name="streetAddress"
+          <Field
+            {...register("streetAddress")}
             label="House number"
             placeholder="e.g. 100 Better Giving Rd"
             classes={{ container: "field-donate" }}
             required
+            error={errors.streetAddress?.message}
           />
-          <Field<FV>
-            name="zipCode"
+          <Field
+            {...register("zipCode")}
             label="Postal code"
             placeholder="e.g. BG21 1BG"
             classes={{ container: "field-donate" }}
             required
+            error={errors.zipCode?.message}
           />
         </div>
       )}
@@ -173,12 +184,13 @@ export default function SummaryForm({
 
       {withHonorary && (
         <div className="col-span-full p-4 bg-blue-l5 rounded-lg mt-2 shadow-inner">
-          <Field<FV>
-            name="honoraryFullName"
+          <Field
+            {...register("honoraryFullName")}
             label="Honoree's name"
             placeholder="e.g. Jane Doe"
             classes="w-full field-donate [&_input]:bg-white"
             required
+            error={errors.honoraryFullName?.message}
           />
           <CheckField<FV>
             name="withTributeNotif"
@@ -189,30 +201,33 @@ export default function SummaryForm({
 
           {withTributeNotif && (
             <div className="grid gap-y-3 mt-4 rounded-lg p-4 bg-white shadow-inner">
-              <Field<FV>
-                name="tributeNotif.toFullName"
+              <Field
+                {...register("tributeNotif.toFullName")}
                 label="Recipient name"
                 placeholder="e.g. Jane Doe"
                 classes="field-donate [&_label]:text-sm [&_input]:text-sm"
                 required
+                error={errors.tributeNotif?.toFullName?.message}
               />
-              <Field<FV>
-                name="tributeNotif.toEmail"
+              <Field
+                {...register("tributeNotif.toEmail")}
                 label="Email address"
                 placeholder="e.g. janedoe@better.giving"
                 classes="field-donate [&_label]:text-sm [&_input]:text-sm"
                 required
+                error={errors.tributeNotif?.toEmail?.message}
               />
-              <Field<FV, "textarea">
+              <Field
+                {...register("tributeNotif.fromMsg")}
                 rows={2}
                 type="textarea"
-                name="tributeNotif.fromMsg"
                 label="Custom message"
                 placeholder="Message to recipient"
                 classes={{
                   container: "field-donate [&_label]:text-sm [&_input]:text-sm",
                 }}
                 required={false}
+                error={errors.tributeNotif?.fromMsg?.message}
               />
               <p
                 data-exceed={errors.tributeNotif?.fromMsg?.type === "max"}

--- a/src/components/form/CheckField.tsx
+++ b/src/components/form/CheckField.tsx
@@ -65,7 +65,6 @@ export const NativeCheckField = fixedForwardRef(_CheckField);
 
 export function CheckField<T extends FieldValues>({
   name,
-  children,
   onChange,
   disabled,
   ...props

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -48,6 +48,7 @@ function _Field<T extends InputType = InputType>(
   const style = unpack(classes);
 
   const id = "__" + String(props.name);
+  const errorId = "__error_" + String(props.name);
 
   return (
     <div className={style.container + " field"}>
@@ -62,6 +63,7 @@ function _Field<T extends InputType = InputType>(
         id,
         "aria-invalid": !!error,
         "aria-disabled": props.disabled,
+        "aria-errormessage": errorId,
         className: style.input,
         autoComplete: "off",
         spellCheck: false,
@@ -74,12 +76,15 @@ function _Field<T extends InputType = InputType>(
           ) : (
             tooltip
           )}{" "}
-          <span className="empty:hidden text-red dark:text-red-l2 text-xs before:content-['('] before:mr-0.5 after:content-[')'] after:ml-0.5 empty:before:hidden empty:after:hidden">
+          <span
+            id={errorId}
+            className="empty:hidden text-red dark:text-red-l2 text-xs before:content-['('] before:mr-0.5 after:content-[')'] after:ml-0.5 empty:before:hidden empty:after:hidden"
+          >
             {error}
           </span>
         </p>
       )) || (
-        <span data-error className={style.error + " empty:hidden"}>
+        <span id={errorId} data-error className={style.error + " empty:hidden"}>
           {error}
         </span>
       )}

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -2,7 +2,7 @@ export * from "./Label";
 export * from "./Field";
 export * from "./Input";
 export * from "./PasswordInput";
-export { CheckField } from "./CheckField";
+export { CheckField, NativeCheckField } from "./CheckField";
 export { Radio } from "./Radio";
 export { default as Form } from "./Form";
 export { dateToFormFormat } from "./helpers";

--- a/src/helpers/react.ts
+++ b/src/helpers/react.ts
@@ -1,0 +1,8 @@
+import { forwardRef } from "react";
+
+/** wraps forwardRef to preserve generic */
+export function fixedForwardRef<T, P = {}>(
+  render: (props: P, ref: React.Ref<T>) => React.ReactNode
+): (props: P & React.RefAttributes<T>) => React.ReactNode {
+  return forwardRef(render) as any;
+}


### PR DESCRIPTION
Towards BG-1425
Towards BG-1171
## Explanation of the solution
*  add test cases
   ✓ summary form: fields based on donation method (4)
     ✓ stocks: no cover fee option, with gift aid option
     ✓ daf: no cover fee option, with gift aid option
     ✓ stripe: with cover fee option, with gift aid option
     ✓ crypto: with cover fee option, without gift aid option
   ✓ summary form: expandable fields (3) 613ms
     ✓ top fields validation
     ✓ checking uk gift aid, shows additional fields
     ✓ dedication fields
     
* others
  - extract selector ui from context-scoped selector
  - extract checkfield ui from context-scoped checkfield
  - add accessible error message attributes

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
