### PR TITLE
Auth redirect

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,10 +1,19 @@
 import * as Sentry from "@sentry/react";
+import { Hub } from "aws-amplify/utils";
 import { appRoutes, donateWidgetRoutes } from "constants/routes";
 import ModalContext from "contexts/ModalContext";
 import useScrollTop from "hooks/useScrollTop";
-import { lazy } from "react";
-import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+import { lazy, useEffect } from "react";
+import {
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
 import { usePingQuery } from "services/aws/aws";
+import * as auth from "slices/auth";
+import { useSetter } from "store/accessors";
 import Layout from "./Layout";
 
 const Admin = lazy(() => import("pages/Admin"));
@@ -47,6 +56,33 @@ export default function App() {
   usePingQuery({}, { pollingInterval: 5 * 60 * 60 * 1000 });
   const location = useLocation();
   useScrollTop(location.pathname);
+
+  const dispatch = useSetter();
+  const navigate = useNavigate();
+  useEffect(() => {
+    dispatch(auth.loadSession());
+    const unsubscribe = Hub.listen("auth", async ({ payload }) => {
+      switch (payload.event) {
+        case "signedIn":
+          dispatch(auth.loadSession(payload.data));
+          break;
+        case "signedOut":
+          dispatch(auth.reset());
+          break;
+        case "tokenRefresh":
+          dispatch(auth.loadSession());
+          break;
+        case "tokenRefresh_failure":
+          dispatch(auth.reset());
+          break;
+        case "customOAuthState":
+          navigate(appRoutes.auth_redirector, { state: payload.data });
+      }
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [dispatch, navigate]);
 
   const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 

--- a/src/components/form/Input.tsx
+++ b/src/components/form/Input.tsx
@@ -1,35 +1,23 @@
 import Icon, { type IconType } from "components/Icon";
 import type { Classes } from "components/form/types";
 import { unpack } from "helpers";
-import type { HTMLInputTypeAttribute, InputHTMLAttributes } from "react";
-import {
-  type FieldValues,
-  type Path,
-  get,
-  useFormContext,
-} from "react-hook-form";
+import { type InputHTMLAttributes, forwardRef } from "react";
+
 import { fieldClasses } from "./constants";
 
-type Props<T extends FieldValues> = {
+type El = HTMLInputElement;
+interface Props extends Omit<InputHTMLAttributes<El>, "type" | "className"> {
   classes?: Classes;
-  name: Path<T>;
-  placeholder: string;
+  error?: string;
   icon?: IconType;
-  autoComplete?: InputHTMLAttributes<HTMLInputTypeAttribute>["autoComplete"];
-};
+}
 
-export function Input<T extends FieldValues>(props: Props<T>) {
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext<T>();
-
-  const errorMsg = get(errors, props.name)?.message;
-
-  const { container, input, error } = unpack(props.classes);
+export const Input = forwardRef<El, Props>((props, ref) => {
+  const { classes, error, icon, ...rest } = props;
+  const style = unpack(classes);
 
   return (
-    <div className={container}>
+    <div className={style.container}>
       <div
         className={`grid ${
           props.icon ? "grid-cols-[auto_1fr]" : ""
@@ -39,19 +27,18 @@ export function Input<T extends FieldValues>(props: Props<T>) {
           <Icon type={props.icon} className="ml-5 text-navy-l3" size={20} />
         )}
         <input
-          {...register(props.name)}
+          {...rest}
+          ref={ref}
           type="text"
           className={`w-full h-full placeholder:font-medium placeholder:font-heading placeholder:text-navy-l3 max-sm:placeholder:text-sm focus:outline-none bg-transparent ${
             props.icon ? "pr-5" : "px-5"
-          } ${input}`}
-          placeholder={props.placeholder}
-          aria-invalid={!!errorMsg}
-          autoComplete={props.autoComplete}
+          } ${style.input}`}
+          aria-invalid={!!error}
         />
       </div>
-      {errorMsg && (
-        <p className={`text-xs text-red-d3 mt-1.5 ${error}`}>{errorMsg}</p>
+      {error && (
+        <p className={`text-xs text-red-d3 mt-1.5 ${error}`}>{error}</p>
       )}
     </div>
   );
-}
+});

--- a/src/components/form/PasswordInput.tsx
+++ b/src/components/form/PasswordInput.tsx
@@ -1,38 +1,26 @@
 import Icon from "components/Icon";
-import { useState } from "react";
-import {
-  type FieldValues,
-  type Path,
-  get,
-  useFormContext,
-} from "react-hook-form";
+import { type InputHTMLAttributes, forwardRef, useState } from "react";
 import { fieldClasses } from "./constants";
 
-type Props<T extends FieldValues> = {
-  name: Path<T>;
-  placeholder?: string;
-};
+type El = HTMLInputElement;
+interface Props extends Omit<InputHTMLAttributes<El>, "className" | "type"> {
+  error?: string;
+}
 
-export function PasswordInput<T extends FieldValues>(props: Props<T>) {
+export const PasswordInput = forwardRef<El, Props>((props, ref) => {
+  const { error, ...rest } = props;
   const [isPasswordShown, setIsPasswordShown] = useState(false);
-
-  const {
-    register,
-    formState: { errors },
-  } = useFormContext<T>();
-
-  const errorMsg = get(errors, props.name)?.message;
 
   return (
     <div>
       <div className={`grid grid-cols-[auto_1fr_auto] px-5 ${fieldClasses}`}>
         <Icon type="Padlock" className="text-navy-l3" size={20} />
         <input
-          {...register(props.name)}
+          ref={ref}
+          {...rest}
           type={isPasswordShown ? "text" : "password"}
           className="w-full h-full placeholder:font-medium placeholder:font-heading placeholder:text-navy-l3 max-sm:placeholder:text-sm focus:outline-none bg-transparent"
-          placeholder={props.placeholder}
-          aria-invalid={!!errorMsg}
+          aria-invalid={!!error}
         />
         <button
           type="button"
@@ -42,7 +30,7 @@ export function PasswordInput<T extends FieldValues>(props: Props<T>) {
           <Icon type={isPasswordShown ? "EyeSlashed" : "Eye"} size={20} />
         </button>
       </div>
-      {errorMsg && <p className="text-xs text-red mt-1.5">{errorMsg}</p>}
+      {error && <p className="text-xs text-red mt-1.5">{error}</p>}
     </div>
   );
-}
+});

--- a/src/components/form/PasswordInput.tsx
+++ b/src/components/form/PasswordInput.tsx
@@ -3,7 +3,8 @@ import { type InputHTMLAttributes, forwardRef, useState } from "react";
 import { fieldClasses } from "./constants";
 
 type El = HTMLInputElement;
-interface Props extends Omit<InputHTMLAttributes<El>, "className" | "type"> {
+interface Props
+  extends Omit<InputHTMLAttributes<El>, "className" | "type" | "autoComplete"> {
   error?: string;
 }
 
@@ -19,6 +20,7 @@ export const PasswordInput = forwardRef<El, Props>((props, ref) => {
           ref={ref}
           {...rest}
           type={isPasswordShown ? "text" : "password"}
+          autoComplete="current-password"
           className="w-full h-full placeholder:font-medium placeholder:font-heading placeholder:text-navy-l3 max-sm:placeholder:text-sm focus:outline-none bg-transparent"
           aria-invalid={!!error}
         />

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,6 +1,5 @@
 import type { CognitoGroup } from "types/auth";
 
-export const OAUTH_PATH_STORAGE_KEY = "OATH_ORIGIN";
 export const TEMP_JWT = "__JWT__";
 
 export const groups: { [G in CognitoGroup]: G } = {

--- a/src/helpers/getAuthRedirect.ts
+++ b/src/helpers/getAuthRedirect.ts
@@ -18,15 +18,13 @@ interface SignUpOpts {
 }
 
 export function getAuthRedirect(
-  signInRouteState: SignInRouteState | undefined,
+  fromState: SignInRouteState | undefined,
   signupOpts?: SignUpOpts
 ): AuthRedirect {
-  const search = signInRouteState?.search || "";
+  const search = fromState?.search || "";
   const pathname =
-    signupOpts &&
-    signupOpts.isNpo &&
-    signInRouteState?.from === appRoutes.register
+    signupOpts && signupOpts.isNpo && fromState?.from === appRoutes.register
       ? `${appRoutes.register}/${regRoutes.welcome}`
-      : signInRouteState?.from || "/marketplace";
-  return { path: pathname, search, data: signInRouteState?.data };
+      : fromState?.from || "/marketplace";
+  return { path: pathname, search, data: fromState?.data };
 }

--- a/src/helpers/getAuthRedirect.ts
+++ b/src/helpers/getAuthRedirect.ts
@@ -22,9 +22,19 @@ export function getAuthRedirect(
   signupOpts?: SignUpOpts
 ): AuthRedirect {
   const search = fromState?.search || "";
-  const pathname =
-    signupOpts && signupOpts.isNpo && fromState?.from === appRoutes.register
-      ? `${appRoutes.register}/${regRoutes.welcome}`
-      : fromState?.from || "/marketplace";
-  return { path: pathname, search, data: fromState?.data };
+  const data = fromState?.data;
+
+  if (fromState?.from === appRoutes.register) {
+    return { path: `${appRoutes.register}/${regRoutes.welcome}`, search, data };
+  }
+
+  if (signupOpts?.isNpo) {
+    return { path: appRoutes.register, search, data };
+  }
+
+  return {
+    path: fromState?.from || "/marketplace",
+    search,
+    data: fromState?.data,
+  };
 }

--- a/src/helpers/getAuthRedirect.ts
+++ b/src/helpers/getAuthRedirect.ts
@@ -6,22 +6,27 @@ import type { SignInRouteState } from "types/auth";
  * @param isSigningUp defaults to `true`
  */
 
-type Return = {
-  redirectPath: {
-    pathname: string;
-    search: string;
-  };
+interface AuthRedirect {
+  path: string;
+  search: string;
   data?: unknown;
-};
+}
 
-export function determineAuthRedirectPath(
+/** only provide if user is signing up */
+interface SignUpOpts {
+  isNpo: boolean;
+}
+
+export function getAuthRedirect(
   signInRouteState: SignInRouteState | undefined,
-  { isSigningUp } = { isSigningUp: true }
-): Return {
+  signupOpts?: SignUpOpts
+): AuthRedirect {
   const search = signInRouteState?.search || "";
   const pathname =
-    isSigningUp && signInRouteState?.from === appRoutes.register
+    signupOpts &&
+    signupOpts.isNpo &&
+    signInRouteState?.from === appRoutes.register
       ? `${appRoutes.register}/${regRoutes.welcome}`
       : signInRouteState?.from || "/marketplace";
-  return { redirectPath: { pathname, search }, data: signInRouteState?.data };
+  return { path: pathname, search, data: signInRouteState?.data };
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,6 +1,6 @@
 export * from "./createNavLinkStyler";
 export * from "./decimal";
-export * from "./determineAuthRedirectPath";
+export * from "./getAuthRedirect";
 export * from "./evm";
 export * from "./getFilePreviews";
 export * from "./getTxUrl";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,8 @@ import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 import { store } from "store/store";
 import "./index.css";
+import { Amplify } from "aws-amplify";
+import amplifyConfig from "constants/aws";
 
 //set theme immediately, so even suspense loaders and can use it
 // NOTE: Turning off option for Dark theme for now
@@ -20,6 +22,8 @@ const LoaderComponent = () => (
 
 const container = document.getElementById("root");
 const root = createRoot(container as Element);
+
+Amplify.configure(amplifyConfig);
 
 Sentry.init({
   dsn: process.env.PUBLIC_SENTRY_DSN,

--- a/src/pages/OAuthRedirector.tsx
+++ b/src/pages/OAuthRedirector.tsx
@@ -9,6 +9,10 @@ export default function OAuthRedirector() {
     ? JSON.parse(location.state)
     : null;
 
+  /** when provider (`A.`) redirects back to our app thru `/oauth-redirector` it doesn't pass `state`
+   * `A.` - Amplify is configured in src/index.tsx
+   *  App.tsx listens to `auth.customOAuthState` event and navigates to `/oauth-redirector`, this time with `state`
+   */
   if (!state) {
     return (
       <LoaderRing

--- a/src/pages/OAuthRedirector.tsx
+++ b/src/pages/OAuthRedirector.tsx
@@ -1,11 +1,11 @@
 import LoaderRing from "components/LoaderRing";
 import { Navigate, useLocation } from "react-router-dom";
-import type { StoredRouteState } from "types/auth";
+import type { OAuthState } from "types/auth";
 
 export default function OAuthRedirector() {
   const location = useLocation();
 
-  const state: StoredRouteState | null = location.state
+  const state: OAuthState | null = location.state
     ? JSON.parse(location.state)
     : null;
 

--- a/src/pages/OAuthRedirector.tsx
+++ b/src/pages/OAuthRedirector.tsx
@@ -1,16 +1,23 @@
-import { OAUTH_PATH_STORAGE_KEY } from "constants/auth";
-import { Navigate } from "react-router-dom";
+import LoaderRing from "components/LoaderRing";
+import { Navigate, useLocation } from "react-router-dom";
 import type { StoredRouteState } from "types/auth";
 
 export default function OAuthRedirector() {
-  const retrieved: StoredRouteState | null = (() => {
-    try {
-      const item = localStorage.getItem(OAUTH_PATH_STORAGE_KEY);
-      return item && JSON.parse(item);
-    } catch (_) {
-      return null;
-    }
-  })();
-  const { pathname = "/", data } = retrieved || {};
+  const location = useLocation();
+
+  const state: StoredRouteState | null = location.state
+    ? JSON.parse(location.state)
+    : null;
+
+  if (!state) {
+    return (
+      <LoaderRing
+        thickness={10}
+        classes={{ container: "w-32 place-self-center" }}
+      />
+    );
+  }
+
+  const { pathname = "/", data } = state || {};
   return <Navigate to={pathname} state={data} />;
 }

--- a/src/pages/ResetPassword/InitForm.tsx
+++ b/src/pages/ResetPassword/InitForm.tsx
@@ -21,8 +21,9 @@ export default function InitForm(props: Props) {
     ),
   });
   const {
+    register,
     handleSubmit,
-    formState: { isSubmitting },
+    formState: { isSubmitting, errors },
   } = methods;
 
   type FV = typeof methods extends UseFormReturn<infer U> ? U : never;
@@ -61,7 +62,6 @@ export default function InitForm(props: Props) {
     <Form
       className="grid w-full max-w-md px-6 sm:px-7 py-7 sm:py-8 bg-white border border-gray-l4 rounded-2xl"
       disabled={isSubmitting}
-      methods={methods}
       onSubmit={handleSubmit(submit)}
     >
       <h3 className="text-center text-xl sm:text-2xl font-bold text-navy-d4">
@@ -71,11 +71,12 @@ export default function InitForm(props: Props) {
         Enter your registered email to reset password
       </p>
 
-      <Input<FV>
-        name="email"
+      <Input
+        {...register("email")}
         placeholder="Email address"
         classes={{ container: "mt-6" }}
         icon="Email"
+        error={errors.email?.message}
       />
 
       <button

--- a/src/pages/ResetPassword/SetPasswordForm.tsx
+++ b/src/pages/ResetPassword/SetPasswordForm.tsx
@@ -36,8 +36,9 @@ export default function SetPasswordForm(props: Props) {
     ),
   });
   const {
+    register,
     handleSubmit,
-    formState: { isSubmitting },
+    formState: { isSubmitting, errors },
   } = methods;
 
   type FV = typeof methods extends UseFormReturn<infer U> ? U : never;
@@ -94,7 +95,6 @@ export default function SetPasswordForm(props: Props) {
     <Form
       className="grid w-full max-w-md px-6 sm:px-7 py-7 sm:py-8 bg-white border border-gray-l4 rounded-2xl"
       disabled={isSubmitting || isRequestingNewCode}
-      methods={methods}
       onSubmit={handleSubmit(submit)}
     >
       <h3 className="text-center text-xl sm:text-2xl font-bold text-navy-d4">
@@ -114,10 +114,11 @@ export default function SetPasswordForm(props: Props) {
       </p>
 
       <div className="mt-6 grid gap-3">
-        <Input<FV>
-          name="code"
+        <Input
+          {...register("code")}
           placeholder="Enter 6-digit code"
           autoComplete="one-time-code"
+          error={errors.code?.message}
         />
 
         <span className="mb-3 flex items-center justify-between text-xs sm:text-sm font-medium">
@@ -132,9 +133,14 @@ export default function SetPasswordForm(props: Props) {
           </button>
         </span>
 
-        <PasswordInput<FV> name="password" placeholder="New Password" />
-        <PasswordInput<FV>
-          name="passwordConfirmation"
+        <PasswordInput
+          {...register("password")}
+          error={errors.password?.message}
+          placeholder="New Password"
+        />
+        <PasswordInput
+          {...register("passwordConfirmation")}
+          error={errors.passwordConfirmation?.message}
           placeholder="Confirm New Password"
         />
       </div>

--- a/src/pages/SignUp/ConfirmForm.tsx
+++ b/src/pages/SignUp/ConfirmForm.tsx
@@ -24,8 +24,9 @@ export default function ConfirmForm(props: Props) {
     resolver: yupResolver(object({ code: requiredString })),
   });
   const {
+    register,
     handleSubmit,
-    formState: { isSubmitting },
+    formState: { isSubmitting, errors },
   } = methods;
 
   type FV = typeof methods extends UseFormReturn<infer U> ? U : never;
@@ -77,7 +78,6 @@ export default function ConfirmForm(props: Props) {
     <Form
       className="grid w-full max-w-md px-6 sm:px-7 py-7 sm:py-8 bg-white border border-gray-l4 rounded-2xl"
       disabled={isSubmitting || isRequestingNewCode}
-      methods={methods}
       onSubmit={handleSubmit(submit)}
     >
       <h3 className="text-center text-xl sm:text-2xl font-bold text-navy-d4">
@@ -87,11 +87,12 @@ export default function ConfirmForm(props: Props) {
         You are almost there! 6-digit security code has been sent to{" "}
         <span className="font-medium">{props.codeRecipientEmail.obscured}</span>
       </p>
-      <Input<FV>
-        name="code"
+      <Input
+        {...register("code")}
         placeholder="Enter 6-digit code"
         classes={{ container: "my-6" }}
         autoComplete="one-time-code"
+        error={errors.code?.message}
       />
 
       <span className="flex items-center justify-between text-xs sm:text-sm font-medium">

--- a/src/pages/SignUp/SignupForm/SignupForm.tsx
+++ b/src/pages/SignUp/SignupForm/SignupForm.tsx
@@ -8,12 +8,12 @@ import { Separator } from "components/Separator";
 import { Form, Input, PasswordInput } from "components/form";
 import { appRoutes } from "constants/routes";
 import { useErrorContext } from "contexts/ErrorContext";
-import { determineAuthRedirectPath } from "helpers";
+import { getAuthRedirect } from "helpers";
 import { useController, useForm } from "react-hook-form";
 import { Link, Navigate, useLocation } from "react-router-dom";
 import { password, requiredString } from "schemas/string";
 import { useGetter } from "store/accessors";
-import type { StoredRouteState } from "types/auth";
+import type { OAuthState } from "types/auth";
 import { mixed, object } from "yup";
 import type { FormValues, StateSetter, UserType } from "../types";
 import UserTypeSelector from "./UserTypeSelector";
@@ -46,7 +46,9 @@ export default function SignupForm(props: Props) {
   const { field: userType } = useController({ name: "userType", control });
 
   const { state } = useLocation();
-  const { redirectPath, data } = determineAuthRedirectPath(state);
+  const redirect = getAuthRedirect(state, {
+    isNpo: userType.value === "non-profit",
+  });
   const currUser = useGetter((state) => state.auth.user);
 
   if (currUser === "loading" || currUser?.isSigningOut) {
@@ -54,7 +56,7 @@ export default function SignupForm(props: Props) {
   }
 
   if (currUser) {
-    return <Navigate to={redirectPath} replace />;
+    return <Navigate to={redirect.path} replace />;
   }
 
   async function submit(fv: FormValues) {
@@ -115,9 +117,9 @@ export default function SignupForm(props: Props) {
           className="flex-center btn-outline-2 gap-2 h-12 sm:h-[52px] mt-6 border-[0.8px]"
           type="button"
           onClick={() => {
-            const stored: StoredRouteState = {
-              pathname: redirectPath.pathname,
-              data,
+            const stored: OAuthState = {
+              pathname: redirect.path,
+              data: redirect.data,
             };
             signInWithRedirect({
               provider: "Google",

--- a/src/pages/SignUp/SignupForm/SignupForm.tsx
+++ b/src/pages/SignUp/SignupForm/SignupForm.tsx
@@ -33,6 +33,7 @@ export default function SignupForm(props: Props) {
     register,
     formState: { isSubmitting, errors },
     handleSubmit,
+    trigger,
     control,
   } = useForm<FormValues>({
     resolver: yupResolver(
@@ -120,7 +121,10 @@ export default function SignupForm(props: Props) {
         <button
           className="flex-center btn-outline-2 gap-2 h-12 sm:h-[52px] mt-6 border-[0.8px]"
           type="button"
-          onClick={() => {
+          onClick={async () => {
+            const valid = await trigger("userType");
+            if (!valid) return;
+
             const stored: OAuthState = {
               pathname: redirect.path,
               data: redirect.data,

--- a/src/pages/SignUp/SignupForm/SignupForm.tsx
+++ b/src/pages/SignUp/SignupForm/SignupForm.tsx
@@ -152,6 +152,7 @@ export default function SignupForm(props: Props) {
           </div>
           <Input
             {...register("email")}
+            autoComplete="username"
             placeholder="Email address"
             icon="Email"
             error={errors.email?.message}

--- a/src/pages/SignUp/SignupForm/SignupForm.tsx
+++ b/src/pages/SignUp/SignupForm/SignupForm.tsx
@@ -24,6 +24,10 @@ type Props = {
 };
 
 export default function SignupForm(props: Props) {
+  const location = useLocation();
+  const fromState: SignInRouteState | undefined = location.state;
+  const isRegistrant = fromState?.from === appRoutes.register;
+
   const { handleError, displayError } = useErrorContext();
   const {
     register,
@@ -184,7 +188,7 @@ export default function SignupForm(props: Props) {
           Already have an account?
           <Link
             to={appRoutes.signin}
-            state={state}
+            state={fromState}
             className="text-blue-d1 hover:text-blue active:text-blue-d2 aria-disabled:text-gray font-medium underline"
             aria-disabled={isSubmitting}
           >

--- a/src/pages/SignUp/SignupForm/SignupForm.tsx
+++ b/src/pages/SignUp/SignupForm/SignupForm.tsx
@@ -6,7 +6,6 @@ import Image from "components/Image";
 import LoaderRing from "components/LoaderRing";
 import { Separator } from "components/Separator";
 import { Form, Input, PasswordInput } from "components/form";
-import { OAUTH_PATH_STORAGE_KEY } from "constants/auth";
 import { appRoutes } from "constants/routes";
 import { useErrorContext } from "contexts/ErrorContext";
 import { determineAuthRedirectPath } from "helpers";
@@ -120,11 +119,10 @@ export default function SignupForm(props: Props) {
               pathname: redirectPath.pathname,
               data,
             };
-            localStorage.setItem(
-              OAUTH_PATH_STORAGE_KEY,
-              JSON.stringify(stored)
-            );
-            signInWithRedirect({ provider: "Google" });
+            signInWithRedirect({
+              provider: "Google",
+              customState: JSON.stringify(stored),
+            });
           }}
         >
           <Image src={googleIcon} height={18} width={18} />

--- a/src/pages/SignUp/SignupForm/SignupForm.tsx
+++ b/src/pages/SignUp/SignupForm/SignupForm.tsx
@@ -9,7 +9,7 @@ import { Form, Input, PasswordInput } from "components/form";
 import { appRoutes } from "constants/routes";
 import { useErrorContext } from "contexts/ErrorContext";
 import { determineAuthRedirectPath } from "helpers";
-import { useForm } from "react-hook-form";
+import { useController, useForm } from "react-hook-form";
 import { Link, Navigate, useLocation } from "react-router-dom";
 import { password, requiredString } from "schemas/string";
 import { useGetter } from "store/accessors";
@@ -25,7 +25,12 @@ type Props = {
 
 export default function SignupForm(props: Props) {
   const { handleError, displayError } = useErrorContext();
-  const methods = useForm<FormValues>({
+  const {
+    register,
+    formState: { isSubmitting, errors },
+    handleSubmit,
+    control,
+  } = useForm<FormValues>({
     resolver: yupResolver(
       object({
         email: requiredString.trim().email("invalid email format"),
@@ -38,6 +43,7 @@ export default function SignupForm(props: Props) {
       })
     ),
   });
+  const { field: userType } = useController({ name: "userType", control });
 
   const { state } = useLocation();
   const { redirectPath, data } = determineAuthRedirectPath(state);
@@ -90,16 +96,10 @@ export default function SignupForm(props: Props) {
     }
   }
 
-  const {
-    formState: { isSubmitting },
-    handleSubmit,
-  } = methods;
-
   return (
     <div className="grid justify-items-center gap-3.5">
       <Form
         className="grid w-full max-w-md px-6 sm:px-7 py-7 sm:py-8 bg-white border border-gray-l4 rounded-2xl"
-        methods={methods}
         disabled={isSubmitting}
         onSubmit={handleSubmit(submit)}
       >
@@ -137,24 +137,38 @@ export default function SignupForm(props: Props) {
 
         <div className="grid gap-3">
           <div className="flex gap-3">
-            <Input<FormValues> name="firstName" placeholder="First Name" />
-            <Input<FormValues> name="lastName" placeholder="Last Name" />
+            <Input
+              {...register("firstName")}
+              placeholder="First Name"
+              error={errors.firstName?.message}
+            />
+            <Input
+              {...register("lastName")}
+              placeholder="Last Name"
+              error={errors.lastName?.message}
+            />
           </div>
-          <Input<FormValues>
-            name="email"
+          <Input
+            {...register("email")}
             placeholder="Email address"
             icon="Email"
+            error={errors.email?.message}
           />
-          <PasswordInput<FormValues>
-            name="password"
+          <PasswordInput
+            {...register("password")}
             placeholder="Create password"
+            error={errors.password?.message}
           />
         </div>
 
         <span className="mt-7 mb-3 font-normal max-sm:text-sm">
           You are signing up as
         </span>
-        <UserTypeSelector />
+        <UserTypeSelector
+          value={userType.value}
+          onChange={userType.onChange}
+          error={errors.userType?.message}
+        />
 
         <button
           type="submit"

--- a/src/pages/SignUp/SignupForm/UserTypeSelector.tsx
+++ b/src/pages/SignUp/SignupForm/UserTypeSelector.tsx
@@ -1,5 +1,4 @@
-import { useController, useFormContext } from "react-hook-form";
-import type { FormValues } from "../types";
+import type { UserType } from "../types";
 
 const btnClass = (isSelected: boolean) =>
   `flex items-center justify-center btn-outline-2 h-[42px] ${
@@ -8,17 +7,12 @@ const btnClass = (isSelected: boolean) =>
       : "font-medium"
   }`;
 
-export default function UserTypeSelector() {
-  const { control } = useFormContext<FormValues>();
-
-  const {
-    field: { value, onChange },
-    fieldState: { error },
-  } = useController<FormValues, "userType">({
-    control: control,
-    name: "userType",
-  });
-
+interface Props {
+  value: UserType;
+  onChange: (type: UserType) => void;
+  error?: string;
+}
+export default function UserTypeSelector({ value, onChange, error }: Props) {
   return (
     <div>
       <div className="grid grid-cols-2 gap-3">
@@ -37,7 +31,7 @@ export default function UserTypeSelector() {
           Non-profit
         </button>
       </div>
-      {error && <p className="text-xs text-red mt-1">{error.message}</p>}
+      {error && <p className="text-xs text-red mt-1">{error}</p>}
     </div>
   );
 }

--- a/src/pages/SignUp/SignupForm/UserTypeSelector.tsx
+++ b/src/pages/SignUp/SignupForm/UserTypeSelector.tsx
@@ -8,14 +8,20 @@ const btnClass = (isSelected: boolean) =>
   }`;
 
 interface Props {
+  classes?: string;
   value: UserType;
   onChange: (type: UserType) => void;
   error?: string;
 }
-export default function UserTypeSelector({ value, onChange, error }: Props) {
+export default function UserTypeSelector({
+  value,
+  onChange,
+  error,
+  classes,
+}: Props) {
   return (
     <div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className={`${classes} grid grid-cols-2 gap-3`}>
         <button
           className={btnClass(value === "donor")}
           type="button"

--- a/src/pages/SignUp/Success.tsx
+++ b/src/pages/SignUp/Success.tsx
@@ -1,6 +1,6 @@
 import Icon from "components/Icon";
 import { appRoutes } from "constants/routes";
-import { determineAuthRedirectPath } from "helpers";
+import { getAuthRedirect } from "helpers";
 import { Link, useLocation } from "react-router-dom";
 import type { SignInRouteState } from "types/auth";
 import type { UserType } from "./types";
@@ -9,11 +9,11 @@ type Props = { userType: UserType };
 
 export default function Success({ userType }: Props) {
   const { state } = useLocation();
-  const { redirectPath } = determineAuthRedirectPath(state);
+  const authRedirect = getAuthRedirect(state);
   // donors get redirected to the route which they originally attempted to
   // access; nonprofits get redirected to the page to register their NPO
   const signInRouteState: SignInRouteState = {
-    from: userType === "donor" ? redirectPath.pathname : appRoutes.register,
+    from: userType === "donor" ? authRedirect.path : appRoutes.register,
   };
 
   return (

--- a/src/pages/SignUp/Success.tsx
+++ b/src/pages/SignUp/Success.tsx
@@ -8,8 +8,8 @@ import type { UserType } from "./types";
 type Props = { userType: UserType };
 
 export default function Success({ userType }: Props) {
-  const { state } = useLocation();
-  const authRedirect = getAuthRedirect(state);
+  const { state: fromState } = useLocation();
+  const authRedirect = getAuthRedirect(fromState);
   // donors get redirected to the route which they originally attempted to
   // access; nonprofits get redirected to the page to register their NPO
   const signInRouteState: SignInRouteState = {

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -36,8 +36,8 @@ export default function Signin() {
     ),
   });
 
-  const { state } = useLocation();
-  const redirect = getAuthRedirect(state);
+  const { state: fromState } = useLocation();
+  const redirect = getAuthRedirect(fromState);
   const currUser = useGetter((state) => state.auth.user);
 
   if (currUser === "loading" || currUser?.isSigningOut) {
@@ -120,7 +120,7 @@ export default function Signin() {
           <Link
             to={appRoutes.reset_password}
             className="font-medium text-navy-l1 hover:text-navy active:text-navy-d2 text-xs sm:text-sm justify-self-end hover:underline"
-            state={state}
+            state={fromState}
           >
             Forgot password?
           </Link>
@@ -135,7 +135,7 @@ export default function Signin() {
           Don't have an account?
           <Link
             to={appRoutes.signup}
-            state={state}
+            state={fromState}
             className="text-blue-d1 hover:text-blue active:text-blue-d2 aria-disabled:text-gray font-medium underline"
             aria-disabled={isSubmitting}
           >

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -23,7 +23,11 @@ type FormValues = {
 
 export default function Signin() {
   const { handleError, displayError } = useErrorContext();
-  const methods = useForm<FormValues>({
+  const {
+    register,
+    formState: { isSubmitting, errors },
+    handleSubmit,
+  } = useForm<FormValues>({
     resolver: yupResolver(
       object({
         email: requiredString.trim().email("invalid email format"),
@@ -67,16 +71,10 @@ export default function Signin() {
     }
   }
 
-  const {
-    formState: { isSubmitting },
-    handleSubmit,
-  } = methods;
-
   return (
     <div className="grid justify-items-center gap-3.5 px-4 py-14 text-navy-l1">
       <Form
         className="grid w-full max-w-md px-6 sm:px-7 py-7 sm:py-8 bg-white border border-gray-l4 rounded-2xl"
-        methods={methods}
         disabled={isSubmitting}
         onSubmit={handleSubmit(submit)}
       >
@@ -109,12 +107,17 @@ export default function Signin() {
           OR
         </Separator>
         <div className="grid gap-3">
-          <Input<FormValues>
-            name="email"
+          <Input
+            {...register("email")}
             placeholder="Email address"
             icon="Email"
+            error={errors.email?.message}
           />
-          <PasswordInput<FormValues> name="password" placeholder="Password" />
+          <PasswordInput
+            {...register("password")}
+            error={errors.password?.message}
+            placeholder="Password"
+          />
           <Link
             to={appRoutes.reset_password}
             className="font-medium text-navy-l1 hover:text-navy active:text-navy-d2 text-xs sm:text-sm justify-self-end hover:underline"

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -6,7 +6,6 @@ import Image from "components/Image";
 import LoaderRing from "components/LoaderRing";
 import { Separator } from "components/Separator";
 import { Form, Input, PasswordInput } from "components/form";
-import { OAUTH_PATH_STORAGE_KEY } from "constants/auth";
 import { appRoutes } from "constants/routes";
 import { useErrorContext } from "contexts/ErrorContext";
 import { determineAuthRedirectPath } from "helpers";
@@ -95,11 +94,10 @@ export default function Signin() {
               pathname: redirectPath.pathname,
               data,
             };
-            localStorage.setItem(
-              OAUTH_PATH_STORAGE_KEY,
-              JSON.stringify(routeState)
-            );
-            signInWithRedirect({ provider: "Google" });
+            signInWithRedirect({
+              provider: "Google",
+              customState: JSON.stringify(routeState),
+            });
           }}
         >
           <Image src={googleIcon} height={18} width={18} />

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -8,12 +8,12 @@ import { Separator } from "components/Separator";
 import { Form, Input, PasswordInput } from "components/form";
 import { appRoutes } from "constants/routes";
 import { useErrorContext } from "contexts/ErrorContext";
-import { determineAuthRedirectPath } from "helpers";
+import { getAuthRedirect } from "helpers";
 import { useForm } from "react-hook-form";
 import { Link, Navigate, useLocation } from "react-router-dom";
 import { password, requiredString } from "schemas/string";
 import { useGetter } from "store/accessors";
-import type { StoredRouteState } from "types/auth";
+import type { OAuthState } from "types/auth";
 import { object } from "yup";
 
 type FormValues = {
@@ -37,9 +37,7 @@ export default function Signin() {
   });
 
   const { state } = useLocation();
-  const { redirectPath, data } = determineAuthRedirectPath(state, {
-    isSigningUp: false,
-  });
+  const redirect = getAuthRedirect(state);
   const currUser = useGetter((state) => state.auth.user);
 
   if (currUser === "loading" || currUser?.isSigningOut) {
@@ -51,7 +49,7 @@ export default function Signin() {
   }
 
   if (currUser) {
-    return <Navigate to={redirectPath} state={data} replace />;
+    return <Navigate to={redirect.path} state={redirect.data} replace />;
   }
 
   async function submit(fv: FormValues) {
@@ -88,9 +86,9 @@ export default function Signin() {
           className="flex-center btn-outline-2 gap-2 h-12 sm:h-[52px] mt-6 border-[0.8px]"
           type="button"
           onClick={() => {
-            const routeState: StoredRouteState = {
-              pathname: redirectPath.pathname,
-              data,
+            const routeState: OAuthState = {
+              pathname: redirect.path,
+              data: redirect.data,
             };
             signInWithRedirect({
               provider: "Google",

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -108,6 +108,7 @@ export default function Signin() {
           <Input
             {...register("email")}
             placeholder="Email address"
+            autoComplete="username"
             icon="Email"
             error={errors.email?.message}
           />

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,13 +1,10 @@
 import { configureStore } from "@reduxjs/toolkit";
-import { Amplify } from "aws-amplify";
-import { Hub } from "aws-amplify/utils";
-import amplifyConfig from "constants/aws";
 import { apes } from "services/apes";
 import { aws } from "services/aws/aws";
 import { coingecko } from "services/coingecko";
 import { terra } from "services/terra";
 import { wordpress } from "services/wordpress";
-import auth, { loadSession, reset } from "slices/auth";
+import auth from "slices/auth";
 import gift from "slices/gift";
 
 export const store = configureStore({
@@ -28,26 +25,6 @@ export const store = configureStore({
       wordpress.middleware,
       terra.middleware,
     ]),
-});
-
-Amplify.configure(amplifyConfig);
-
-store.dispatch(loadSession());
-Hub.listen("auth", async ({ payload }) => {
-  switch (payload.event) {
-    case "signedIn":
-      store.dispatch(loadSession(payload.data));
-      break;
-    case "signedOut":
-      store.dispatch(reset());
-      break;
-    case "tokenRefresh":
-      store.dispatch(loadSession());
-      break;
-    case "tokenRefresh_failure":
-      store.dispatch(reset());
-      break;
-  }
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -26,7 +26,7 @@ export type SignInRouteState = {
   data?: unknown;
 };
 
-export type StoredRouteState = {
+export type OAuthState = {
   pathname: string;
   data?: unknown;
 };


### PR DESCRIPTION
Closes BG-1479
Towards BG-1171
## Explanation of the solution

* make `Amplify.configure` to load in  root `src/index.tsx` same as `Sentry`
* move `Hub` event listening to `App.tsx` where it has access to `react-router-dom.useNavigate` (instead of using window.location.replace (reloads the whole app))
* instead of manually (thru `localStorage`) persisting `oauth` state - [include in `federeRatedSignin`](https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/3165/files#diff-5a3b43532f226411d46b3f459979b2e4979c6998b1f7a09b03e152b740f1ac3eR95) and [retrieve in Hub event](https://github.com/AngelProtocolFinance/angelprotocol-web-app/pull/3165/files#diff-1deef93890e359e3ea9cccd8b9fb992a1008c1f21b9eee105a1a364afae4f170R78)
* move `UserSelector` at the top of signup form (hidden when user came from `/register` )
* attempting to signup with google without clicking, errs
* error message is updated 
<img width="574" alt="image" src="https://github.com/user-attachments/assets/0316a4f0-18e9-4088-82d3-8afdcece8ecd">



### Others
* `Signin/Signup` elements now doesn't rely on `react-hook-form` context
* `Signin/Signup` elements have `autoComplete` prop  ( chrome suggest to include this in console warnings )

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
