### PR TITLE
Can not remove NPO `slug` once it is set

### DIFF
--- a/src/pages/admin/edit-profile/use-edit-profile.ts
+++ b/src/pages/admin/edit-profile/use-edit-profile.ts
@@ -25,13 +25,15 @@ export default function useEditProfile(df: DirtyFields) {
       if (df.card_img) update.card_img = fv.card_img;
 
       if (df.slug) {
-        const result = await getEndow(fv.slug, ["id"], false);
-        //endow is found with update.slug
-        if (result.id) {
-          return setPrompt({
-            type: "error",
-            children: `Slug "${fv.slug}" is already taken`,
-          });
+        if (fv.slug !== "") {
+          const result = await getEndow(fv.slug, ["id"], false);
+          //endow is found with update.slug
+          if (result.id) {
+            return setPrompt({
+              type: "error",
+              children: `Slug "${fv.slug}" is already taken`,
+            });
+          }
         }
         update.slug = fv.slug;
       }


### PR DESCRIPTION
Resolves BG-1766

## Bug
Removing an already set NPO `slug` results in validation error due to empty string `""`.

## Fix
Added skip if slug is empty string so that it can be removed from NPO's profile.