### PR TITLE
Hot Fix: Better Giving Blog Post page - Header Sign Up button only appears on hover

### DIFF
--- a/src/App/Header/UserMenu/UserMenu.tsx
+++ b/src/App/Header/UserMenu/UserMenu.tsx
@@ -2,7 +2,7 @@ import Image from "components/Image";
 import LoaderRing from "components/LoaderRing";
 import { appRoutes } from "constants/routes";
 import { CircleUserRound } from "lucide-react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useMatch } from "react-router-dom";
 import { useGetter } from "store/accessors";
 import type { SignInRouteState } from "types/auth";
 
@@ -11,6 +11,8 @@ export default function UserMenu() {
 
   const location = useLocation();
 
+  const isWpPost = !!useMatch(`${appRoutes.blog}/:slug`);
+
   if (!user) {
     const state: SignInRouteState = { from: location.pathname };
     return (
@@ -18,14 +20,14 @@ export default function UserMenu() {
         <Link
           to={appRoutes.signin}
           state={state}
-          className="btn text-base normal-case max-sm:hidden hover:underline"
+          className={`${isWpPost ? "log-in-link" : "btn text-base normal-case max-sm:hidden hover:underline"}`}
         >
           Log in
         </Link>
         <Link
           to={appRoutes.signup}
           state={state}
-          className="btn text-base normal-case max-sm:hidden bg-blue-d1 hover:bg-blue text-white text-nowrap px-6 py-2 rounded-full"
+          className={`${isWpPost ? "btn-user-sign-up" : "btn text-base normal-case max-sm:hidden bg-blue-d1 hover:bg-blue text-white text-nowrap px-6 py-2 rounded-full"}`}
         >
           Sign up
         </Link>

--- a/src/App/Layout.tsx
+++ b/src/App/Layout.tsx
@@ -20,9 +20,7 @@ export default function Layout() {
       <Seo /> {/* Load all defaults for SEO meta tags */}
       <Header
         links={headerLinks}
-        classes={`${isHome ? "mt-8 px-4" : ""} ${
-          isWpPost ? "override-wp-overrides" : ""
-        } sticky z-40 top-[-1px]`}
+        classes={`${isHome ? "mt-8 px-4" : ""} sticky z-40 top-[-1px]`}
       />
       <ErrorBoundary key={key} /** allows for recovery when changing page */>
         <Outlet />

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -169,6 +169,11 @@
     @apply text-sm;
   }
 
+  /** overrides wp style for blog post Header */
+  .btn-user-sign-up {
+    @apply btn text-base normal-case max-sm:hidden bg-blue-d1 hover:bg-blue hover:text-white text-white text-nowrap px-6 py-2 rounded-full
+  }
+
   .field-gift > input {
     @apply bg-white dark:bg-blue-d6;
   }
@@ -205,6 +210,11 @@
 
   .field-admin-sec > input {
     @apply border-0 border-b rounded-none bg-transparent p-0 pb-2;
+  }
+
+  /** overrides wp style for blog post Header */
+  .log-in-link {
+    @apply btn text-base text-navy-d4 normal-case max-sm:hidden hover:underline hover:text-navy-d4
   }
   
   /** tailwind classes of children of this wrapper can still override this styles */


### PR DESCRIPTION
Resolves BG-1666

## Explanation of the solution
- Removed `override-wp-overrides` from `Header` component
- Created custom styles that are applied directly to the `UserMenu` component when path is related to Blog post page

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- visit `/blog/savings-and-investments-matter` page

## UI changes for review
### After applying custom styles:
<img width="173" alt="Screenshot 2024-11-13 at 13 21 59" src="https://github.com/user-attachments/assets/3bca5f7f-c9ba-40c7-bd6c-6f53ebc2c4a7">