### PR TITLE
User avatar

### DIFF
--- a/src/App/Header/UserMenu/UserMenu.tsx
+++ b/src/App/Header/UserMenu/UserMenu.tsx
@@ -1,4 +1,5 @@
 import Icon from "components/Icon";
+import Image from "components/Image";
 import LoaderRing from "components/LoaderRing";
 import { appRoutes } from "constants/routes";
 import { Link, useLocation } from "react-router-dom";
@@ -37,8 +38,19 @@ export default function UserMenu() {
   }
 
   return (
-    <Link to={appRoutes.user_dashboard} className="cursor-pointer contents">
-      <Icon size={24} type="User" className="text-blue disabled:text-navy-l2" />
+    <Link
+      to={`${appRoutes.user_dashboard}/edit-profile`}
+      className="cursor-pointer contents"
+    >
+      {user.avatarUrl ? (
+        <Image src={user.avatarUrl} className="rounded-full size-8" />
+      ) : (
+        <Icon
+          size={24}
+          type="User"
+          className="text-blue disabled:text-navy-l2"
+        />
+      )}
     </Link>
   );
 }

--- a/src/components/ImgEditor/ImgCropper.tsx
+++ b/src/components/ImgEditor/ImgCropper.tsx
@@ -6,12 +6,18 @@ import Cropper from "cropperjs";
 import { useCallback, useRef } from "react";
 
 type Props = {
+  classes?: string;
   file: File;
   aspect: [number, number];
   onSave(cropped: File): void;
 };
 
