### PR TITLE
Hot Fix: Go Back link on Blog Post page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ We use `yarn` as a package manager. After installing yarn, simply run the packag
 yarn install
 ```
 
-Lastly, we have provided an example `.env` file as `.env.template`.
+Lastly, we have provided an example `.env` file as `.env.example`.
 You'll need to copy this file to `.env` and then modify/add your relevant app's settings, API Keys and the like:
 
 ```shell
-cp .env.template .env
+cp .env.example .env
 ```
 
 To run the web app server locally, simply execute:

--- a/src/pages/Blog/Post.tsx
+++ b/src/pages/Blog/Post.tsx
@@ -2,6 +2,7 @@ import ContentLoader from "components/ContentLoader";
 import Media from "components/Media";
 import QueryLoader from "components/QueryLoader";
 import Seo from "components/Seo";
+import { appRoutes } from "constants/routes";
 import { useRendered } from "hooks/use-rendered";
 import { ChevronLeft } from "lucide-react";
 import { Helmet } from "react-helmet";
@@ -43,7 +44,7 @@ export function Component() {
       />
 
       <Link
-        to={".."}
+        to={appRoutes.blog}
         className="flex items-center gap-2 font-medium text-blue-d1 hover:text-blue mt-6"
       >
         <ChevronLeft className="text-[1em]" />


### PR DESCRIPTION
Resolves BG-1669

## Explanation of the solution
- fixed `Go Back` link
- small typo correction on README to reflect our given example file

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- visit blog post page, click `Go Back` and it should take user to blog posts page

## UI changes for review
No major UI changes.