### PR TITLE
Terms move from page to checkout 

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -47,6 +47,7 @@
         "noSwitchDeclarations": "off",
         "noChildrenProp": "off",
         "noUnusedVariables": "warn",
+        "noUnusedImports":"warn",
         "useJsxKeyInIterable": "off"
       },
       "a11y": {

--- a/src/components/Copier/Copier.test.tsx
+++ b/src/components/Copier/Copier.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, test, vi } from "vitest";
 import Copier from "./Copier";

--- a/src/components/DonationTerms.tsx
+++ b/src/components/DonationTerms.tsx
@@ -1,15 +1,19 @@
 import { APP_NAME } from "constants/env";
 import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
-import type ExtLink from "./ExtLink";
+import ExtLink from "./ExtLink";
 
 interface Props {
   classes?: string;
   endowName: string;
-  Link: typeof ExtLink;
+  Link?: typeof ExtLink;
 }
-export function DonationTerms({ classes = "", endowName, Link: A }: Props) {
+export function DonationTerms({
+  classes = "",
+  endowName,
+  Link: A = Link,
+}: Props) {
   return (
-    <p className={classes}>
+    <p className={`${classes} text-sm leading-normal text-navy-l1`}>
       100% of your donation is tax-deductible to the extent allowed by US law.
       Your donation is made to {APP_NAME}, a tax-exempt US 501(c)(3) charity
       that grants unrestricted funds to {endowName} on your behalf. As a legal
@@ -21,3 +25,12 @@ export function DonationTerms({ classes = "", endowName, Link: A }: Props) {
     </p>
   );
 }
+
+export const Link: typeof ExtLink = ({ className, ...props }) => {
+  return (
+    <ExtLink
+      {...props}
+      className={className + " font-medium hover:underline"}
+    />
+  );
+};

--- a/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
@@ -1,4 +1,5 @@
 import { WalletProvider } from "@terra-money/wallet-provider";
+import { DonationTerms } from "components/DonationTerms";
 import QueryLoader from "components/QueryLoader";
 import { chains } from "constants/chains";
 import WalletContext from "contexts/WalletContext/WalletContext";
@@ -50,6 +51,7 @@ export default function Crypto(props: CryptoSubmitStep) {
       }
     >
       <TerraLoadedCheckout {...props} />
+      <DonationTerms endowName={props.init.recipient.name} classes="mt-5" />
     </Summary>
   );
 }

--- a/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/Crypto.tsx
@@ -1,5 +1,4 @@
 import { WalletProvider } from "@terra-money/wallet-provider";
-import { DonationTerms } from "components/DonationTerms";
 import QueryLoader from "components/QueryLoader";
 import { chains } from "constants/chains";
 import WalletContext from "contexts/WalletContext/WalletContext";
@@ -9,6 +8,7 @@ import { useDonationState } from "../../Context";
 import Summary from "../../common/Summary";
 import { token } from "../../common/Token";
 import type { CryptoSubmitStep } from "../../types";
+import { DonationTerms } from "../DonationTerms";
 import Checkout from "./Checkout";
 
 export default function Crypto(props: CryptoSubmitStep) {

--- a/src/components/donation/Steps/Submit/Crypto/WalletSelection.tsx
+++ b/src/components/donation/Steps/Submit/Crypto/WalletSelection.tsx
@@ -1,4 +1,3 @@
-import type { ChainID } from "types/chain";
 import type { DisconnectedWallet } from "types/wallet";
 import Wallet from "./Wallet";
 

--- a/src/components/donation/Steps/Submit/DAFCheckout/ManualDonation.tsx
+++ b/src/components/donation/Steps/Submit/DAFCheckout/ManualDonation.tsx
@@ -1,3 +1,4 @@
+import { DonationTerms } from "components/DonationTerms";
 import { EMAIL_SUPPORT } from "constants/env";
 import { appRoutes } from "constants/routes";
 import type { DafCheckoutStep } from "../../types";
@@ -62,6 +63,11 @@ export default function ManualDonation(props: DafCheckoutStep) {
       >
         Generate email
       </a>
+
+      <DonationTerms
+        endowName={props.init.recipient.name}
+        classes="border-t border-gray-l4 mt-5 pt-4 "
+      />
     </>
   );
 }