-export default function ImgCropper({ file, aspect: [x, y], onSave }: Props) {
+export default function ImgCropper({
+  file,
+  aspect: [x, y],
+  onSave,
+  classes = "",
+}: Props) {
   const { closeModal } = useModalContext();
 
   const cropperRef = useRef<Cropper>();
@@ -41,7 +47,9 @@ export default function ImgCropper({ file, aspect: [x, y], onSave }: Props) {
   }
 
   return (
-    <Modal className="grid grid-rows-[auto_1fr] fixed-center z-20 max-w-[90vmax] max-h-[90vmin] border-2 rounded-sm">
+    <Modal
+      className={`${classes} grid grid-rows-[auto_1fr] fixed-center z-20 max-w-[90vmax] max-h-[90vmin] border-2 rounded-sm`}
+    >
       <div className="bg-white flex items-center justify-end gap-2 p-1">
         <button
           type="button"

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -15,7 +15,7 @@ import useImgEditor from "./useImgEditor";
 
 const BYTES_IN_MB = 1e6;
 
-function _ImgEditor(props: ControlledProps, ref: React.Ref<any>) {
+function _ImgEditor(props: ControlledProps, ref: React.Ref<HTMLInputElement>) {
   const { handleOpenCropper, handleReset, onDrop } = useImgEditor(props);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -1,57 +1,41 @@
-import { ErrorMessage } from "@hookform/error-message";
 import Icon from "components/Icon";
-import { humanize } from "helpers";
+import { humanize, unpack } from "helpers";
+import { fixedForwardRef } from "helpers/react";
 import type React from "react";
 import { useDropzone } from "react-dropzone";
 import {
   type FieldValues,
   type Path,
   get,
+  useController,
   useFormContext,
 } from "react-hook-form";
-import type { Props } from "./types";
+import type { ControlledProps, Props } from "./types";
 import useImgEditor from "./useImgEditor";
 
 const BYTES_IN_MB = 1e6;
 
-export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
-  props: Props<T, K>
-) {
-  const { name, classes, maxSize, accept } = props;
-
-  const {
-    formState: { errors, isSubmitting },
-  } = useFormContext<T>();
-
-  const {
-    handleOpenCropper,
-    handleReset,
-    file,
-    filePath,
-    isInitial,
-    noneUploaded,
-    onDrop,
-    preview,
-    ref,
-  } = useImgEditor(props);
+function _ImgEditor(props: ControlledProps, ref: React.Ref<any>) {
+  const { handleOpenCropper, handleReset, onDrop } = useImgEditor(props);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    disabled: isSubmitting,
+    disabled: props.disabled,
     multiple: false,
     onDrop,
   });
 
-  const invalid = !!get(errors, name);
+  const styles = unpack(props.classes);
+
   const overlay = `before:content-[''] before:absolute before:inset-0 data-[drag="true"]:before:bg-blue-l5 `;
 
   return (
-    <div className={`${classes?.container ?? ""} grid grid-rows-[1fr_auto]`}>
+    <div className={`${styles.container} grid grid-rows-[1fr_auto]`}>
       <div
-        data-invalid={invalid}
+        data-invalid={!!props.error}
         data-drag={isDragActive}
-        data-disabled={isSubmitting}
+        data-disabled={props.disabled}
         {...getRootProps({
-          className: `relative ${overlay} ${classes?.dropzone ?? ""} group rounded border border-gray-l2 border-dashed 
+          className: `relative ${overlay} ${styles.dropzone} group rounded border border-gray-l2 border-dashed 
           focus:outline-none focus:ring-2 data-[drag="true"]:ring-2 has-[:active]:ring-2 ring-blue-d1 ring-offset-2 
           hover:bg-blue-l5
           data-[disabled="true"]:bg-gray-l5 data-[disabled="true"]:pointer-events-none
@@ -60,12 +44,12 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
           ref,
         })}
         style={{
-          background: preview
-            ? `url('${preview}') center/cover no-repeat`
+          background: props.value.preview
+            ? `url('${props.value.preview}') center/cover no-repeat`
             : undefined,
         }}
       >
-        {noneUploaded ? (
+        {!props.value.preview ? (
           <div
             className="absolute-center grid justify-items-center text-sm text-navy-l1 dark:text-navy-l2 select-none"
             tabIndex={-1}
@@ -87,14 +71,14 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
             </div>
             {
               /** only show controls if new file is uploaded */
-              !isInitial && (
-                <IconButton disabled={isSubmitting} onClick={handleReset}>
+              props.value.file && (
+                <IconButton disabled={props.disabled} onClick={handleReset}>
                   <Icon type="Undo" />
                 </IconButton>
               )
             }
-            {!isInitial && (
-              <IconButton onClick={handleOpenCropper} disabled={isSubmitting}>
+            {props.value.file && !props.error && (
+              <IconButton onClick={handleOpenCropper} disabled={props.disabled}>
                 <Icon type="Crop" />
               </IconButton>
             )}
@@ -104,30 +88,63 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
       <p className="text-xs text-navy-l1 dark:text-navy-l2 mt-2">
         <span>
           Valid types are:{" "}
-          {accept
+          {props.accept
             .map((m) => m.split("/")[1].toUpperCase().replace(/\+xml/gi, ""))
             .join(", ")}
           .{" "}
-          {maxSize ? (
+          {props.maxSize ? (
             <>
-              Image should be less than {maxSize / BYTES_IN_MB}MB in size.
+              Image should be less than {props.maxSize / BYTES_IN_MB}MB in size.
               <br />
-              {file.size
-                ? `Current image size: ${humanize(file.size / BYTES_IN_MB)}MB.`
+              {props.value.file?.size
+                ? `Current image size: ${humanize(
+                    props.value.file?.size / BYTES_IN_MB
+                  )}MB.`
                 : ""}
             </>
           ) : (
             ""
           )}
         </span>{" "}
-        <ErrorMessage
-          errors={errors}
-          name={filePath}
-          as="span"
-          className="text-red dark:text-red-l2 text-xs before:content-['('] before:mr-0.5 after:content-[')'] after:ml-0.5 empty:before:hidden empty:after:hidden"
-        />
+        <span className="empty:hidden text-red dark:text-red-l2 text-xs before:content-['('] before:mr-0.5 after:content-[')'] after:ml-0.5 empty:before:hidden empty:after:hidden">
+          {props.error}
+        </span>
       </p>
     </div>
+  );
+}
+
+export const ControlledImgEditor = fixedForwardRef(_ImgEditor);
+
+export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
+  props: Props<T, K>
+) {
+  const { name, ...rest } = props;
+  const {
+    trigger,
+    formState: { errors, isSubmitting },
+  } = useFormContext<T>();
+
+  const {
+    field: { value, onChange, ref },
+  } = useController<T, typeof name>({
+    name,
+  });
+
+  const filePath = `${name}.file`;
+
+  return (
+    <ControlledImgEditor
+      ref={ref}
+      value={value}
+      onChange={(v) => {
+        onChange(v);
+        trigger(filePath as any);
+      }}
+      error={get(errors, filePath)?.message}
+      disabled={isSubmitting}
+      {...rest}
+    />
   );
 }
 

--- a/src/components/ImgEditor/ImgEditor.tsx
+++ b/src/components/ImgEditor/ImgEditor.tsx
@@ -16,7 +16,7 @@ import useImgEditor from "./useImgEditor";
 const BYTES_IN_MB = 1e6;
 
 function _ImgEditor(props: ControlledProps, ref: React.Ref<HTMLInputElement>) {
-  const { handleOpenCropper, handleReset, onDrop } = useImgEditor(props);
+  const { handleOpenCropper, onDrop } = useImgEditor(props);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     disabled: props.disabled,
@@ -72,7 +72,7 @@ function _ImgEditor(props: ControlledProps, ref: React.Ref<HTMLInputElement>) {
             {
               /** only show controls if new file is uploaded */
               props.value.file && (
-                <IconButton disabled={props.disabled} onClick={handleReset}>
+                <IconButton disabled={props.disabled} onClick={props.onUndo}>
                   <Icon type="Undo" />
                 </IconButton>
               )
@@ -122,6 +122,7 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
   const { name, ...rest } = props;
   const {
     trigger,
+    resetField,
     formState: { errors, isSubmitting },
   } = useFormContext<T>();
 
@@ -140,6 +141,11 @@ export default function ImgEditor<T extends FieldValues, K extends Path<T>>(
       onChange={(v) => {
         onChange(v);
         trigger(filePath as any);
+      }}
+      onUndo={(e) => {
+        ////prevent container dropzone from catching click event
+        e.stopPropagation();
+        resetField(name);
       }}
       error={get(errors, filePath)?.message}
       disabled={isSubmitting}

--- a/src/components/ImgEditor/index.ts
+++ b/src/components/ImgEditor/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./ImgEditor";
+export { default, ControlledImgEditor } from "./ImgEditor";
 export * from "./types";

--- a/src/components/ImgEditor/types.ts
+++ b/src/components/ImgEditor/types.ts
@@ -21,15 +21,15 @@ export type Props<T extends FieldValues, K extends Path<T>> = {
    * Maximum image size in bytes
    */
   maxSize?: number;
+  rounded?: boolean;
 };
 
-export type ControlledProps = {
+export interface ControlledProps extends Omit<Props<any, any>, "name"> {
   value: ImgLink;
+  /** optional: also run some validation */
   onChange: (value: ImgLink) => void;
-  accept: ImageMIMEType[];
-  aspect: [number, number];
-  maxSize?: number;
+  onUndo: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   classes?: Classes;
   disabled?: boolean;
   error?: string;
-};
+}

--- a/src/components/ImgEditor/types.ts
+++ b/src/components/ImgEditor/types.ts
@@ -22,3 +22,14 @@ export type Props<T extends FieldValues, K extends Path<T>> = {
    */
   maxSize?: number;
 };
+
+export type ControlledProps = {
+  value: ImgLink;
+  onChange: (value: ImgLink) => void;
+  accept: ImageMIMEType[];
+  aspect: [number, number];
+  maxSize?: number;
+  classes?: Classes;
+  disabled?: boolean;
+  error?: string;
+};

--- a/src/components/ImgEditor/useImgEditor.ts
+++ b/src/components/ImgEditor/useImgEditor.ts
@@ -13,6 +13,8 @@ export default function useImgEditor({
 }: ControlledProps) {
   const { showModal } = useModalContext();
 
+  const roundedClasses = rounded ? "[&_.cropper-view-box]:rounded-full" : "";
+
   const handleCropResult = (cropped: File) =>
     onChange({
       file: cropped,
@@ -47,9 +49,7 @@ export default function useImgEditor({
       file: newFile,
       aspect,
       onSave: handleCropResult,
-      classes: rounded
-        ? "[&_.cropper-crop-box,_.cropper-view-box]:border-full"
-        : "",
+      classes: roundedClasses,
     });
   };
 
@@ -60,6 +60,7 @@ export default function useImgEditor({
       file: curr.file ?? new File([], "default file"),
       aspect,
       onSave: handleCropResult,
+      classes: roundedClasses,
     });
   };
 

--- a/src/components/ImgEditor/useImgEditor.ts
+++ b/src/components/ImgEditor/useImgEditor.ts
@@ -1,5 +1,5 @@
 import { useModalContext } from "contexts/ModalContext";
-import { type MouseEventHandler, useRef } from "react";
+import type { MouseEventHandler } from "react";
 import type { DropzoneOptions } from "react-dropzone";
 import ImgCropper from "./ImgCropper";
 import type { ControlledProps } from "./types";
@@ -9,9 +9,9 @@ export default function useImgEditor({
   onChange,
   aspect,
   accept,
+  rounded,
 }: ControlledProps) {
   const { showModal } = useModalContext();
-  const initRef = useRef(curr);
 
   const handleCropResult = (cropped: File) =>
     onChange({
@@ -46,8 +46,10 @@ export default function useImgEditor({
     showModal(ImgCropper, {
       file: newFile,
       aspect,
-      type: newFile.type,
       onSave: handleCropResult,
+      classes: rounded
+        ? "[&_.cropper-crop-box,_.cropper-view-box]:border-full"
+        : "",
     });
   };
 
@@ -61,15 +63,5 @@ export default function useImgEditor({
     });
   };
 
-  const handleReset: MouseEventHandler<HTMLButtonElement> = (e) => {
-    //prevent container dropzone from catching click event
-    e.stopPropagation();
-    onChange(initRef.current);
-  };
-
-  return {
-    onDrop,
-    handleOpenCropper,
-    handleReset,
-  };
+  return { onDrop, handleOpenCropper };
 }

--- a/src/helpers/uploadFiles.ts
+++ b/src/helpers/uploadFiles.ts
@@ -3,7 +3,7 @@ import { version as v } from "services/helpers";
 import { isEmpty } from "./isEmpty";
 import { jwtToken } from "./jwt-token";
 
-export type Bucket = "endow-profiles" | "endow-reg";
+export type Bucket = "endow-profiles" | "endow-reg" | "bg-user";
 export const bucketURL = "s3.amazonaws.com";
 
 const SPACES = /\s+/g;

--- a/src/pages/UserDashboard/EditProfile/Form.tsx
+++ b/src/pages/UserDashboard/EditProfile/Form.tsx
@@ -73,8 +73,6 @@ export default function Form(props: Props) {
     },
   });
 
-  console.log({ errors });
-
   const { field: prefCurrency } = useController<FV, "prefCurrency">({
     control,
     name: "prefCurrency",

--- a/src/pages/UserDashboard/EditProfile/Form.tsx
+++ b/src/pages/UserDashboard/EditProfile/Form.tsx
@@ -5,7 +5,7 @@ import { NativeField as Field, Label, Form as _Form } from "components/form";
 import { useErrorContext } from "contexts/ErrorContext";
 import { useModalContext } from "contexts/ModalContext";
 import { cleanObject } from "helpers/cleanObject";
-import { uploadFiles } from "helpers/uploadFiles";
+import { getFullURL, uploadFiles } from "helpers/uploadFiles";
 import { useEditUserMutation } from "services/aws/users";
 import { updateUserAttributes } from "slices/auth";
 import { useSetter } from "store/accessors";
@@ -37,9 +37,11 @@ export default function Form(props: Props) {
               type: "loading",
               children: "Uploading avatar...",
             });
-            const url = await uploadFiles([file], "bg-user");
+            const baseUrl = await uploadFiles([file], "bg-user");
+            if (!baseUrl) return closeModal();
+
             closeModal();
-            return url;
+            return getFullURL(baseUrl, file.name);
           })();
 
           const update: Required<UserAttributes> = {

--- a/src/pages/UserDashboard/EditProfile/Form.tsx
+++ b/src/pages/UserDashboard/EditProfile/Form.tsx
@@ -1,43 +1,16 @@
-import { yupResolver } from "@hookform/resolvers/yup";
 import CurrencySelector from "components/CurrencySelector";
-import type { ImgLink } from "components/ImgEditor";
 import { ControlledImgEditor as ImgEditor } from "components/ImgEditor";
 import Prompt from "components/Prompt";
 import { NativeField as Field, Label, Form as _Form } from "components/form";
 import { useErrorContext } from "contexts/ErrorContext";
 import { useModalContext } from "contexts/ModalContext";
 import { cleanObject } from "helpers/cleanObject";
-import { useController, useForm } from "react-hook-form";
-import { genFileSchema } from "schemas/file";
-import { schema } from "schemas/shape";
-import type { SchemaShape } from "schemas/types";
 import { useEditUserMutation } from "services/aws/users";
 import { updateUserAttributes } from "slices/auth";
 import { useSetter } from "store/accessors";
-import type { AuthenticatedUser } from "types/auth";
 import type { UserAttributes } from "types/aws";
-import type { DetailedCurrency } from "types/components";
-import type { ImageMIMEType } from "types/lists";
-import { object, string } from "yup";
-import type { FV } from "./types";
-
-type Props = {
-  currencies: DetailedCurrency[];
-  defaultCurr?: DetailedCurrency;
-  user: AuthenticatedUser;
-};
-
-export const AVATAR_MAX_SIZE_BYTES = 1e6;
-export const AVATAR_MIME_TYPE: ImageMIMEType[] = [
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-  "image/svg+xml",
-];
-
-const fileObj = object<any, SchemaShape<ImgLink>>({
-  file: genFileSchema(AVATAR_MAX_SIZE_BYTES, AVATAR_MIME_TYPE),
-});
+import type { Props } from "./types";
+import { AVATAR_MAX_SIZE_BYTES, AVATAR_MIME_TYPE, useRhf } from "./useRhf";
 
 export default function Form(props: Props) {
   const dispatch = useSetter();
@@ -45,52 +18,16 @@ export default function Form(props: Props) {
   const { showModal } = useModalContext();
   const [editUser] = useEditUserMutation();
 
-  const {
-    register,
-    control,
-    reset,
-    handleSubmit,
-    resetField,
-    trigger,
-    formState: { isSubmitting, isDirty, errors },
-  } = useForm({
-    resolver: yupResolver(
-      schema<FV>({
-        firstName: string().required("required"),
-        lastName: string().required("required"),
-        avatar: fileObj,
-      })
-    ),
-    defaultValues: {
-      prefCurrency: props.defaultCurr || { code: "usd", min: 1, rate: 1 },
-      firstName: props.user.firstName ?? "",
-      lastName: props.user.lastName ?? "",
-      avatar: {
-        name: "",
-        preview: props.user.avatarUrl ?? "",
-        publicUrl: props.user.avatarUrl ?? "",
-      },
-    },
-  });
-
-  const { field: prefCurrency } = useController<FV, "prefCurrency">({
-    control,
-    name: "prefCurrency",
-  });
-
-  const { field: avatar } = useController<FV, "avatar">({
-    control,
-    name: "avatar",
-  });
+  const rhf = useRhf(props);
 
   return (
     <_Form
-      disabled={isSubmitting}
+      disabled={rhf.isSubmitting}
       onReset={(e) => {
         e.preventDefault();
-        reset();
+        rhf.reset();
       }}
-      onSubmit={handleSubmit(async (fv) => {
+      onSubmit={rhf.handleSubmit(async (fv) => {
         try {
           const update: Required<UserAttributes> = {
             givenName: fv.firstName,
@@ -110,19 +47,21 @@ export default function Form(props: Props) {
           handleError(err, { context: "updating settings" });
         }
       })}
-      className="w-full max-w-4xl justify-self-center grid content-start gap-6"
+      className="w-full max-w-4xl justify-self-center content-start"
     >
-      <Label className="-mb-4">Avatar</Label>
+      <h2 className="text-3xl mb-6">User Profile</h2>
+
+      <Label className="text-base font-medium mb-2">Avatar</Label>
       <ImgEditor
         rounded
-        value={avatar.value}
+        value={rhf.avatar.value}
         onChange={(v) => {
-          avatar.onChange(v);
-          trigger("avatar.file");
+          rhf.avatar.onChange(v);
+          rhf.trigger("avatar.file");
         }}
         onUndo={(e) => {
           e.stopPropagation();
-          resetField("avatar");
+          rhf.resetField("avatar");
         }}
         accept={AVATAR_MIME_TYPE}
         aspect={[1, 1]}
@@ -131,47 +70,48 @@ export default function Form(props: Props) {
           dropzone: "w-60 aspect-[1/1] rounded-full",
         }}
         maxSize={AVATAR_MAX_SIZE_BYTES}
-        error={errors.avatar?.file?.message}
+        error={rhf.errors.avatar?.file?.message}
       />
 
       <CurrencySelector
         currencies={props.currencies}
         label="Default currency"
-        onChange={prefCurrency.onChange}
-        value={prefCurrency.value}
-        classes={{ label: "text-sm" }}
+        onChange={rhf.prefCurrency.onChange}
+        value={rhf.prefCurrency.value}
+        classes={{ label: "font-medium text-base", container: "mt-16" }}
         required
       />
 
       <Field
-        {...register("firstName")}
+        {...rhf.register("firstName")}
         label="First name"
         placeholder="First name"
-        classes="mt-8"
+        classes={{ container: "mt-16", label: "text-base font-medium" }}
         required
-        error={errors.firstName?.message}
+        error={rhf.errors.firstName?.message}
       />
 
       <Field
-        {...register("lastName")}
+        {...rhf.register("lastName")}
         label="Last name"
         placeholder="Last name"
         required
-        error={errors.lastName?.message}
+        classes={{ container: "mt-4", label: "text-base font-medium" }}
+        error={rhf.errors.lastName?.message}
       />
 
-      <div className="flex gap-3">
+      <div className="flex gap-3 mt-8">
         <button
           type="reset"
           className="px-6 btn-outline-filled text-sm"
-          disabled={!isDirty}
+          disabled={!rhf.isDirty}
         >
           Reset changes
         </button>
         <button
           type="submit"
           className="px-6 btn-blue text-sm"
-          disabled={!isDirty}
+          disabled={!rhf.isDirty}
         >
           Submit changes
         </button>

--- a/src/pages/UserDashboard/EditProfile/Form.tsx
+++ b/src/pages/UserDashboard/EditProfile/Form.tsx
@@ -1,19 +1,24 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import CurrencySelector from "components/CurrencySelector";
+import type { ImgLink } from "components/ImgEditor";
+import { ControlledImgEditor as ImgEditor } from "components/ImgEditor";
 import Prompt from "components/Prompt";
-import { Field, Form as FormWithContext } from "components/form";
+import { NativeField as Field, Label, Form as _Form } from "components/form";
 import { useErrorContext } from "contexts/ErrorContext";
 import { useModalContext } from "contexts/ModalContext";
 import { cleanObject } from "helpers/cleanObject";
 import { useController, useForm } from "react-hook-form";
+import { genFileSchema } from "schemas/file";
 import { schema } from "schemas/shape";
+import type { SchemaShape } from "schemas/types";
 import { useEditUserMutation } from "services/aws/users";
 import { updateUserAttributes } from "slices/auth";
 import { useSetter } from "store/accessors";
 import type { AuthenticatedUser } from "types/auth";
 import type { UserAttributes } from "types/aws";
 import type { DetailedCurrency } from "types/components";
-import { string } from "yup";
+import type { ImageMIMEType } from "types/lists";
+import { object, string } from "yup";
 import type { FV } from "./types";
 
 type Props = {
@@ -22,44 +27,67 @@ type Props = {
   user: AuthenticatedUser;
 };
 
+export const AVATAR_MAX_SIZE_BYTES = 1e6;
+export const AVATAR_MIME_TYPE: ImageMIMEType[] = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/svg+xml",
+];
+
+const fileObj = object<any, SchemaShape<ImgLink>>({
+  file: genFileSchema(AVATAR_MAX_SIZE_BYTES, AVATAR_MIME_TYPE),
+});
+
 export default function Form(props: Props) {
   const dispatch = useSetter();
   const { handleError } = useErrorContext();
   const { showModal } = useModalContext();
   const [editUser] = useEditUserMutation();
 
-  const methods = useForm({
+  const {
+    register,
+    control,
+    reset,
+    handleSubmit,
+    resetField,
+    trigger,
+    formState: { isSubmitting, isDirty, errors },
+  } = useForm({
     resolver: yupResolver(
       schema<FV>({
         firstName: string().required("required"),
         lastName: string().required("required"),
+        avatar: fileObj,
       })
     ),
     defaultValues: {
       prefCurrency: props.defaultCurr || { code: "usd", min: 1, rate: 1 },
       firstName: props.user.firstName ?? "",
       lastName: props.user.lastName ?? "",
+      avatar: {
+        name: "",
+        preview: props.user.avatarUrl ?? "",
+        publicUrl: props.user.avatarUrl ?? "",
+      },
     },
   });
 
-  const {
-    control,
-    reset,
-    handleSubmit,
-    formState: { isSubmitting, isDirty },
-  } = methods;
+  console.log({ errors });
 
-  const {
-    field: { value: prefCurrency, onChange: onPrefCurrencyChange },
-  } = useController<FV, "prefCurrency">({
+  const { field: prefCurrency } = useController<FV, "prefCurrency">({
     control,
     name: "prefCurrency",
   });
 
+  const { field: avatar } = useController<FV, "avatar">({
+    control,
+    name: "avatar",
+  });
+
   return (
-    <FormWithContext
+    <_Form
       disabled={isSubmitting}
-      methods={methods}
       onReset={(e) => {
         e.preventDefault();
         reset();
@@ -86,28 +114,52 @@ export default function Form(props: Props) {
       })}
       className="w-full max-w-4xl justify-self-center grid content-start gap-6"
     >
+      <Label className="-mb-4">Avatar</Label>
+      <ImgEditor
+        rounded
+        value={avatar.value}
+        onChange={(v) => {
+          avatar.onChange(v);
+          trigger("avatar.file");
+        }}
+        onUndo={(e) => {
+          e.stopPropagation();
+          resetField("avatar");
+        }}
+        accept={AVATAR_MIME_TYPE}
+        aspect={[1, 1]}
+        classes={{
+          container: "mb-4",
+          dropzone: "w-60 aspect-[1/1] rounded-full",
+        }}
+        maxSize={AVATAR_MAX_SIZE_BYTES}
+        error={errors.avatar?.file?.message}
+      />
+
       <CurrencySelector
         currencies={props.currencies}
         label="Default currency"
-        onChange={onPrefCurrencyChange}
-        value={prefCurrency}
+        onChange={prefCurrency.onChange}
+        value={prefCurrency.value}
         classes={{ label: "text-sm" }}
         required
       />
 
-      <Field<FV>
-        name="firstName"
+      <Field
+        {...register("firstName")}
         label="First name"
         placeholder="First name"
         classes="mt-8"
         required
+        error={errors.firstName?.message}
       />
 
-      <Field<FV>
-        name="lastName"
+      <Field
+        {...register("lastName")}
         label="Last name"
         placeholder="Last name"
         required
+        error={errors.lastName?.message}
       />
 
       <div className="flex gap-3">
@@ -126,6 +178,6 @@ export default function Form(props: Props) {
           Submit changes
         </button>
       </div>
-    </FormWithContext>
+    </_Form>
   );
 }

--- a/src/pages/UserDashboard/EditProfile/types.ts
+++ b/src/pages/UserDashboard/EditProfile/types.ts
@@ -1,7 +1,9 @@
+import type { ImgLink } from "components/ImgEditor";
 import type { CurrencyOption } from "types/components";
 
 export type FV = {
   firstName: string;
   lastName: string;
   prefCurrency: CurrencyOption;
+  avatar: ImgLink;
 };

--- a/src/pages/UserDashboard/EditProfile/types.ts
+++ b/src/pages/UserDashboard/EditProfile/types.ts
@@ -1,9 +1,16 @@
 import type { ImgLink } from "components/ImgEditor";
-import type { CurrencyOption } from "types/components";
+import type { AuthenticatedUser } from "types/auth";
+import type { CurrencyOption, DetailedCurrency } from "types/components";
 
 export type FV = {
   firstName: string;
   lastName: string;
   prefCurrency: CurrencyOption;
   avatar: ImgLink;
+};
+
+export type Props = {
+  currencies: DetailedCurrency[];
+  defaultCurr?: DetailedCurrency;
+  user: AuthenticatedUser;
 };

--- a/src/pages/UserDashboard/EditProfile/useRhf.ts
+++ b/src/pages/UserDashboard/EditProfile/useRhf.ts
@@ -1,0 +1,74 @@
+import { yupResolver } from "@hookform/resolvers/yup";
+import type { ImgLink } from "components/ImgEditor";
+import { useController, useForm } from "react-hook-form";
+import { genFileSchema } from "schemas/file";
+import { schema } from "schemas/shape";
+import type { SchemaShape } from "schemas/types";
+import type { ImageMIMEType } from "types/lists";
+import { object, string } from "yup";
+import type { FV, Props } from "./types";
+
+export const AVATAR_MAX_SIZE_BYTES = 1e6;
+export const AVATAR_MIME_TYPE: ImageMIMEType[] = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/svg+xml",
+];
+
+const fileObj = object<any, SchemaShape<ImgLink>>({
+  file: genFileSchema(AVATAR_MAX_SIZE_BYTES, AVATAR_MIME_TYPE),
+});
+
+export function useRhf(props: Props) {
+  const {
+    register,
+    control,
+    reset,
+    handleSubmit,
+    resetField,
+    trigger,
+    formState: { isSubmitting, isDirty, errors },
+  } = useForm({
+    resolver: yupResolver(
+      schema<FV>({
+        firstName: string().required("required"),
+        lastName: string().required("required"),
+        avatar: fileObj,
+      })
+    ),
+    defaultValues: {
+      prefCurrency: props.defaultCurr || { code: "usd", min: 1, rate: 1 },
+      firstName: props.user.firstName ?? "",
+      lastName: props.user.lastName ?? "",
+      avatar: {
+        name: "",
+        preview: props.user.avatarUrl ?? "",
+        publicUrl: props.user.avatarUrl ?? "",
+      },
+    },
+  });
+
+  const { field: prefCurrency } = useController<FV, "prefCurrency">({
+    control,
+    name: "prefCurrency",
+  });
+
+  const { field: avatar } = useController<FV, "avatar">({
+    control,
+    name: "avatar",
+  });
+
+  return {
+    prefCurrency,
+    avatar,
+    register,
+    handleSubmit,
+    resetField,
+    reset,
+    trigger,
+    isSubmitting,
+    errors,
+    isDirty,
+  };
+}

--- a/src/slices/auth.ts
+++ b/src/slices/auth.ts
@@ -61,6 +61,7 @@ export const loadSession = createAsyncThunk<User, AuthUser | undefined>(
         email: userEmail,
         firstName: userAttributes.givenName,
         lastName: userAttributes.familyName,
+        avatarUrl: userAttributes.avatarUrl,
         prefCurrencyCode: userAttributes.prefCurrencyCode,
         isSigningOut: false,
       };

--- a/src/slices/auth.ts
+++ b/src/slices/auth.ts
@@ -85,7 +85,7 @@ const auth = createSlice({
     },
     updateUserAttributes: (state, { payload }: PayloadAction<UserUpdate>) => {
       if (userIsSignedIn(state.user)) {
-        const { familyName, givenName, prefCurrencyCode } = payload;
+        const { familyName, givenName, prefCurrencyCode, avatarUrl } = payload;
         if (givenName) {
           state.user.firstName = givenName;
         }
@@ -94,6 +94,9 @@ const auth = createSlice({
         }
         if (prefCurrencyCode) {
           state.user.prefCurrencyCode = prefCurrencyCode;
+        }
+        if (avatarUrl) {
+          state.user.avatarUrl = avatarUrl;
         }
       }
     },

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -6,6 +6,7 @@ export type AuthenticatedUser = {
   email: string;
   firstName?: string;
   lastName?: string;
+  avatarUrl?: string;
   isSigningOut: boolean;
   /** lowercase */
   prefCurrencyCode?: string;

--- a/src/types/aws/ap/index.ts
+++ b/src/types/aws/ap/index.ts
@@ -208,6 +208,7 @@ export type UserAttributes = {
   familyName: string;
   givenName: string;
   prefCurrencyCode?: string;
+  avatarUrl?: string;
 };
 
 export type UserUpdate = Partial<UserAttributes>;


### PR DESCRIPTION
Towards BG-1456
## Explanation of the solution
* user icon replaced with actual avatar if available
<img width="531" alt="image" src="https://github.com/user-attachments/assets/0899e769-b15b-4e37-9aa2-db7ae9cb14dd">

* user can edit avatar, wiring per https://github.com/AngelProtocolFinance/devops/pull/658
<img width="617" alt="image" src="https://github.com/user-attachments/assets/57e55746-986d-417b-b4d1-dd427ef5902f">
<img width="966" alt="image" src="https://github.com/user-attachments/assets/05131f32-f09f-4817-9d2c-b958877b4505">

### Others
* extract react-hook-form from ImgEditor
* remove wrapper context in `EditProfile` form 


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
