### PR TITLE
snippet defaults

### DIFF
--- a/src/pages/Widget/Snippet/Snippet.tsx
+++ b/src/pages/Widget/Snippet/Snippet.tsx
@@ -12,7 +12,7 @@ export default function Snippet({ classes = "", config }: Props) {
   const widgetURL = widgetURLfn(config);
   const iframeURL =
     config.endowment.id !== 0
-      ? `<iframe src="${widgetURL}" width="700" height="900" style="border: 0px;"></iframe>`
+      ? `<iframe src="${widgetURL}" width="100%" height="100%" allow="payment" style="border: 0px;"></iframe>`
       : "Please select organization";
 
   return (


### PR DESCRIPTION
Towards BG-1686,BG-1697
## Explanation of the solution
* `width` and `height` set to `100%`
*  `allow=paymnent` iframe attribute (to show google pay | apple pay (need more setup for safari < v17 ))

## Instructions on making this work

- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
-

## UI changes for review

When major UI changes are introduced with a PR, please include links to URLS to compare or screenshots demonstrating the difference and notify on design changes
