### PR TITLE
Summary step integration test

### DIFF
--- a/src/components/donation/Steps/DonateMethods/Stripe/Form.test.tsx
+++ b/src/components/donation/Steps/DonateMethods/Stripe/Form.test.tsx
@@ -46,7 +46,9 @@ describe("Stripe form test", () => {
     render(<_Form step="donate-form" init={init} />);
     expect(screen.getByText(/loading donate form/i));
     //after loading
-    expect(await screen.findByText(/failed to load donate form/i));
+    expect(
+      await screen.findByText(/failed to load donate form/i)
+    ).toBeInTheDocument();
   });
 
   test("blank state: no default currency specified", async () => {

--- a/src/components/donation/Steps/Summary/Summary.test.tsx
+++ b/src/components/donation/Steps/Summary/Summary.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { store } from "store/store";
 import type { AuthenticatedUser } from "types/auth";
@@ -172,9 +172,9 @@ describe("summary step", () => {
     //dollar amount is loading
     expect(donationTerm.nextSibling).toHaveTextContent("100.0000 ($--)");
     //dollar amount is loaded
-
-    await new Promise((r) => setTimeout(r, 50));
-    expect(donationTerm.nextSibling).toHaveTextContent("100.0000 ($100.00)");
+    await waitFor(() => {
+      expect(donationTerm.nextSibling).toHaveTextContent("100.0000 ($100.00)");
+    });
   });
 
   const user: Partial<AuthenticatedUser> = {

--- a/src/components/donation/Steps/Summary/Summary.test.tsx
+++ b/src/components/donation/Steps/Summary/Summary.test.tsx
@@ -54,7 +54,7 @@ const props: SummaryStep = {
 const coverFeeCheckboxLabel =
   /cover payment processing fees for your donation \( example charity receives the full amount \)/i;
 
-describe("summary items", () => {
+describe("summary step", () => {
   test("donation amount text if no tip", () => {
     render(<Summary {...props} />);
     const totalRow = screen.getByRole("term", { name: /amount/i });

--- a/src/components/donation/Steps/Summary/Summary.test.tsx
+++ b/src/components/donation/Steps/Summary/Summary.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { store } from "store/store";
+import { describe, expect, test, vi } from "vitest";
+import { initTokenOption } from "../common/constants";
+import type {
+  CryptoDonationDetails,
+  StripeDonationDetails,
+  SummaryStep,
+} from "../types";
+import Summary from "./Summary";
+
+vi.mock("../Context", () => ({
+  useDonationState: vi.fn().mockReturnValue({ state: {}, setState: vi.fn() }),
+}));
+
+const mockUseGetter = vi.hoisted(() => vi.fn());
+vi.mock("store/accessors", () => ({
+  useGetter: mockUseGetter,
+}));
+
+const oneTimeStripeDetails: StripeDonationDetails = {
+  method: "stripe",
+  frequency: "one-time",
+  amount: "100.00",
+  currency: { code: "usd", min: 1, rate: 1 },
+  program: { value: "prog_789", label: "Education Initiative" },
+};
+
+const props: SummaryStep = {
+  step: "summary",
+  init: {
+    source: "bg-marketplace",
+    mode: "live",
+    recipient: { id: 1, name: "Example Charity" },
+    config: null,
+  },
+  details: oneTimeStripeDetails,
+  liquidSplitPct: 80,
+};
+
+const coverFeeCheckboxLabel =
+  /cover payment processing fees for your donation \( example charity receives the full amount \)/i;
+
+describe("summary items", () => {
+  test("donation amount text if no tip", () => {
+    render(<Summary {...props} />);
+    const totalRow = screen.getByRole("term", { name: /amount/i });
+    expect(totalRow).toHaveTextContent(/total donation/i);
+  });
+  test("donation amount text with tip", () => {
+    render(<Summary {...props} tip={{ value: 17, format: "pct" }} />);
+    const totalRow = screen.getByRole("term", { name: /amount/i });
+    expect(totalRow).toHaveTextContent(/donation for example charity/i);
+  });
+  test("total amount text - one time", () => {
+    render(<Summary {...props} />);
+    const totalRow = screen.getByRole("term", { name: /total/i });
+    expect(totalRow).toHaveTextContent(/total charge/i);
+  });
+
+  const subsStripeDetails: StripeDonationDetails = {
+    ...oneTimeStripeDetails,
+    frequency: "subscription",
+  };
+  test("total amount text - subscription", () => {
+    render(<Summary {...props} details={subsStripeDetails} />);
+    const totalRow = screen.getByRole("term", { name: /total/i });
+    expect(totalRow).toHaveTextContent(/total monthly charge/i);
+  });
+
+  test("if fee allowance is previously set, cover fee checkbox must be checked", () => {
+    render(<Summary {...props} feeAllowance={2} />);
+
+    const coverFeeCheckbox = screen.getByLabelText(coverFeeCheckboxLabel);
+    expect(coverFeeCheckbox).toBeChecked();
+
+    //processing fee row is not shown in summary step
+    expect(screen.queryByRole("term", { name: /fee allowance/i })).toBeNull();
+  });
+  test("fee allowance not previously set", () => {
+    render(<Summary {...props} />);
+
+    const coverFeeCheckbox = screen.getByLabelText(coverFeeCheckboxLabel);
+    expect(coverFeeCheckbox).not.toBeChecked();
+  });
+
+  test("only amount row and total row", () => {
+    render(<Summary {...props} liquidSplitPct={100} />);
+    expect(screen.getByRole("term", { name: /amount/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("term", { name: /sustainability fund/i })
+    ).toBeNull();
+    expect(screen.queryByRole("term", { name: /direct donation/i })).toBeNull();
+    expect(screen.queryByRole("term", { name: /tip/i })).toBeNull();
+    expect(screen.getByRole("term", { name: /total/i })).toBeInTheDocument();
+  });
+  test("with tip row: and effect to total", () => {
+    render(
+      <Summary
+        {...props}
+        liquidSplitPct={100}
+        tip={{ value: 17, format: "amount" }}
+      />
+    );
+    expect(screen.getByRole("term", { name: /amount/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("term", { name: /sustainability fund/i })
+    ).toBeNull();
+    expect(screen.queryByRole("term", { name: /direct donation/i })).toBeNull();
+
+    const tipTerm = screen.getByRole("term", { name: /tip/i });
+    expect(tipTerm).toBeInTheDocument();
+    expect(tipTerm.nextSibling).toHaveTextContent(/\$17/i);
+
+    const totalTerm = screen.getByRole("term", { name: /total/i });
+    expect(totalTerm).toBeInTheDocument();
+    expect(totalTerm.nextSibling).toHaveTextContent(/\$117/i);
+  });
+  test("with tip, splits rows", () => {
+    render(
+      <Summary
+        {...props}
+        liquidSplitPct={60}
+        tip={{ value: 17, format: "amount" }}
+      />
+    );
+    expect(screen.getByRole("term", { name: /amount/i })).toBeInTheDocument();
+
+    const lockTerm = screen.getByRole("term", { name: /sustainability fund/i });
+    expect(lockTerm).toBeInTheDocument();
+    //dt is enclosed by div
+    expect(lockTerm.parentNode?.nextSibling).toHaveTextContent(/\$40/i);
+
+    const liqTerm = screen.getByRole("term", { name: /direct donation/i });
+    expect(liqTerm).toBeInTheDocument();
+    expect(liqTerm.nextSibling).toHaveTextContent(/\$60/i);
+
+    expect(screen.getByRole("term", { name: /tip/i })).toBeInTheDocument();
+    expect(screen.getByRole("term", { name: /total/i })).toBeInTheDocument();
+
+    expect(screen.getByLabelText(coverFeeCheckboxLabel)).not.toBeChecked();
+  });
+
+  const cryptoDetails: CryptoDonationDetails = {
+    method: "crypto",
+    chainId: "80002",
+    token: { ...initTokenOption, amount: "100", coingecko_denom: "wagmi" },
+    program: props.details.program,
+  };
+  test("crypto amount + dollar amount", async () => {
+    render(
+      <Provider store={store}>
+        <Summary {...props} details={cryptoDetails} />
+      </Provider>
+    );
+
+    const donationTerm = screen.getByRole("term", { name: /amount/i });
+    expect(donationTerm).toBeInTheDocument();
+    //dollar amount is loading
+    expect(donationTerm.nextSibling).toHaveTextContent("100.0000 ($--)");
+    //dollar amount is loaded
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(donationTerm.nextSibling).toHaveTextContent("100.0000 ($100.00)");
+  });
+});

--- a/src/components/donation/Steps/common/Summary.tsx
+++ b/src/components/donation/Steps/common/Summary.tsx
@@ -53,7 +53,7 @@ export default function Summary({
         className={`text-navy-l1 grid grid-cols-[1fr_auto] items-center justify-between border-y border-gray-l4 divide-y divide-gray-l4 ${splitClass}`}
       >
         <div className="grid grid-cols-[1fr_auto] py-3 gap-y-1">
-          <dt className="mr-auto text-navy-d4">
+          <dt aria-label="amount" className="mr-auto text-navy-d4">
             {props.tip && tipValue > 0
               ? `Donation for ${props.tip.charityName}`
               : `Total donation`}
@@ -63,7 +63,9 @@ export default function Summary({
           {locked > 0 && (
             <div className="flex items-center justify-between col-span-full">
               <div className="mr-auto flex">
-                <dt className="text-sm mt-2">Sustainability Fund</dt>
+                <dt aria-label="sustainability fund" className="text-sm mt-2">
+                  Sustainability Fund
+                </dt>
                 <Image src={character} className="inline-block px-1 h-8" />
               </div>
               <Amount classes="text-sm" amount={locked} />
@@ -72,7 +74,9 @@ export default function Summary({
 
           {locked > 0 && ( //show 0 liquid even if 100% locked
             <div className="flex items-center justify-between col-span-full">
-              <dt className="mr-auto text-sm">Direct Donation</dt>
+              <dt aria-label="direct donation" className="mr-auto text-sm">
+                Direct Donation
+              </dt>
               <Amount classes="text-sm" amount={liq} />
             </div>
           )}
@@ -80,20 +84,24 @@ export default function Summary({
 
         {tipValue > 0 && (
           <div className="col-span-full grid grid-cols-[1fr_auto] py-3">
-            <dt className="mr-auto">Donation for Better Giving</dt>
+            <dt className="mr-auto" aria-label="tip">
+              Donation for Better Giving
+            </dt>
             <Amount classes="text-sm" amount={tipValue} />
           </div>
         )}
 
         {props.feeAllowance ? (
           <div className="col-span-full grid grid-cols-[1fr_auto] py-3">
-            <dt className="mr-auto">Covered Payment Processing Fees</dt>
+            <dt className="mr-auto" aria-label="fee allowance">
+              Covered Payment Processing Fees
+            </dt>
             <Amount classes="text-sm" amount={props.feeAllowance} />
           </div>
         ) : null}
 
         <div className="grid col-span-full grid-cols-[1fr_auto] font-medium py-3">
-          <dt className="mr-auto text-navy-d4">
+          <dt className="mr-auto text-navy-d4" aria-label="total">
             Total {frequency === "subscription" ? "monthly " : ""}charge
           </dt>
           <Amount

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -5,6 +5,7 @@ import { handlers as programsHandlers } from "services/aws/programs";
 import { afterAll, afterEach, beforeAll, vi } from "vitest";
 import { handlers as apesHandlers } from "./services/apes/mock";
 import { handlers as awsHandlers } from "./services/aws/mock";
+import { handlers as coinGeckoHandlers } from "./services/coingecko/mock";
 import { handlers as wordpressHandlers } from "./services/wordpress/mock";
 
 vi.mock("@walletconnect/modal", () => ({
@@ -73,7 +74,8 @@ export const mswServer = setupServer(
   ...programsHandlers,
   ...apesHandlers,
   ...awsHandlers,
-  ...wordpressHandlers
+  ...wordpressHandlers,
+  ...coinGeckoHandlers
 );
 
 // Start server before all tests


### PR DESCRIPTION
## Explanation of the solution
Towards BG-1418

add test cases
   ✓ summary step (12)
     ✓ donation amount text if no tip
     ✓ donation amount text with tip
     ✓ total amount text - one time
     ✓ total amount text - subscription
     ✓ if fee allowance is previously set, cover fee checkbox must be checked
     ✓ fee allowance not previously set
     ✓ only amount row and total row
     ✓ with tip row: and effect to total
     ✓ with tip, splits rows
     ✓ crypto amount + dollar amount
     ✓ donor information is pre-filled when user is logged in and donor info is not manually set previously
     ✓ previously set donor information is always used

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
