### PR TITLE
Add registration number in fundraiser member option

### DIFF
--- a/src/pages/funds/create-fund/endowment-selector/options.tsx
+++ b/src/pages/funds/create-fund/endowment-selector/options.tsx
@@ -75,8 +75,12 @@ export function Options({ classes = "", searchText }: Props) {
           className="flex gap-x-2 p-2 data-selected:text-blue-d1 data-selected:pointer-events-none hover:bg-blue-l4 select-none"
         >
           <Image src={o.card_img} className="w-8" />
-          <span>{o.name}</span>
-          <span>{o.registration_number}</span>
+          <div>
+            <span>{o.name}</span>{" "}
+            <span className="text-xs text-gray-l1">
+              {o.registration_number}
+            </span>
+          </div>
         </ComboboxOption>
       ))}
     </ComboboxOptions>

--- a/src/pages/funds/create-fund/endowment-selector/options.tsx
+++ b/src/pages/funds/create-fund/endowment-selector/options.tsx
@@ -21,7 +21,7 @@ const fetcher = async ({
     query,
     page,
     fund_opt_in,
-    fields: "id,name,card_img",
+    fields: "id,name,card_img,registration_number",
   });
   const res = await fetch(`/api/npos?${search.toString()}`);
 
@@ -76,6 +76,7 @@ export function Options({ classes = "", searchText }: Props) {
         >
           <Image src={o.card_img} className="w-8" />
           <span>{o.name}</span>
+          <span>{o.registration_number}</span>
         </ComboboxOption>
       ))}
     </ComboboxOptions>

--- a/src/types/npo.ts
+++ b/src/types/npo.ts
@@ -32,7 +32,7 @@ export interface EndowCardsPage
 export interface EndowOptionsPage
   extends EndowsPage<"id" | "name" | "registration_number"> {}
 export interface EndowFundMembersOptionsPage
-  extends EndowsPage<"id" | "name" | "card_img"> {}
+  extends EndowsPage<"id" | "name" | "card_img" | "registration_number"> {}
 
 export type EndowmentCard = EndowCardsPage["items"][number];
 export type EndowmentOption = EndowOptionsPage["items"][number];


### PR DESCRIPTION
Resolves BG-1747

## Description
Added `registration_number` beside NPO name in fundraiser member options.

### Sample
<img width="611" alt="Screenshot 2025-03-31 at 11 42 53" src="https://github.com/user-attachments/assets/a8b9561b-8b1e-49ec-8766-24ac0a04eb51" />