### PR TITLE
Update 'Book a demo' button's link to new one

### DIFF
--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -11,6 +11,7 @@ export const SEO_IMAGE =
 export const EMAIL_SUPPORT = "support@better.giving";
 export const APP_NAME = "Better Giving";
 export const BASE_URL = `https://${IS_TEST ? "staging." : ""}better.giving`;
+export const BOOK_A_DEMO = "https://buytickets.at/bettergiving/1337711";
 export const INTERCOM_HELP = "https://intercom.help/better-giving/en";
 export const AWS_S3_PUBLIC_BUCKET = "https://endow-profiles.s3.amazonaws.com";
 

--- a/src/pages/informational/NonprofitInfo/BottomCta.tsx
+++ b/src/pages/informational/NonprofitInfo/BottomCta.tsx
@@ -1,6 +1,6 @@
 import waivingLira from "assets/laira/laira-waiving.png";
 import Image from "components/Image";
-import { INTERCOM_HELP } from "constants/env";
+import { BOOK_A_DEMO } from "constants/env";
 import { appRoutes } from "constants/routes";
 import { Link } from "react-router-dom";
 
@@ -25,7 +25,7 @@ export default function BottomCta({ className = "" }) {
             Start today
           </Link>
           <Link
-            to={INTERCOM_HELP}
+            to={BOOK_A_DEMO}
             className="btn-outline-blue bg-white border-2 rounded-full px-8 py-3 @5xl:px-12 @5xl:py-6 @5xl:text-xl"
           >
             Book a Demo

--- a/src/pages/informational/NonprofitInfo/Hero.tsx
+++ b/src/pages/informational/NonprofitInfo/Hero.tsx
@@ -1,5 +1,5 @@
 import Image from "components/Image";
-import { INTERCOM_HELP } from "constants/env";
+import { BOOK_A_DEMO } from "constants/env";
 import { appRoutes } from "constants/routes";
 import { benefits } from "content/benefits";
 import { Link } from "react-router-dom";
@@ -28,7 +28,7 @@ export default function Hero({ className = "" }) {
             Start today
           </Link>
           <Link
-            to={INTERCOM_HELP}
+            to={BOOK_A_DEMO}
             className="btn-outline-blue border-2 rounded-full px-8 py-3 @6xl:px-12 @6xl:py-6 @6xl:text-xl hover:shadow-2xl hover:shadow-blue/50"
           >
             Book a Demo


### PR DESCRIPTION
Resolves BG-1541

## Explanation of the solution
Added new environment variable `BOOK_A_DEMO` to hold link that is used for the "Book a Demo" button in the nonprofit page.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- Upon clicking the button, user should be taken to `https://buytickets.at/bettergiving/1337711`
- To apply in prod, we might need to add the env var in AWS too

## UI changes for review
No major UI changes.