### PR TITLE
Bump stripe rate to  2.9

### DIFF
--- a/src/components/donation/Steps/Summary/helpers.ts
+++ b/src/components/donation/Steps/Summary/helpers.ts
@@ -16,7 +16,7 @@ export const processingFee = (
         return [
           +details.amount,
           PROCESSING_RATES.stripe,
-          0.3 * details.currency.rate,
+          PROCESSING_RATES.stripe_flat * details.currency.rate,
         ];
       default: {
         details.method satisfies "stocks";

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -6,7 +6,9 @@ export const BYTES_IN_MB = 1e6;
 
 export const PROCESSING_RATES = {
   chariot: 0.029,
-  stripe: 0.024,
+  stripe: 0.029,
+  /** $cents */
+  stripe_flat: 0.3,
   crypto: 0.01,
 };
 


### PR DESCRIPTION
## Explanation of the solution

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
