### PR TITLE
Dapp logo, go to BG if in widget - client side navigation to homepage otherwise 

### DIFF
--- a/src/components/Image/DappLogo.tsx
+++ b/src/components/Image/DappLogo.tsx
@@ -1,20 +1,32 @@
 import dappLogoWhite from "assets/images/bettergiving-logo-white.png";
 import dappLogo from "assets/images/bettergiving-logo.png";
+import ExtLink from "components/ExtLink";
 import { appRoutes } from "constants/routes";
+import { Link } from "react-router-dom";
 import Image from "./Image";
 
 type Props = {
   classes?: string;
   color?: "blue" | "white";
+  to?: { href: string; title: string };
 };
 
-export default function DappLogo({ classes = "", color = "blue" }: Props) {
+export default function DappLogo({ classes = "", color = "blue", to }: Props) {
   return (
     <Image
       className={classes}
       src={color === "blue" ? dappLogo : dappLogoWhite}
-      title="Go to Home page"
-      href={appRoutes.home}
+      render={(img) =>
+        to ? (
+          <ExtLink href={to.href} title={to.title}>
+            {img}
+          </ExtLink>
+        ) : (
+          <Link to={appRoutes.home} title="Go to Home page">
+            {img}
+          </Link>
+        )
+      }
     />
   );
 }

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,7 +1,7 @@
 import ContentLoader from "components/ContentLoader";
-import ExtLink from "components/ExtLink";
 import React, {
-  type PropsWithChildren,
+  type ReactElement,
+  type ReactNode,
   useImperativeHandle,
   useRef,
   useState,
@@ -10,11 +10,12 @@ import ImagePlaceholder from "./ImagePlaceholder";
 
 export type ImageProps = React.ImgHTMLAttributes<HTMLImageElement> & {
   isSrcLoading?: boolean;
-} & ({ href: string; title: string } | { href?: never; title?: never });
+  render?: (img: ReactNode) => ReactElement;
+};
 
 const Image = React.forwardRef<HTMLImageElement, ImageProps>(
   (
-    { alt = "", className, isSrcLoading, href, title, onError, ...props },
+    { alt = "", className, isSrcLoading, render, onError, ...props },
     forwardRef
   ) => {
     const ref = useRef<HTMLImageElement>(null);
@@ -66,7 +67,8 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>(
          * wrapping the `img`.
          *
          */}
-        <WithLink className={commonClasses} href={href} title={title}>
+
+        {render?.(
           <img
             ref={ref}
             className={`object-contain ${commonClasses}`}
@@ -74,29 +76,18 @@ const Image = React.forwardRef<HTMLImageElement, ImageProps>(
             onError={(e) => (onError ? onError(e) : setError(true))}
             {...props}
           />
-        </WithLink>
+        ) || (
+          <img
+            ref={ref}
+            className={`object-contain ${commonClasses}`}
+            alt={alt}
+            onError={(e) => (onError ? onError(e) : setError(true))}
+            {...props}
+          />
+        )}
       </>
     );
   }
 );
-
-function WithLink({
-  className,
-  href,
-  title,
-  children,
-}: PropsWithChildren<{
-  className?: string;
-  href?: string;
-  title?: string;
-}>) {
-  return href ? (
-    <ExtLink href={href} title={title} className={className}>
-      {children}
-    </ExtLink>
-  ) : (
-    <>{children}</>
-  );
-}
 
 export default Image;

--- a/src/pages/DonateWidget/DonateWidget.tsx
+++ b/src/pages/DonateWidget/DonateWidget.tsx
@@ -2,6 +2,7 @@ import { DappLogo } from "components/Image";
 import LoaderRing from "components/LoaderRing";
 import QueryLoader from "components/QueryLoader";
 import { ErrorStatus } from "components/Status";
+import { APP_NAME, BASE_URL } from "constants/env";
 import { idParamToNum, setToLightMode } from "helpers";
 import { useEffect } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
@@ -67,7 +68,11 @@ export default function DonateWidget() {
         {(profile) => <Content profile={profile} config={config} />}
       </QueryLoader>
       <footer className="grid place-items-center h-20 w-full bg-[--accent-primary]">
-        <DappLogo classes="w-40" color="white" />
+        <DappLogo
+          classes="w-40"
+          color="white"
+          to={{ href: BASE_URL, title: `Go to ${APP_NAME}` }}
+        />
       </footer>
     </div>
   );

--- a/src/pages/Widget/Preview.tsx
+++ b/src/pages/Widget/Preview.tsx
@@ -2,6 +2,7 @@ import character from "assets/laira/laira-waiving.png";
 import { DappLogo } from "components/Image";
 import Image from "components/Image/Image";
 import { type DonationState, Steps, initDetails } from "components/donation";
+import { APP_NAME, BASE_URL } from "constants/env";
 import { useEndowment } from "services/aws/useEndowment";
 import type { WidgetConfig } from "types/widget";
 
@@ -75,7 +76,11 @@ export default function Preview({ classes = "", config }: Props) {
             className="my-5 @md/preview:w-3/4 border border-gray-l4"
           />
           <footer className="mt-auto grid place-items-center h-20 w-full bg-[--accent-primary]">
-            <DappLogo classes="w-40" color="white" />
+            <DappLogo
+              classes="w-40"
+              color="white"
+              to={{ href: BASE_URL, title: `Go to ${APP_NAME}` }}
+            />
           </footer>
         </div>
       </div>


### PR DESCRIPTION
## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
