### PR TITLE
APES API Auth Updates

### DIFF
--- a/src/pages/Admin/Context.tsx
+++ b/src/pages/Admin/Context.tsx
@@ -12,8 +12,10 @@ export function Context({
   user,
 }: PropsWithChildren<{ user: AuthenticatedUser }>) {
   const { id } = useParams<AdminParams>();
+  const isNpoAdmin = user.endowments.includes(idParamToNum(id));
+  const isBgAdmin = user.groups.includes("ap-admin");
 
-  if (!user.endowments.includes(idParamToNum(id))) {
+  if (!isNpoAdmin && !isBgAdmin) {
     return (
       <div className="grid content-start place-items-center pt-40 pb-20">
         <CircleAlert size={80} className="text-red" />

--- a/src/services/apes/donations.ts
+++ b/src/services/apes/donations.ts
@@ -38,6 +38,7 @@ export const {
         return {
           url: `endowments/${endowId}/balance-txs`,
           params,
+          headers: { authorization: TEMP_JWT },
         };
       },
     }),


### PR DESCRIPTION
Resolves BG-1711

## Explanation of the solution
Added an authorization header to the `GET /endowments/{id}/balance-txs` endpoint. With this update, BG admins would have access to NPO's dashboards due to expanded Admin Context.

## Instructions on making this work
- run `yarn` or `yarn install` to install npm dependencies
- run `yarn run test --watchAll` to verify all tests still pass
- (optional) run `yarn run build` to verify the build passes
- run `yarn start` to start the webapp
- logged in BG admin account should be able to access NPO's dashboards but can not move balances
- logged in BG admin can only access their own NPO dashboard
- non-NPO admin and non-BG admin account should not have access to any NPO dashboard
- to test if auth header works for `GET .../balance-txs` endpoint, please change it to `/balancetxstest`

## UI changes for review
N/A