--- a/src/components/donation/Steps/Submit/DAFCheckout/ManualDonation.tsx
+++ b/src/components/donation/Steps/Submit/DAFCheckout/ManualDonation.tsx
@@ -1,7 +1,7 @@
-import { DonationTerms } from "components/DonationTerms";
 import { EMAIL_SUPPORT } from "constants/env";
 import { appRoutes } from "constants/routes";
 import type { DafCheckoutStep } from "../../types";
+import { DonationTerms } from "../DonationTerms";
 
 export default function ManualDonation(props: DafCheckoutStep) {
   const profileUrl = `${window.location.origin}${appRoutes.donate}/${props.init.recipient.id}`;

--- a/src/components/donation/Steps/Submit/DonationTerms.tsx
+++ b/src/components/donation/Steps/Submit/DonationTerms.tsx
@@ -1,17 +1,12 @@
 import { APP_NAME } from "constants/env";
 import { PRIVACY_POLICY, TERMS_OF_USE_DONOR } from "constants/urls";
-import ExtLink from "./ExtLink";
+import ExtLink from "../../../ExtLink";
 
 interface Props {
   classes?: string;
   endowName: string;
-  Link?: typeof ExtLink;
 }
-export function DonationTerms({
-  classes = "",
-  endowName,
-  Link: A = Link,
-}: Props) {
+export function DonationTerms({ classes = "", endowName }: Props) {
   return (
     <p className={`${classes} text-sm leading-normal text-navy-l1`}>
       100% of your donation is tax-deductible to the extent allowed by US law.
@@ -26,7 +21,7 @@ export function DonationTerms({
   );
 }
 
-export const Link: typeof ExtLink = ({ className, ...props }) => {
+const A: typeof ExtLink = ({ className, ...props }) => {
   return (
     <ExtLink
       {...props}

--- a/src/components/donation/Steps/Submit/Stocks.tsx
+++ b/src/components/donation/Steps/Submit/Stocks.tsx
@@ -1,9 +1,9 @@
-import { DonationTerms } from "components/DonationTerms";
 import { EMAIL_SUPPORT } from "constants/env";
 import { appRoutes } from "constants/routes";
 import { useDonationState } from "../Context";
 import BackBtn from "../common/BackBtn";
 import type { StockCheckoutStep } from "../types";
+import { DonationTerms } from "./DonationTerms";
 
 export default function Stocks(props: StockCheckoutStep) {
   const profileUrl = `${window.location.origin}${appRoutes.donate}/${props.init.recipient.id}`;

--- a/src/components/donation/Steps/Submit/Stocks.tsx
+++ b/src/components/donation/Steps/Submit/Stocks.tsx
@@ -1,3 +1,4 @@
+import { DonationTerms } from "components/DonationTerms";
 import { EMAIL_SUPPORT } from "constants/env";
 import { appRoutes } from "constants/routes";
 import { useDonationState } from "../Context";
@@ -65,6 +66,10 @@ export default function Stocks(props: StockCheckoutStep) {
       >
         Generate email
       </a>
+      <DonationTerms
+        endowName={props.init.recipient.name}
+        classes="mt-5 border-t border-gray-l4 pt-4"
+      />
     </div>
   );
 }

--- a/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
@@ -1,6 +1,5 @@
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
-import { DonationTerms } from "components/DonationTerms";
 import { PUBLIC_STRIPE_KEY } from "constants/env";
 import ErrorBoundary from "errors/ErrorBoundary";
 import ErrorTrigger from "errors/ErrorTrigger";
@@ -10,6 +9,7 @@ import { currency } from "../../common/Currency";
 import Summary from "../../common/Summary";
 import { toDonor } from "../../common/constants";
 import type { StripeCheckoutStep } from "../../types";
+import { DonationTerms } from "../DonationTerms";
 import Loader from "../Loader";
 import Checkout from "./Checkout";
 

--- a/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
+++ b/src/components/donation/Steps/Submit/StripeCheckout/StripeCheckout.tsx
@@ -1,5 +1,6 @@
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
+import { DonationTerms } from "components/DonationTerms";
 import { PUBLIC_STRIPE_KEY } from "constants/env";
 import ErrorBoundary from "errors/ErrorBoundary";
 import ErrorTrigger from "errors/ErrorTrigger";
@@ -102,6 +103,7 @@ export default function StripeCheckout(props: StripeCheckoutStep) {
           </Elements>
         )}
       </ErrorBoundary>
+      <DonationTerms endowName={props.init.recipient.name} classes="mt-5" />
     </Summary>
   );
 }

--- a/src/components/donation/Steps/Summary/SummaryForm.test.tsx
+++ b/src/components/donation/Steps/Summary/SummaryForm.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, expectTypeOf, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { FormDonor, Honorary } from "../types";
 import SummaryForm, { type Props } from "./SummaryForm";
 

--- a/src/helpers/uploadFiles.test.ts
+++ b/src/helpers/uploadFiles.test.ts
@@ -1,4 +1,3 @@
-import { APIs } from "constants/urls";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { type Bucket, bucketURL, uploadFiles } from "./uploadFiles";
 

--- a/src/pages/Donate/Content.tsx
+++ b/src/pages/Donate/Content.tsx
@@ -8,7 +8,6 @@ import { PRIVACY_POLICY } from "constants/urls";
 import { memo } from "react";
 import { Link } from "react-router-dom";
 
-import { DonationTerms } from "components/DonationTerms";
 import type { DonationIntent, Endowment } from "types/aws";
 import FAQ from "./FAQ";
 import OrgCard from "./OrgCard";
@@ -62,12 +61,6 @@ function Content({ intent, endowment }: Props) {
         <FAQ
           classes="max-md:px-4 md:col-start-2 md:row-span-5 md:w-[18.875rem]"
           endowId={endowment.id}
-        />
-
-        <DonationTerms
-          Link={A}
-          endowName={endowment.name}
-          classes="max-md:border-t max-md:border-gray-l3 max-md:px-4 max-md:pt-4 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2"
         />
 
         <p className="max-md:px-4 mb-4 max-mbcol-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2">

--- a/src/pages/DonateWidget/Content.tsx
+++ b/src/pages/DonateWidget/Content.tsx
@@ -1,5 +1,3 @@
-import { DonationTerms } from "components/DonationTerms";
-import ExtLink from "components/ExtLink";
 import Seo from "components/Seo";
 import { type DonationRecipient, Steps } from "components/donation";
 import { APP_NAME, BASE_URL } from "constants/env";
@@ -51,20 +49,6 @@ export default function Content({ profile, config, classes = "" }: Props) {
         config={config}
         programId={config.programId}
       />
-      <DonationTerms
-        Link={A}
-        endowName={profile.name}
-        classes="px-4 mb-5 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2"
-      />
     </div>
   );
 }
-
-const A: typeof ExtLink = ({ className, ...props }) => {
-  return (
-    <ExtLink
-      {...props}
-      className={className + " font-medium hover:underline"}
-    />
-  );
-};

--- a/src/pages/Widget/Preview.tsx
+++ b/src/pages/Widget/Preview.tsx
@@ -1,5 +1,4 @@
 import character from "assets/laira/laira-waiving.png";
-import { DonationTerms } from "components/DonationTerms";
 import ExtLink from "components/ExtLink";
 import { DappLogo } from "components/Image";
 import Image from "components/Image/Image";
@@ -75,11 +74,6 @@ export default function Preview({ classes = "", config }: Props) {
             key={JSON.stringify(initState)}
             init={initState}
             className="my-5 @md/preview:w-3/4 border border-gray-l4"
-          />
-          <DonationTerms
-            endowName={endowName}
-            Link={A}
-            classes="px-4 mb-5 col-start-1 text-sm leading-normal text-left text-navy-l1 dark:text-navy-l2"
           />
           <footer className="mt-auto grid place-items-center h-20 w-full bg-[--accent-primary]">
             <DappLogo classes="w-40" color="white" />

--- a/src/pages/Widget/Preview.tsx
+++ b/src/pages/Widget/Preview.tsx
@@ -1,5 +1,4 @@
 import character from "assets/laira/laira-waiving.png";
-import ExtLink from "components/ExtLink";
 import { DappLogo } from "components/Image";
 import Image from "components/Image/Image";
 import { type DonationState, Steps, initDetails } from "components/donation";
@@ -83,12 +82,3 @@ export default function Preview({ classes = "", config }: Props) {
     </section>
   );
 }
-
-const A: typeof ExtLink = ({ className, ...props }) => {
-  return (
-    <ExtLink
-      {...props}
-      className={className + " font-medium hover:underline"}
-    />
-  );
-};


### PR DESCRIPTION
## Explanation of the solution
* move T&C to each checkout page
sample: stocks
<img width="846" alt="image" src="https://github.com/user-attachments/assets/1e4fcc52-eafd-4c50-9c6d-77f392ae3934">

* move `DonationTerms` component closer to `/Submit` directory


## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
