### PR TITLE
Migrate `donation-sorter` from AWS to web app server function

### DIFF
--- a/src/.server/donation-receipt.ts
+++ b/src/.server/donation-receipt.ts
@@ -1,0 +1,28 @@
+import type { Donation } from "@better-giving/donation";
+import { tables } from "@better-giving/types/list";
+import { UpdateCommand, apes } from "./aws/db";
+
+type KYC = Omit<Donation.V2FullKyc, "ukGiftAid">;
+
+export const sendDonationReceipt = async (id: string, update: KYC) => {
+  const components = Object.entries(update).map(([k, v]) => ({
+    update: `#${k} = :${k}`,
+    name: [`#${k}`, k],
+    value: [`:${k}`, v],
+  }));
+  const command = new UpdateCommand({
+    TableName: tables.donations,
+    Key: { transactionId: id } satisfies Donation.PrimaryKey,
+    ConditionExpression: "attribute_exists(transactionId)",
+    UpdateExpression: "SET " + components.map(({ update: u }) => u).join(","),
+    ExpressionAttributeNames: components.reduce(
+      (prev, { name: [n, _n] }) => ({ ...prev, [n]: _n }),
+      {}
+    ),
+    ExpressionAttributeValues: components.reduce(
+      (prev, { value: [v, _v] }) => ({ ...prev, [v]: _v }),
+      {}
+    ),
+  });
+  await apes.send(command);
+};

--- a/src/components/kyc-form/schema.ts
+++ b/src/components/kyc-form/schema.ts
@@ -2,6 +2,7 @@ import * as v from "valibot";
 
 const str = v.pipe(v.string("required"), v.trim());
 const rqrd = v.pipe(str, v.nonEmpty("required"));
+const email = v.pipe(str, v.email("invalid"));
 export const schema = v.object({
   name: v.object({ first: rqrd, last: rqrd }),
   address: v.object({ street: rqrd, complement: str }),
@@ -9,10 +10,20 @@ export const schema = v.object({
   postalCode: rqrd,
   //internal
   country: v.object({ name: rqrd, code: str, flag: str }),
-  kycEmail: v.pipe(str, v.email("invalid")),
+  kycEmail: email,
   //pre-selected
   usState: v.object({ label: str, value: str }),
   state: str,
+});
+
+export const schemaDbUpdate = v.object({
+  fullName: rqrd,
+  kycEmail: email,
+  streetAddress: rqrd,
+  city: rqrd,
+  state: str,
+  zipCode: rqrd,
+  country: rqrd,
 });
 
 export interface FV extends v.InferOutput<typeof schema> {}

--- a/src/components/kyc-form/schema.ts
+++ b/src/components/kyc-form/schema.ts
@@ -16,7 +16,7 @@ export const schema = v.object({
   state: str,
 });
 
-export const schemaDbUpdate = v.object({
+export const kycSchema = v.object({
   fullName: rqrd,
   kycEmail: email,
   streetAddress: rqrd,


### PR DESCRIPTION
Related to BG-1802

## Description
Migrated the donation receipt (KYC update) logic in `donation-sorter` to the app's server function. The function is named `sendDonationReceipt` but what it really does is just update the KYC data of the donor. The update will then trigger one of our DB-triggered function which handles email sending logic.